### PR TITLE
DDO-476 Firewall restrictions for WSM

### DIFF
--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: workspacemanager
-version: 0.1.1
+version: 0.2.1
 
 description: Chart for Terra Workspace Manager
 type: application

--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -20,3 +20,21 @@ FQDN template
     {{ end -}}
     .{{ .Values.domain.suffix }}
 {{- end }}
+
+{{/*
+Service firewall
+*/}}
+{{- define "workspacemanager.servicefirewall" -}}
+  {{- $trustedIPs := .Values.global.trustedIPs | default dict -}}
+  {{- $allowedAddresses := merge .Values.serviceAllowedAddresses $trustedIPs -}}
+  {{- if $allowedAddresses | empty -}}
+    {{- fail "Please specify at least one allowed address" -}}
+  {{- end -}}
+
+  {{- range $nickname, $cidrs := $allowedAddresses }}
+  # {{ $nickname }}
+  {{- range $cidr := $cidrs }}
+  - {{ $cidr }}
+  {{- end -}}
+  {{- end -}}
+{{- end }}

--- a/charts/workspacemanager/templates/service.yaml
+++ b/charts/workspacemanager/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   type: LoadBalancer
   loadBalancerIP: {{ required "A valid serviceIP value is required!" .Values.serviceIP }}
+  {{- if .Values.serviceFirewallEnabled }}
+  loadBalancerSourceRanges:
+  {{- template "workspacemanager.servicefirewall" . }}
+  {{- end }}
   selector:
     app: terra-workspace-manager
   {{- if .Values.enableProxy}}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -21,6 +21,15 @@ samAddress: https://sam.dsde-dev.broadinstitute.org/
 # External IP of the service. Required.
 # serviceIP: $.$.$.$
 
+# Whether to restrict access to the service to the IPs supplied via serviceAllowedAddresses
+serviceFirewallEnabled: false
+
+# A map of addresses in the form
+# {
+#   "nickname": ["x.x.x.x/y", "x.x.x.x/y"]
+# }
+serviceAllowedAddresses: {}
+
 # DNS/TLS Values
 domain:
   hostname: workspace


### PR DESCRIPTION
Add new values to the workspacemanager chart:
`serviceFirewallEnable` - set to true to restrict traffic to the service based on source address
`serviceAllowedAddresses` - map of trusted source addresses
`global.trustedAddresses` - optional global map of trusted source addresses, merged with `serviceAllowedAddresses` to create final whitelist


Eg.
```
    serviceAllowedAddresses:
      broadInternal:
      - 69.43.20.2/24
      prodRawls:
      - 35.1.2.23/32
      - 109.5.6.7./32
```
