### PR TITLE
DDO-475 Suitability restrictions on Terra environment projects

### DIFF
--- a/charts/terra-argocd-env/Chart.yaml
+++ b/charts/terra-argocd-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terra-argocd-env
 description: A Helm chart for generating environment-wide ArgoCD resources for Terra environments
 type: application
-version: 0.0.6
+version: 0.0.7
 dependencies:
 - name: terra-argocd-templates
   version: 0.0.4

--- a/charts/terra-argocd-env/templates/project.yaml
+++ b/charts/terra-argocd-env/templates/project.yaml
@@ -1,8 +1,9 @@
 {{- with .Values -}}
+{{- $projectName := include "terra-argocd.projectName" . -}}
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: {{ include "terra-argocd.projectName" . }}
+  name: {{ $projectName }}
 spec:
   description: "Applications for Terra {{ .environment }} environment"
   destinations:
@@ -10,4 +11,16 @@ spec:
     server: {{ .clusterAddress }}
   sourceRepos:
   - "*"
+  roles:
+  - description: Edit privileges for all applications in terra-staging
+    name: edit
+    policies:
+    - p, proj:{{ $projectName }}:edit, applications, *, {{ $projectName }}/*, allow
+    groups:
+    - local-suitable
+    - broadinstitute:Workbench Admins
+{{- if not .requireSuitable }}
+    - local-notsuitable
+    - broadinstitute:DSDE Engineering
+{{- end }}
 {{- end -}}

--- a/charts/terra-argocd-env/templates/project.yaml
+++ b/charts/terra-argocd-env/templates/project.yaml
@@ -12,7 +12,7 @@ spec:
   sourceRepos:
   - "*"
   roles:
-  - description: Edit privileges for all applications in terra-staging
+  - description: Edit privileges for all applications in {{ $projectName }}
     name: edit
     policies:
     - p, proj:{{ $projectName }}:edit, applications, *, {{ $projectName }}/*, allow

--- a/charts/terra-argocd-env/values.yaml
+++ b/charts/terra-argocd-env/values.yaml
@@ -7,3 +7,6 @@ clusterAddress: null
 
 # The Terra environment this project is for. Eg. `dev`
 environment: null
+
+# Whether this environment requires a user to be suitable to make changes.
+requireSuitable: false


### PR DESCRIPTION
Add new value, requireSuitable, to terra-env-argocd chart, that limits edit permissions for applications in the project to users in the Workbench Admins group