### PR TITLE
DDO-398 terra cluster dependency prometheus

### DIFF
--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to configure a k8s cluster for Terra
 
 type: application
 
-version: 0.1.4
+version: 0.1.5
 
 keywords:
 - dsp

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -34,5 +34,5 @@ dependencies:
   repository: https://broadinstitute.github.io/terra-helm/
 - name: terra-prometheus
   condition: terra-prometheus.enabled
-  version: 0.1.1
+  version: 0.1.2
   repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to configure a k8s cluster for Terra
 
 type: application
 
-version: 0.1.5
+version: 0.1.6
 
 keywords:
 - dsp

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -33,5 +33,6 @@ dependencies:
   version: 0.0.1
   repository: https://broadinstitute.github.io/terra-helm/
 - name: terra-prometheus
+  condition: terra-prometheus.enabled
   version: 0.1.1
   repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -32,3 +32,6 @@ dependencies:
   condition: terra-cluster-networking.enabled
   version: 0.0.1
   repository: https://broadinstitute.github.io/terra-helm/
+- name: terra-prometheus
+  version: 0.1.1
+  repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to configure a k8s cluster for Terra
 
 type: application
 
-version: 0.1.6
+version: 0.1.7
 
 keywords:
 - dsp

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -34,6 +34,7 @@ terra-cluster-psps:
     - istio-sidecar-injector-service-account
     - promsd
 terra-prometheus:
+  enabled: true
   namespaceOverride: monitoring
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -42,7 +42,7 @@ terra-prometheus:
 
     defaultRules:
       rules:
-        promtheus: false
+        prometheus: false
     # Namespace overrides for sub charts
     grafana:
       namespaceOverride: monitoring

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -34,7 +34,7 @@ terra-cluster-psps:
     - istio-sidecar-injector-service-account
     - promsd
 terra-prometheus:
-  enabled: true
+  enabled: false
   namespaceOverride: monitoring
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -39,9 +39,7 @@ terra-prometheus:
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency
     namespaceOverride: monitoring
-
     defaultRules:
-      create: false
       rules:
         prometheus: false
         prometheusOperator: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -43,6 +43,7 @@ terra-prometheus:
     defaultRules:
       rules:
         prometheus: false
+        PrometheusOperator: false
     # Namespace overrides for sub charts
     grafana:
       namespaceOverride: monitoring

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -46,6 +46,9 @@ terra-prometheus:
         prometheus: false
         prometheusOperator: false
     # Namespace overrides for sub charts
+    prometheusOperator:
+      admissionWebhooks:
+        failurePolicy: Ignore
     grafana:
       namespaceOverride: monitoring
     kube-state-metrics:

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -34,7 +34,7 @@ terra-cluster-psps:
     - istio-sidecar-injector-service-account
     - promsd
 terra-prometheus:
-  enabled: true
+  enabled: false
   namespaceOverride: monitoring
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency
@@ -46,7 +46,7 @@ terra-prometheus:
     # Namespace overrides for sub charts
     prometheusOperator:
       admissionWebhooks:
-        failurePolicy: Ignore
+        enabled: false # known issue with GKE clusters
     grafana:
       namespaceOverride: monitoring
     kube-state-metrics:

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -34,7 +34,7 @@ terra-cluster-psps:
     - istio-sidecar-injector-service-account
     - promsd
 terra-prometheus:
-  enabled: false
+  enabled: true
   namespaceOverride: monitoring
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -43,7 +43,7 @@ terra-prometheus:
     defaultRules:
       rules:
         prometheus: false
-        PrometheusOperator: false
+        prometheusOperator: false
     # Namespace overrides for sub charts
     grafana:
       namespaceOverride: monitoring

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -33,4 +33,8 @@ terra-cluster-psps:
     - istio-security-post-install-account
     - istio-sidecar-injector-service-account
     - promsd
-
+terra-prometheus:
+  namespaceOverride: monitoring
+  prometheus-operator:
+    # passing override to stable/prometheus-operator dependency
+    namespaceOverride: monitoring

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -41,6 +41,7 @@ terra-prometheus:
     namespaceOverride: monitoring
 
     defaultRules:
+      create: false
       rules:
         prometheus: false
         prometheusOperator: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -39,6 +39,10 @@ terra-prometheus:
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency
     namespaceOverride: monitoring
+
+    defaultRules:
+      rules:
+        promtheus: false
     # Namespace overrides for sub charts
     grafana:
       namespaceOverride: monitoring

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -39,3 +39,24 @@ terra-prometheus:
   prometheus-operator:
     # passing override to stable/prometheus-operator dependency
     namespaceOverride: monitoring
+    # Namespace overrides for sub charts
+    grafana:
+      namespaceOverride: monitoring
+    kube-state-metrics:
+      namespaceOverride: monitoring
+    prometheus-node-exporter:
+      namespaceOverride: monitoring
+    # Some k8s internals are abstracted by gke and are not accessible
+    # The following disable prometheus scraping of those components
+    coreDns:
+      enabled: false
+    kubeControllerManager:
+      enabled: false
+    kubeDns:
+      enabled: true # used instead of coreDns in GKE
+    kubeEtcd:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeProxy:
+      enabled: false


### PR DESCRIPTION
This pr ensures that when deployed with argocd, prometheus is installing all its resources to the monitoring namespace as desired. ( rather than mixing them between default and monitoring)

GKE also abstracts away some internals and does not make them accessible. These include Etcd, controller-manager, and the scheduler. In the default configuration prometheus will try to discover and scrape these components. Disabling monitoring of these inaccessible components makes the prometheus deployment appear healthy.