### PR TITLE
DDO-545 Add labels to support orchestrated syncing

### DIFF
--- a/charts/terra-argocd-app/Chart.yaml
+++ b/charts/terra-argocd-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terra-argocd-app
 description: A Helm chart for generating ArgoCD resources for a Terra app in an environment
 type: application
-version: 0.1.0
+version: 0.1.1
 dependencies:
 - name: terra-argocd-templates
   version: 0.0.4

--- a/charts/terra-argocd-app/templates/app.yaml
+++ b/charts/terra-argocd-app/templates/app.yaml
@@ -9,6 +9,7 @@ metadata:
     cluster: {{ .clusterName }}
     type: app
     has-legacy-configs: {{ .legacyConfigsEnabled }}
+    jenkins-sync-enabled: {{ .jenkinsSyncEnabled }}
   {{- if .purgeDeployedResourcesOnDelete }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/charts/terra-argocd-app/templates/app.yaml
+++ b/charts/terra-argocd-app/templates/app.yaml
@@ -4,9 +4,11 @@ kind: Application
 metadata:
   name: {{ required "A valid app name is required" .app }}-{{ required "A valid environment is required" .environment }}
   labels:
-    app: {{ .app }} # These labels are used as selectors in the UI
+    app: {{ .app }} # These labels are used as selectors in the UI and for argocd CLI calls
     env: {{ .environment }}
     cluster: {{ .clusterName }}
+    type: app
+    has-legacy-configs: {{ .legacyConfigsEnabled }}
   {{- if .purgeDeployedResourcesOnDelete }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/charts/terra-argocd-app/templates/legacy-configs-app.yaml
+++ b/charts/terra-argocd-app/templates/legacy-configs-app.yaml
@@ -5,9 +5,10 @@ kind: Application
 metadata:
   name: {{ .app }}-configs-{{ .environment }}
   labels:
-    app: {{ .app }} # These labels are used as selectors in the UI
+    app: {{ .app }} # These labels are used as selectors in the UI and for argocd CLI calls
     env: {{ .environment }}
     cluster: {{ .clusterName }}
+    type: legacy-configs
   {{- if .purgeDeployedResourcesOnDelete }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/charts/terra-argocd-app/templates/legacy-configs-app.yaml
+++ b/charts/terra-argocd-app/templates/legacy-configs-app.yaml
@@ -9,6 +9,7 @@ metadata:
     env: {{ .environment }}
     cluster: {{ .clusterName }}
     type: legacy-configs
+    jenkins-sync-enabled: {{ .jenkinsSyncEnabled }}
   {{- if .purgeDeployedResourcesOnDelete }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/charts/terra-argocd-app/values.yaml
+++ b/charts/terra-argocd-app/values.yaml
@@ -11,6 +11,9 @@ environment: null
 # Name of the application to render for. Eg. `cromwell`
 app: null
 
+# Whether to sync this app on Jenkins environment deploys
+jenkinsSyncEnabled: true
+
 # Optional: Sync policy for the app.
 # See https://argoproj.github.io/argo-cd/user-guide/auto_sync/
 # Default to no sync policy (manual)


### PR DESCRIPTION
Add some new labels to ArgoCD deployment definitions.

For Terra apps (eg. `cromwell-staging`, `workspacemanager-prod`):
* `type: app` (used to distinguish app deployments from other types)
* `has-legacy-configs: (false|true)` true if this deployment depends on another deployment that pulls configuration from firecloud-develop
* `jenkins-sync-enabled: true` can be overriden in terra-helmfile to stop Jenkins deploys to $ENV from syncing specific apps

For deploys that pull configs from firecloud-develop (eg. `cromwell-configs-staging`)
* `type:  legacy-configs`
* `jenkins-sync-enabled: true`

These labels will be used by Jenkins to trigger ArgoCD syncs. See:
* https://github.com/broadinstitute/jenkins-terra-gke-deploy/pull/1
* https://github.com/broadinstitute/dsp-jenkins/pull/415