### PR TITLE
Add ic, hydra, icdemo charts

### DIFF
--- a/charts/hydra/Chart.yaml
+++ b/charts/hydra/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: hydra
+version: 0.0.0
+
+description: Chart for the Hydra deployment used by Identity Concentrator in Terra
+type: application
+
+keywords:
+- dsp
+- broadinstitute
+- terra
+- hydra
+
+sources:
+- https://github.com/broadinstitute/terra-helm/tree/master/charts
+- https://github.com/DataBiosphere/healthcare-federated-access-services

--- a/charts/hydra/templates/_helpers.tpl
+++ b/charts/hydra/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/*
+Create labels to use for resources in this chart
+*/}}
+{{- define "hydra.labels" -}}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: hydra
+    app.kubernetes.io/part-of: terra
+{{- end }}

--- a/charts/hydra/templates/deployment.yaml
+++ b/charts/hydra/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hydra-deployment
+  labels:
+    app: hydra
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: hydra
+  template:
+    metadata:
+      name: hydra-service
+      labels:
+        app: hydra
+    spec:
+      serviceAccountName: hydra-sa
+      containers:
+        - name: hydra
+          image: "{{- if .Values.image -}}
+              {{ .Values.image }}
+            {{- else -}}
+              {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
+            {{- end }}"
+          imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
+          ports:
+            - containerPort: 4444
+            - containerPort: 4445
+          env:
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name:  hydra-postgres-db-creds
+                  key: username
+            - name: DATABASE_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-postgres-db-creds
+                  key: password
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-postgres-db-creds
+                  key: db
+            - name: URL
+              value: https://{{ required "A valid .Values.domain entry required!" .Values.domain }}
+            - name: DSN
+              value: postgres://$(DATABASE_USER):$(DATABASE_USER_PASSWORD)@127.0.0.1:5432/$(DATABASE_NAME)?sslmode=disable
+          readinessProbe:
+            httpGet:
+              port: 4444
+              path: /health/ready
+        - name: cloudsql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.16
+          env:
+            - name: SQL_INSTANCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-cloudsql-postgres-instance-name
+                  key: name
+          command: ["/cloud_sql_proxy",
+                    "-instances=terra-kernel-k8s:us-central1:$(SQL_INSTANCE_NAME)=tcp:5432",
+                    "-credential_file=/secrets/sa/service-account.json"]
+          securityContext:
+            runAsUser: 2  # non-root user
+            allowPrivilegeEscalation: false
+          volumeMounts:
+          - name: sa-creds
+            mountPath: /secrets/sa
+            readOnly: true
+      volumes:
+        - name: sa-creds
+          secret:
+            secretName: hydra-sa

--- a/charts/hydra/templates/istio-ingress.yaml
+++ b/charts/hydra/templates/istio-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: hydra
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+spec:
+  hosts:
+    - "*"
+  gateways:
+  - {{ .Values.ingress.istioGatewayName }}.{{ .Values.ingress.istioGatewayNamespace }}.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        exact: /oauth2/token
+    - uri:
+        prefix: /identity
+    - uri:
+        prefix: /tokens
+    - uri:
+        prefix: /visas/jwks
+    route:
+    - destination:
+        port:
+          number: 8080
+        host: hydra-service.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/hydra/templates/role.yaml
+++ b/charts/hydra/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hydra-service-role
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - terra-default-psp
+- apiGroups: ['']
+  resources: ['secrets']
+  verbs: ['get', 'create']

--- a/charts/hydra/templates/rolebinding.yaml
+++ b/charts/hydra/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hydra-service-role-binding
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+roleRef:
+  kind: Role
+  name: hydra-service-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: hydra-sa

--- a/charts/hydra/templates/secrets.yaml
+++ b/charts/hydra/templates/secrets.yaml
@@ -1,0 +1,47 @@
+{{ if .Values.vault.enabled -}}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-hydra-postgres-instance-name
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+spec:
+  name: hydra-cloudsql-postgres-instance-name
+  keysMap:
+    name:
+      path: {{ .Values.vault.pathPrefix }}/ic/postgres/instance
+      key: name
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-hydra-postgres-db-creds
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+spec:
+  name: hydra-postgres-db-creds
+  keysMap:
+    db:
+      path: {{ .Values.vault.pathPrefix }}/ic/postgres/db-creds
+      key: db
+    username:
+      path: {{ .Values.vault.pathPrefix }}/ic/postgres/db-creds
+      key: username
+    password:
+      path: {{ .Values.vault.pathPrefix }}/ic/postgres/db-creds
+      key: password
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-hydra-app-sa
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+spec:
+  name: hydra-sa
+  keysMap:
+    service-account.json:
+      path: {{ .Values.vault.pathPrefix }}/ic/app-sa
+      encoding: base64
+      key: key
+{{ end -}}

--- a/charts/hydra/templates/service-account.yaml
+++ b/charts/hydra/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hydra-sa
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}

