### PR TITLE
DDO-512 Implement JSON-style logging for Cromwell with a custom logback.xml file

### DIFF
--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.5.1
+version: 0.6.0
 type: application
 
 description: A Helm chart for Cromwell, the Terra Workflow Management System

--- a/charts/cromwell/templates/_configmap.tpl
+++ b/charts/cromwell/templates/_configmap.tpl
@@ -1,0 +1,13 @@
+{{- /* Generate a configmap for a Cromwell deployment */ -}}
+{{- define "cromwell.configmap" -}}
+{{- $settings := ._deploymentSettings -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $settings.name }}-cm
+  labels:
+{{ include "cromwell.labels" . | indent 4 }}
+data:
+  logback.xml: |
+{{ include "cromwell.config.logback" . | indent 4 }}
+{{ end -}}

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -93,7 +93,7 @@ spec:
           name: app-ctmpls
           readOnly: true
         - mountPath: /etc/cromwell-cm
-          name: cromwell-cm
+          name: {{ $settings.name }}-cm
           readOnly: true
         readinessProbe:
           httpGet:

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -47,6 +47,8 @@ spec:
       - name: {{ $settings.name }}-cm
         configMap:
           name: {{ $settings.name }}-cm
+      - name: {{ $settings.name }}-gc-logs
+        emptyDir: {}
       containers:
       - name: {{ $settings.name }}-app
         image: "broadinstitute/cromwell:{{ $imageTag }}"
@@ -95,6 +97,8 @@ spec:
         - mountPath: /etc/cromwell-cm
           name: {{ $settings.name }}-cm
           readOnly: true
+        - mountPath: /var/log/gc
+          name: {{ $settings.name }}-gc-logs
         readinessProbe:
           httpGet:
             path: /engine/latest/version

--- a/charts/cromwell/templates/config/_logback.xml.tpl
+++ b/charts/cromwell/templates/config/_logback.xml.tpl
@@ -14,7 +14,7 @@
               * Newlines in exceptions are also escaped using the %replace function
               * Curly braces are added as HTML entities, because literal curly braces can't be escaped in logback patterns
             -->
-            <pattern><pattern>&#123;"severity":"%level", "localTimestamp":"%date", "sourceThread":"%X{sourceThread}", "message":"%replace(%replace(%msg){'"','\\"'}){'\n','\\n'}%replace(%xException){'\n','\\n'}%nopex"&#125;%n</pattern></pattern>
+            <pattern>&#123;"severity":"%level", "localTimestamp":"%date", "sourceThread":"%X{sourceThread}", "message":"%replace(%replace(%msg){'"','\\"'}){'\n','\\n'}%replace(%xException){'\n','\\n'}%nopex"&#125;%n</pattern>
         </encoder>
     </appender>
 

--- a/charts/cromwell/templates/config/_logback.xml.tpl
+++ b/charts/cromwell/templates/config/_logback.xml.tpl
@@ -1,0 +1,39 @@
+{{- /* Generate a logback.xml config file for a Cromwell deployment */ -}}
+{{- define "cromwell.config.logback" -}}
+<configuration>
+    <appender name="STANDARD_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!--
+              Poor man's JSON logging. Create a message in the form
+                {"severity": "WARNING", "message": "<msg>"}
+
+              Read more about the rationale for this in DDO-512.
+
+              Notes:
+              * Double quotes and newlines in messages are escaped using the %replace function
+              * Newlines in exceptions are also escaped using the %replace function
+              * Curly braces are added as HTML entities, because literal curly braces can't be escaped in logback patterns
+            -->
+            <pattern><pattern>&#123;"severity":"%level", "message":"%replace(%replace(%msg){'"','\\"'}){'\n','\\n'}%replace(%xException){'\n','\\n'}%nopex"&#125;%n</pattern></pattern>
+        </encoder>
+    </appender>
+
+    <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STANDARD_APPENDER" />
+        <appender-ref ref="Sentry" />
+    </root>
+
+    <logger name="liquibase" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="ERROR"/>
+    <logger name="HikariPool" level="ERROR"/>
+    <logger name="com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel" level="ERROR"/>
+    <logger name="org.semanticweb.owlapi.utilities.Injector" level="ERROR"/>
+</configuration>
+{{ end -}}

--- a/charts/cromwell/templates/config/_logback.xml.tpl
+++ b/charts/cromwell/templates/config/_logback.xml.tpl
@@ -5,7 +5,7 @@
         <encoder>
             <!--
               Poor man's JSON logging. Create a message in the form
-                {"severity": "WARNING", "message": "<msg>"}
+                {"severity": "WARNING", "localTimestamp": "<timestamp>", "sourceThread":"<sourceThread>", "message": "<msg>"}
 
               Read more about the rationale for this in DDO-512.
 
@@ -14,7 +14,7 @@
               * Newlines in exceptions are also escaped using the %replace function
               * Curly braces are added as HTML entities, because literal curly braces can't be escaped in logback patterns
             -->
-            <pattern><pattern>&#123;"severity":"%level", "message":"%replace(%replace(%msg){'"','\\"'}){'\n','\\n'}%replace(%xException){'\n','\\n'}%nopex"&#125;%n</pattern></pattern>
+            <pattern><pattern>&#123;"severity":"%level", "localTimestamp":"%date", "sourceThread":"%X{sourceThread}", "message":"%replace(%replace(%msg){'"','\\"'}){'\n','\\n'}%replace(%xException){'\n','\\n'}%nopex"&#125;%n</pattern></pattern>
         </encoder>
     </appender>
 

--- a/charts/cromwell/templates/deployments.yaml
+++ b/charts/cromwell/templates/deployments.yaml
@@ -12,6 +12,9 @@
 {{- $_ := set $templateScope "_deploymentSettings" $settings -}}
 {{- if $settings.enabled }}
 ---
+# Cromwell {{ $deploymentType }} configmap
+{{ template "cromwell.configmap" $templateScope }}
+---
 # Cromwell {{ $deploymentType }} deployment
 {{ template "cromwell.deployment" $templateScope }}
 {{- if $settings.expose }}


### PR DESCRIPTION
Configure cromwell on GKE to use a custom logback.xml that produces single-line JSON log messages.

This is NOT real structured logging, where messages are serialized by the application into JSON. I think that would require an application-side change to, at minimum, pull in libraries from [logback-contrib](https://github.com/qos-ch/logback-contrib/wiki/JSON).

Instead, a Pattern is used to to format the message into a JSON object. Logback's `replace` function is used to escape newlines and double quotes in messages, as well as newlines in exception stacktraces.