### PR TITLE
Add option to run ephemeral Postgres deployment instead of using CloudSQL

### DIFF
--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: workspacemanager
-version: 0.3.1
+version: 0.3.2
 
 description: Chart for Terra Workspace Manager
 type: application
@@ -14,3 +14,9 @@ keywords:
 sources:
 - https://github.com/broadinstitute/terra-helm/tree/master/charts
 - https://github.com/DataBiosphere/terra-workspace-manager
+
+dependencies:
+- name: postgres
+  condition: postgres.enabled
+  version: 0.1.0
+  repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -3,7 +3,11 @@ workspacemanager
 
 Chart for Terra Workspace Manager
 
+## Chart Requirements
 
+| Repository | Name | Version |
+|------------|------|---------|
+| https://broadinstitute.github.io/terra-helm/ | postgres | 0.1.0 |
 
 ## Chart Values
 
@@ -24,6 +28,8 @@ Chart for Terra Workspace Manager
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/terra-workspace-manager"` | Image repository |
 | imageConfig.tag | string | The chart's appVersion value will be used | Image tag. |
+| postgres.dbs | list | `["workspace","stairway"]` | (array(string)) List of databases to create.  |
+| postgres.enabled | bool | `false` | Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options. |
 | proxy.enabled | bool | `true` |  |
 | proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Proxy image repository |
 | proxy.image.version | string | `"bernick_tcell"` | Proxy image tag |

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               name: workspace-stairway-db-creds
               key: db
         {{- else }}
+        - name: DATABASE_HOSTNAME
+          value: {{ .Chart.Name }}-postgres-service.{{ .Release.Namespace }}.svc.cluster.local
         - name: DATABASE_USER
           value: postgres
         - name: DATABASE_USER_PASSWORD

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - containerPort: 8080
         {{- end}}
         env:
+        {{- if not .Values.postgres.enabled }}
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
@@ -59,6 +60,20 @@ spec:
             secretKeyRef:
               name: workspace-stairway-db-creds
               key: db
+        {{- else }}
+        - name: DATABASE_USER
+          value: postgres
+        - name: DATABASE_USER_PASSWORD
+          value: {{ .Values.postgres.password }}
+        - name: DATABASE_NAME
+          value: {{ index .Values.postgres.dbs 0 }}
+        - name: STAIRWAY_DATABASE_USER
+          value: postgres
+        - name: STAIRWAY_DATABASE_USER_PASSWORD
+          value: {{ .Values.postgres.password }}
+        - name: STAIRWAY_DATABASE_NAME
+          value: {{ index .Values.postgres.dbs 1 }}
+        {{- end }}
         - name: SAM_ADDRESS
           value: {{ .Values.samAddress }}
         - name: SERVICE_GOOGLE_PROJECT
@@ -71,6 +86,7 @@ spec:
           - name: cloud-trace-sa-creds
             mountPath: /secrets/cloudtrace
             readOnly: true
+      {{- if not .Values.postgres.enabled }}
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.16
         env:
@@ -99,6 +115,7 @@ spec:
         - name: cloudsql-sa-creds
           mountPath: /secrets/cloudsql
           readOnly: true
+      {{- end }}
       {{- if .Values.proxy.enabled }}
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
@@ -125,12 +142,14 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
+        {{- if not .Values.postgres.enabled }}
         - name: cloudsql-sa-creds
           secret:
             secretName: workspace-sqlproxy-sa
         - name: cloud-trace-sa-creds
           secret:
             secretName: workspace-cloud-trace-sa
+        {{- end }}
         {{- if .Values.proxy.enabled }}
         - name: apache-httpd-proxy-config
           configMap:
@@ -142,3 +161,13 @@ spec:
           secret:
             secretName: {{ .Chart.Name }}-cert
         {{- end }}