--- a/charts/hydra/templates/service.yaml
+++ b/charts/hydra/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: hydra-service
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "hydra.labels" }}{{ end }}
+spec:
+  selector:
+    app: "hydra"
+  ports:
+  - name: "http"
+    port: 4444
+    targetPort: 4444
+  - name: "admin"
+    port: 4445
+    targetPort: 4445

--- a/charts/hydra/values.yaml
+++ b/charts/hydra/values.yaml
@@ -10,6 +10,7 @@ imageConfig:
   # If no value is set, the chart's appVersion value will be used.
   # tag: latest
   imagePullPolicy: Always
+replicas: 1
 vault:
   enabled: true
   # pathPrefix is required if Vault secret sync is enabled

--- a/charts/hydra/values.yaml
+++ b/charts/hydra/values.yaml
@@ -1,0 +1,25 @@
+# image is used for local/Skaffold deploys
+# image: gcr.io/terra-kernel-k8s/hcls-fa-gke-ic
+
+# appVerion is set by Helmfile
+# appVersion: 0.0.0
+
+imageConfig:
+  repository: gcr.io/terra-kernel-k8s/hcls-fa-gke-hydra-ic
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion value will be used.
+  # tag: latest
+  imagePullPolicy: Always
+vault:
+  enabled: true
+  # pathPrefix is required if Vault secret sync is enabled
+  # pathPrefix: secret/dsde/terra/kernel/integration
+ingress:
+  istioGatewayName: template-gateway
+  istioGatewayNamespace: default
+
+# Required values
+# domain: kernel.integ.envs.broadinstitute.org
+
+# Should be set to true when deploying locally
+devDeploy: false

--- a/charts/icdemo/Chart.yaml
+++ b/charts/icdemo/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: icdemo
+version: 0.0.0
+
+description: Chart for the Identity Concentrator demo/test
+type: application
+
+keywords:
+- dsp
+- broadinstitute
+- terra
+- identityconcentrator
+- demo
+
+sources:
+- https://github.com/broadinstitute/terra-helm/tree/master/charts
+- https://github.com/DataBiosphere/healthcare-federated-access-services

--- a/charts/icdemo/templates/_helpers.tpl
+++ b/charts/icdemo/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/*
+Create labels to use for resources in this chart
+*/}}
+{{- define "icdemo.labels" -}}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: icdemo
+    app.kubernetes.io/part-of: terra
+{{- end }}

--- a/charts/icdemo/templates/deployment.yaml
+++ b/charts/icdemo/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: icdemo-deployment
+  labels:
+    app: icdemo
+    {{ if not .Values.devDeploy }}{{ template "icdemo.labels" }}{{ end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: icdemo
+  template:
+    metadata:
+      name: icdemo-service
+      labels:
+        app: icdemo
+    spec:
+      serviceAccountName: ic-sa
+      containers:
+        - name: icdemo
+          image: "{{- if .Values.image -}}
+              {{ .Values.image }}
+            {{- else -}}
+              {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
+            {{- end }}"
+          imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: URL
+              value: https://{{ required "A valid .Values.domain entry required!" .Values.domain }}
+            - name: PROJECT
+              value: {{ required "A valid .Values.project entry required!" .Values.project }}
+            - name: TYPE
+              value: icdemo

--- a/charts/icdemo/templates/istio-ingress.yaml
+++ b/charts/icdemo/templates/istio-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ic
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "icdemo.labels" }}{{ end }}
+spec:
+  hosts:
+    - "*"
+  gateways:
+  - {{ .Values.ingress.istioGatewayName }}.{{ .Values.ingress.istioGatewayNamespace }}.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: /test
+    - uri:
+        prefix: /static
+    route:
+    - destination:
+        port:
+          number: 8080
+        host: icdemo-service.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/icdemo/templates/service.yaml
+++ b/charts/icdemo/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: icdemo-service
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "icdemo.labels" }}{{ end }}
+spec:
+  selector:
+    app: icdemo
+  ports:
+  - name: http
+    port: 8080

