### PR TITLE
Bump cert-manager version, chart-releaser is being silly

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dsp-cert-manager
-version: 0.0.0
+version: 0.0.1
 
 keywords:
 - dsp


### PR DESCRIPTION
Chart-releaser has been failing since this PR got merged: https://github.com/broadinstitute/terra-helm/pull/46

Guess the README update makes it want to release a new version of the chart