### PR TITLE
DDO-511 More refactoring

### DIFF
--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.4.2
+version: 0.5.0
 type: application
 
 description: A Helm chart for Cromwell, the Terra Workflow Management System

--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.4.1
+version: 0.4.2
 type: application
 
 description: A Helm chart for Cromwell, the Terra Workflow Management System

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -1,6 +1,6 @@
 {{- /* Generate a Cromwell deployment */ -}}
 {{- define "cromwell.deployment" -}}
-{{- $settings := .DeploymentSettings -}}
+{{- $settings := ._deploymentSettings -}}
 {{- $imageTag := $settings.imageTag | default .Values.global.applicationVersion -}}
 {{- $legacyResourcePrefix := $settings.legacyResourcePrefix | default $settings.name -}}
 apiVersion: apps/v1

--- a/charts/cromwell/templates/_service.tpl
+++ b/charts/cromwell/templates/_service.tpl
@@ -1,6 +1,6 @@
 {{- /* Generate a Cromwell service */ -}}
 {{- define "cromwell.service" -}}
-{{- $settings := .DeploymentSettings -}}
+{{- $settings := ._deploymentSettings -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,9 +16,12 @@ spec:
     targetPort: 443
   type: LoadBalancer
   loadBalancerIP: {{ $settings.serviceIP }}
-  {{- if not (empty $settings.serviceAllowedAddresses) }}
+  {{- $globalAllowed := $.Values.global.trustedAddresses | deepCopy -}}
+  {{- $serviceAllowed := $settings.serviceAllowedAddresses | deepCopy -}}
+  {{- $allAllowed := mergeOverwrite $globalAllowed $serviceAllowed -}}
+  {{- if not (empty $allAllowed) }}
   loadBalancerSourceRanges:
-  {{- range $nick, $cidrs := $settings.serviceAllowedAddresses }}
+  {{- range $nick, $cidrs := $allAllowed }}
   # {{ $nick }}
   {{- range $cidr := $cidrs }}
   - {{ $cidr }}

--- a/charts/cromwell/templates/_service.tpl
+++ b/charts/cromwell/templates/_service.tpl
@@ -14,8 +14,10 @@ spec:
   - protocol: TCP
     port: 443
     targetPort: 443
+  {{- if $settings.serviceIP }}
   type: LoadBalancer
   loadBalancerIP: {{ $settings.serviceIP }}
+  {{- end }}
   {{- $globalAllowed := $.Values.global.trustedAddresses | deepCopy -}}
   {{- $serviceAllowed := $settings.serviceAllowedAddresses | deepCopy -}}
   {{- $allAllowed := mergeOverwrite $globalAllowed $serviceAllowed -}}

--- a/charts/cromwell/templates/_service.tpl
+++ b/charts/cromwell/templates/_service.tpl
@@ -16,9 +16,9 @@ spec:
     targetPort: 443
   type: LoadBalancer
   loadBalancerIP: {{ $settings.serviceIP }}
-  {{- if not (empty $settings.serviceWhitelist) }}
+  {{- if not (empty $settings.serviceAllowedAddresses) }}
   loadBalancerSourceRanges:
-  {{- range $nick, $cidrs := $settings.serviceWhitelist }}
+  {{- range $nick, $cidrs := $settings.serviceAllowedAddresses }}
   # {{ $nick }}
   {{- range $cidr := $cidrs }}
   - {{ $cidr }}

--- a/charts/cromwell/templates/deployments.yaml
+++ b/charts/cromwell/templates/deployments.yaml
@@ -8,6 +8,7 @@
 {{- $defaults := $.Values.deploymentDefaults -}}
 {{- range $deploymentType, $overrides := $.Values.deployments }}
 {{- $settings := $defaults | merge (deepCopy $overrides) -}}
+{{- if $settings.enabled -}}
 {{- $templateScope := $ | merge (dict "DeploymentSettings" $settings) }}
 ---
 # Cromwell {{ $deploymentType }} deployment
@@ -16,5 +17,6 @@
 ---
 # Cromwell {{ $deploymentType }} service
 {{ template "cromwell.service" $templateScope }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/cromwell/templates/deployments.yaml
+++ b/charts/cromwell/templates/deployments.yaml
@@ -7,9 +7,10 @@
 */ -}}
 {{- $defaults := $.Values.deploymentDefaults -}}
 {{- range $deploymentType, $overrides := $.Values.deployments }}
-{{- $settings := $defaults | merge (deepCopy $overrides) -}}
-{{- if $settings.enabled -}}
-{{- $templateScope := $ | merge (dict "DeploymentSettings" $settings) }}
+{{- $settings := mergeOverwrite ($defaults | deepCopy) ($overrides | deepCopy) -}}
+{{- $templateScope := $ | deepCopy -}}
+{{- $_ := set $templateScope "_deploymentSettings" $settings -}}
+{{- if $settings.enabled }}
 ---
 # Cromwell {{ $deploymentType }} deployment
 {{ template "cromwell.deployment" $templateScope }}

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -5,49 +5,28 @@ global:
   # A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }`
   trustedAddresses: {}
 
-# Cromwell has 4 deployments:
-# - reader      - serves requests from other apps
-# - runner      - background - runs batch jobs
-# - summarizer  - background - summarizes job results
-# - legacy      - legacy all-in-one Cromwell (also serves requests from other apps)
-
-# Default settings for all Cromwell deployments
+# Cromwell is can be run in multiple deployments; this key contains default
+# settings for all deployments configured under the `deployments` key
+#
 deploymentDefaults:
   enabled: true  # Whether a declared deployment is enabled. If false, no resources will be created
   name: null     # Set separately in each deployment. Eg. "cromwell1-reader"
   imageTag: null # Defaults to global.applicationVersion
   replicas: 0    # Number of replicas
-  expose: false  # Whether to create a LoadBalancer service for this deployment
+  expose: false  # Whether to create a service for this deployment
   serviceName: null  # What to call the service
-  serviceIP: x.x.x.x # Static IP to use for the Service
+  serviceIP: null    # Static IP to use for the Service. If set, service will be of type LoadBalancer
   serviceAllowedAddresses: {} # What source IPs to whitelist for access to the service
   # legacyResourcePrefix: null # What prefix to use to refer to secrets rendered from firecloud-develop. Defaults to `name`
 
 # A map of Cromwell deployments. In Terra's production environment,
 # Cromwell is deployed as 4 separate services with different configurations.
 #
+# Here, we configure it as a single standalone deployment, similar to how a
+# developer might run Cromwell.
 deployments:
-  # Settings for the reader deployment
-  reader:
-    name: cromwell1-reader
-    replicas: 3
-    expose: true
-    serviceName: cromwell1
-    legacyResourcePrefix: cromwell1-frontend
-
-  # Settings for the runner deployment
-  runner:
-    name: cromwell1-runner
-    replicas: 3
-
-  # Settings for the summarizer deployment
-  summarizer:
-    name: cromwell1-summarizer
-    replicas: 1
-
-  # Settings for the legacy cromwell2 deploymnet
-  legacy:
-    name: cromwell2
+  standalone:
+    name: cromwell
     replicas: 1
     expose: true
-    serviceName: cromwell2
+    serviceName: cromwell

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -1,6 +1,9 @@
 # What version of Cromwell to deploy
 global:
+  # What version of the application to deploy
   applicationVersion: latest
+  # A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }`
+  trustedAddresses: {}
 
 # Cromwell has 4 deployments:
 # - reader      - serves requests from other apps
@@ -10,29 +13,15 @@ global:
 
 # Default settings for all Cromwell deployments
 deploymentDefaults:
+  enabled: true  # Whether a declared deployment is enabled. If false, no resources will be created
   name: null     # Set separately in each deployment. Eg. "cromwell1-reader"
   imageTag: null # Defaults to global.applicationVersion
   replicas: 0    # Number of replicas
   expose: false  # Whether to create a LoadBalancer service for this deployment
   serviceName: null  # What to call the service
   serviceIP: x.x.x.x # Static IP to use for the Service
-  serviceWhitelist: # What source IPs to whitelist for access to the service
-    broadIPs: # Always allow requests from broad office/VPN addresses
-    - 69.173.112.0/21
-    - 69.173.127.232/29
-    - 69.173.127.128/26
-    - 69.173.127.0/25
-    - 69.173.127.240/28
-    - 69.173.127.224/30
-    - 69.173.127.230/31
-    - 69.173.120.0/22
-    - 69.173.127.228/32
-    - 69.173.126.0/24
-    - 69.173.96.0/20
-    - 69.173.64.0/19
-    - 69.173.127.192/27
-# What prefix to use to refer to secrets rendered from firecloud-develop. Defaults to `name`
-# legacyResourcePrefix: null
+  serviceAllowedAddresses: {} # What source IPs to whitelist for access to the service
+  # legacyResourcePrefix: null # What prefix to use to refer to secrets rendered from firecloud-develop. Defaults to `name`
 
 # A map of Cromwell deployments. In Terra's production environment,
 # Cromwell is deployed as 4 separate services with different configurations.


### PR DESCRIPTION
* Remove hardcoded broad internal IPs from default values -- these will be supplied by terra-helmfile via a global value
* Make it possible to disable a configured deployment by adding a new deployment setting, `enabled`
* More careful handling of `merge`/`mergeOvewrite`, which have [surprising behavior](https://github.com/Masterminds/sprig/issues/188)