--- a/charts/icdemo/values.yaml
+++ b/charts/icdemo/values.yaml
@@ -1,0 +1,26 @@
+# image is used for local/Skaffold deploys
+# image: gcr.io/terra-kernel-k8s/hcls-fa-gke-ic
+
+# appVerion is set by Helmfile
+# appVersion: 0.0.0
+
+imageConfig:
+  repository: gcr.io/terra-kernel-k8s/hcls-fa-gke-icdemo
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion value will be used.
+  # tag: latest
+  imagePullPolicy: Always
+vault:
+  enabled: true
+  # pathPrefix is required if Vault secret sync is enabled
+  # pathPrefix: secret/dsde/terra/kernel/integration
+ingress:
+  istioGatewayName: template-gateway
+  istioGatewayNamespace: default
+
+# Required values
+# domain: kernel.integ.envs.broadinstitute.org
+# project: terra-kernel-k8s
+
+# Should be set to true when deploying locally
+devDeploy: false

--- a/charts/icdemo/values.yaml
+++ b/charts/icdemo/values.yaml
@@ -11,10 +11,6 @@ imageConfig:
   # tag: latest
   imagePullPolicy: Always
 replicas: 1
-vault:
-  enabled: true
-  # pathPrefix is required if Vault secret sync is enabled
-  # pathPrefix: secret/dsde/terra/kernel/integration
 ingress:
   istioGatewayName: template-gateway
   istioGatewayNamespace: default

--- a/charts/icdemo/values.yaml
+++ b/charts/icdemo/values.yaml
@@ -10,6 +10,7 @@ imageConfig:
   # If no value is set, the chart's appVersion value will be used.
   # tag: latest
   imagePullPolicy: Always
+replicas: 1
 vault:
   enabled: true
   # pathPrefix is required if Vault secret sync is enabled

--- a/charts/identityconcentrator/Chart.yaml
+++ b/charts/identityconcentrator/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: identityconcentrator
+version: 0.0.0
+
+description: Chart for the Identity Concentrator deployment used by Terra
+type: application
+
+keywords:
+- dsp
+- broadinstitute
+- terra
+- identityconcentrator
+
+sources:
+- https://github.com/broadinstitute/terra-helm/tree/master/charts
+- https://github.com/DataBiosphere/healthcare-federated-access-services

--- a/charts/identityconcentrator/templates/_helpers.tpl
+++ b/charts/identityconcentrator/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/*
+Create labels to use for resources in this chart
+*/}}
+{{- define "identityconcentrator.labels" -}}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: identityconcentrator
+    app.kubernetes.io/part-of: terra
+{{- end }}

--- a/charts/identityconcentrator/templates/deployment.yaml
+++ b/charts/identityconcentrator/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ic-deployment
+  labels:
+    app: ic
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: ic
+  template:
+    metadata:
+      name: ic-service
+      labels:
+        app: ic
+    spec:
+      serviceAccountName: ic-sa
+      containers:
+        - name: ic
+          image: "{{- if .Values.image -}}
+              {{ .Values.image }}
+            {{- else -}}
+              {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
+            {{- end }}"
+          imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ACCESS_TOKEN_LIFESPAN
+              value: 15m
+            - name: DOMAIN
+              value: {{ required "A valid .Values.domain entry required!" .Values.domain }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/sa/service-account.json
+            - name: SERVICE_NAME
+              value: ic
+            - name: PROJECT
+              value: {{ required "A valid .Values.project entry required!" .Values.project }}
+            - name: TYPE
+              value: ic
+            - name: HYDRA_INTERNAL
+              value: hydra-ic-service.{{ .Release.Namespace }}.svc.cluster.local
+            - name: STORAGE
+              value: datastore
+          volumeMounts:
+            - name: sa-creds
+              mountPath: /secrets/sa
+              readOnly: true
+      volumes:
+        - name: sa-creds
+          secret:
+            secretName: ic-sa

--- a/charts/identityconcentrator/templates/istio-ingress.yaml
+++ b/charts/identityconcentrator/templates/istio-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ic
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}
+spec:
+  hosts:
+    - "*"
+  gateways:
+  - {{ .Values.ingress.istioGatewayName }}.{{ .Values.ingress.istioGatewayNamespace }}.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        exact: /oauth2/token
+    - uri:
+        prefix: /identity
+    - uri:
+        prefix: /tokens
+    - uri:
+        prefix: /visas/jwks
+    route:
+    - destination:
+        port:
+          number: 8080
+        host: ic-service.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/identityconcentrator/templates/role.yaml
+++ b/charts/identityconcentrator/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ic-service-role
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - terra-default-psp
+- apiGroups: ['']
+  resources: ['secrets']
+  verbs: ['get', 'create']

--- a/charts/identityconcentrator/templates/rolebinding.yaml
+++ b/charts/identityconcentrator/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ic-service-role-binding
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}
+roleRef:
+  kind: Role
+  name: ic-service-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: ic-sa

