### PR TITLE
DDO-398 Add terra-prometheus as dependency

### DIFF
--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to configure a k8s cluster for Terra
 
 type: application
 
-version: 0.1.4
+version: 0.1.5
 
 keywords:
 - dsp

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -33,5 +33,6 @@ dependencies:
   version: 0.0.1
   repository: https://broadinstitute.github.io/terra-helm/
 - name: terra-prometheus
+  condition: terra-prometheus.enabled
   version: 0.1.1
   repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -32,3 +32,6 @@ dependencies:
   condition: terra-cluster-networking.enabled
   version: 0.0.1
   repository: https://broadinstitute.github.io/terra-helm/
+- name: terra-prometheus
+  version: 0.1.1
+  repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -34,6 +34,7 @@ terra-cluster-psps:
     - istio-sidecar-injector-service-account
     - promsd
 terra-prometheus:
+  enabled: true
   namespaceOverride: monitoring
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -33,4 +33,8 @@ terra-cluster-psps:
     - istio-security-post-install-account
     - istio-sidecar-injector-service-account
     - promsd
-
+terra-prometheus:
+  namespaceOverride: monitoring
+  prometheus-operator:
+    # passing override to stable/prometheus-operator dependency
+    namespaceOverride: monitoring


### PR DESCRIPTION
This pr adds the new terra-prometheus chart as a dependency of terra cluster so that it can be managed by argocd. 