### PR TITLE
DDO-582 Add label to filter k8s infrastructure metrics from stackdriver

### DIFF
--- a/charts/terra-cluster/Chart.yaml
+++ b/charts/terra-cluster/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to configure a k8s cluster for Terra
 
 type: application
 
-version: 0.1.9
+version: 0.1.10
 
 keywords:
 - dsp

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -75,4 +75,4 @@ terra-prometheus:
         relabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
-            replacement: false
+            replacement: 'false'

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -73,6 +73,6 @@ terra-prometheus:
     kubeStateMetrics:
       serviceMonitor:
         relabelings:
-          - source_labels: '[__name__]'
-            target_label: sd_export
+          - sourceLabels: '[__name__]'
+            targetLabel: sd_export
             replacement: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -40,8 +40,6 @@ terra-prometheus:
     # passing override to stable/prometheus-operator dependency
     namespaceOverride: monitoring
     defaultRules:
-      labels:
-        sd_export: false
       rules:
         prometheus: false
         prometheusOperator: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -40,6 +40,8 @@ terra-prometheus:
     # passing override to stable/prometheus-operator dependency
     namespaceOverride: monitoring
     defaultRules:
+      labels:
+        sd_export: false
       rules:
         prometheus: false
         prometheusOperator: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -73,6 +73,6 @@ terra-prometheus:
     kubeStateMetrics:
       serviceMonitor:
         relabelings:
-          - sourceLabels: '[__name__]'
+          - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -69,3 +69,10 @@ terra-prometheus:
       enabled: false
     kubeProxy:
       enabled: false
+    # Metric relabelings for stackdriver filter
+    kubeStateMetrics:
+      serviceMonitor:
+        relabelings:
+          - source_labels: '[__name__]'
+            target_label: sd_export
+            replacement: false

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -76,3 +76,52 @@ terra-prometheus:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
+    prometheusOperator:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    prometheus:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    alertmanager:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    grafana:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    kubeApiServer:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    kubeDns:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    kubelet:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+    nodeExporter:
+      serviceMonitor:
+        relabelings:
+          - sourceLabels: [__name__]
+            targetLabel: sd_export
+            replacement: 'false'
+        

--- a/charts/terra-cluster/values.yaml
+++ b/charts/terra-cluster/values.yaml
@@ -72,55 +72,55 @@ terra-prometheus:
     # Metric relabelings for stackdriver filter
     kubeStateMetrics:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     prometheusOperator:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     prometheus:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     alertmanager:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     grafana:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     kubeApiServer:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     kubeDns:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     kubelet:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'
     nodeExporter:
       serviceMonitor:
-        relabelings:
+        metricRelabelings:
           - sourceLabels: [__name__]
             targetLabel: sd_export
             replacement: 'false'


### PR DESCRIPTION
Adds a label to default k8s infrastructure metrics to filter them out from forwarding to stackdriver. This is to avoid overwhleming external metric quotas on stackdriver workspaces and to save $.