--- a/charts/identityconcentrator/templates/secrets.yaml
+++ b/charts/identityconcentrator/templates/secrets.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.vault.enabled -}}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-ic-app-sa
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}
+spec:
+  name: ic-sa
+  keysMap:
+    service-account.json:
+      path: {{ .Values.vault.pathPrefix }}/ic/app-sa
+      encoding: base64
+      key: key
+{{ end -}}

--- a/charts/identityconcentrator/templates/service-account.yaml
+++ b/charts/identityconcentrator/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ic-sa
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}

--- a/charts/identityconcentrator/templates/service.yaml
+++ b/charts/identityconcentrator/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: ic-service
+  labels:
+    {{ if not .Values.devDeploy }}{{ template "identityconcentrator.labels" }}{{ end }}
+spec:
+  ports:
+  - name: "http"
+    port: 8080
+  selector:
+    app: "ic"

--- a/charts/identityconcentrator/values.yaml
+++ b/charts/identityconcentrator/values.yaml
@@ -1,0 +1,26 @@
+# image is used for local/Skaffold deploys
+# image: gcr.io/terra-kernel-k8s/hcls-fa-gke-ic
+
+# appVerion is set by Helmfile
+# appVersion: 0.0.0
+
+imageConfig:
+  repository: gcr.io/terra-kernel-k8s/hcls-fa-gke-ic
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion value will be used.
+  # tag: latest
+  imagePullPolicy: Always
+vault:
+  enabled: true
+  # pathPrefix is required if Vault secret sync is enabled
+  # pathPrefix: secret/dsde/terra/kernel/integration
+ingress:
+  istioGatewayName: template-gateway
+  istioGatewayNamespace: default
+
+# Required values
+# domain: kernel.integ.envs.broadinstitute.org
+# project: terra-kernel-k8s
+
+# Should be set to true when deploying locally
+devDeploy: false

--- a/charts/identityconcentrator/values.yaml
+++ b/charts/identityconcentrator/values.yaml
@@ -10,6 +10,7 @@ imageConfig:
   # If no value is set, the chart's appVersion value will be used.
   # tag: latest
   imagePullPolicy: Always
+replicas: 1
 vault:
   enabled: true
   # pathPrefix is required if Vault secret sync is enabled


### PR DESCRIPTION
This PR adds Helm charts for the Identity Concentrator and Hydra apps, as well as a test app called icdemo. It replaces resources previously defined with kustomize:
https://github.com/DataBiosphere/identity-concentrator/tree/master/config
https://github.com/DataBiosphere/terra-config/tree/master/yyu/identity-concentrator

Along with this change, the following change to the deployment flow is proposed:
https://docs.google.com/document/d/103d2H6816feTyHDYSQXBVft4pOssdW6dFz-4KSzxs9M/edit?usp=sharing

Additionally, this is a special case since this is a third-party app that we are just building images from and deploying. I propose we adjust our deployment approach as follows:

- [Fork](https://github.com/DataBiosphere/healthcare-federated-access-services) the [healthcare-federated-access-services repo](https://github.com/GoogleCloudPlatform/healthcare-federated-access-services) that is used to build the images.
- Configure Google cloud build to [build and push the Docker images on updates of our fork](https://console.cloud.google.com/cloud-build/dashboard?project=terra-kernel-k8s).
- Either keep the fork sync process manual or set up a scheduled GH action to sync it.

Since all the [current GitHub action](https://github.com/DataBiosphere/identity-concentrator/blob/master/.github/workflows/master_push.yml) does is build Docker images from the Dockerfiles in the repo, a Google cloud build definition is a much more concise way to do this, as we don't need to go through pulling Vault credentials and then pulling Google credentials with those just so we can auth to GCR.