+---
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}-postgres-deployment
+  labels:
+    {{ template "workspacemanager.labels" . }}
+{{- include "postgres.deployment.tpl" . }}
+{{- end }}

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: terra-workspace-manager-deployment
+  name: {{ .Chart.Name }}-deployment
   labels:
     {{ template "workspacemanager.labels" . }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: terra-workspace-manager
+      app: {{ .Chart.Name }}
   template:
     metadata:
-      name: terra-workspace-manager-service
+      name: {{ .Chart.Name }}-service
       labels:
-        app: terra-workspace-manager
+        app: {{ .Chart.Name }}
     spec:
-      serviceAccountName: terra-workspace-manager-service-sa
+      serviceAccountName: {{ .Chart.Name }}-service-sa
       containers:
-      - name: terra-workspace-manager
+      - name: {{ .Chart.Name }}
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
@@ -134,7 +134,7 @@ spec:
         {{- if .Values.proxy.enabled }}
         - name: apache-httpd-proxy-config
           configMap:
-            name: terra-workspace-manager-proxy-configmap
+            name: {{ .Chart.Name }}-proxy-configmap
             items:
             - key: apache-httpd-proxy-config
               path: workspace-manager-proxy.conf

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -148,10 +148,10 @@ spec:
         - name: cloudsql-sa-creds
           secret:
             secretName: workspace-sqlproxy-sa
+        {{- end }}
         - name: cloud-trace-sa-creds
           secret:
             secretName: workspace-cloud-trace-sa
-        {{- end }}
         {{- if .Values.proxy.enabled }}
         - name: apache-httpd-proxy-config
           configMap:

--- a/charts/workspacemanager/templates/postgres-init-db-configmap.yaml
+++ b/charts/workspacemanager/templates/postgres-init-db-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-postgres-initdb
+  labels:
+    {{ template "workspacemanager.labels" . }}
+{{- template "postgres.init-db-configmap.tpl" . }}
+{{- end }}

--- a/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: terra-workspace-manager-proxy-configmap
+  name: {{ .Chart.Name }}-proxy-configmap
   labels:
     {{ template "workspacemanager.labels" . }}
 data:

--- a/charts/workspacemanager/templates/role.yaml
+++ b/charts/workspacemanager/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: terra-workspace-manager-service-role
+  name: {{ .Chart.Name }}-service-role
   labels:
     {{ template "workspacemanager.labels" . }}
 rules:

--- a/charts/workspacemanager/templates/rolebinding.yaml
+++ b/charts/workspacemanager/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: terra-workspace-manager-service-role-binding
+  name: {{ .Chart.Name }}-service-role-binding
   labels:
     {{ template "workspacemanager.labels" . }}
 roleRef:
   kind: Role
-  name: terra-workspace-manager-service-role
+  name: {{ .Chart.Name }}-service-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:
 - kind: ServiceAccount
-  name: terra-workspace-manager-service-sa
+  name: {{ .Chart.Name }}-service-sa

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.vault.enabled }}
+{{- if not .Values.postgres.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
@@ -70,6 +71,7 @@ spec:
       encoding: base64
       key: key
 ---
+{{- end }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:

--- a/charts/workspacemanager/templates/service-account.yaml
+++ b/charts/workspacemanager/templates/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: terra-workspace-manager-service-sa
+  name: {{ .Chart.Name }}-service-sa
   labels:
     {{ template "workspacemanager.labels" . }}

--- a/charts/workspacemanager/templates/service.yaml
+++ b/charts/workspacemanager/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: terra-workspace-manager-service
+  name: {{ .Chart.Name }}-service
   labels:
     {{ template "workspacemanager.labels" . }}
 spec:
@@ -12,7 +12,7 @@ spec:
   {{- template "workspacemanager.servicefirewall" . }}
   {{- end }}
   selector:
-    app: terra-workspace-manager
+    app: {{ .Chart.Name }}
   {{- if .Values.proxy.enabled }}
   ports:
   - name: http

--- a/charts/workspacemanager/templates/service.yaml
+++ b/charts/workspacemanager/templates/service.yaml
@@ -26,3 +26,13 @@ spec:
   - name: http
     port: 8080
   {{- end}}
+{{- if .Values.postgres.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-postgres-service
+  labels:
+    {{ template "workspacemanager.labels" . }}
+{{- include "postgres.service.tpl" . }}
+{{- end }}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -94,3 +94,10 @@ proxy:
     # proxy.image.version -- Proxy image tag
     version: bernick_tcell
 
+postgres:
+  # postgres.enabled -- Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options.
+  enabled: false
+  # postgres.dbs -- (array(string)) List of databases to create. 
+  dbs:
+    - workspace
+    - stairway


### PR DESCRIPTION
The main use case for this is for preview environments