### PR TITLE
DDO-466-k8s-jvm-cromwell

### DIFF
--- a/charts/crljanitor/Chart.yaml
+++ b/charts/crljanitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crljanitor
-version: 0.1.4
+version: 0.1.5
 
 description: Chart for Cloud Resource Manager Janitor
 type: application

--- a/charts/crljanitor/Chart.yaml
+++ b/charts/crljanitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crljanitor
-version: 0.1.3
+version: 0.1.4
 
 description: Chart for Cloud Resource Manager Janitor
 type: application

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -59,6 +59,16 @@ spec:
             secretKeyRef:
               name: crl-janitor-stairway-db-creds
               key: db
+        - name: TRACK_RESOURCE_PUBSUB_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-pubsub-project-id
+              key: project
+        - name: TRACK_RESOURCE_PUBSUB_SUBSCRIPTION
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-pubsub-subscription
+              key: subscription
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.16
         env:

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -62,12 +62,12 @@ spec:
         - name: TRACK_RESOURCE_PUBSUB_PROJECT_ID
           valueFrom:
             secretKeyRef:
-              name: crl-janitor-pubsub-project-id
+              name: crl-janitor-track-resource-pubsub
               key: project
         - name: TRACK_RESOURCE_PUBSUB_SUBSCRIPTION
           valueFrom:
             secretKeyRef:
-              name: crl-janitor-pubsub-subscription
+              name: crl-janitor-track-resource-pubsub
               key: subscription
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.16

--- a/charts/crljanitor/templates/secrets.yaml
+++ b/charts/crljanitor/templates/secrets.yaml
@@ -69,4 +69,20 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/crl_janitor/app-sa
       encoding: base64
       key: key
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-crl-janitor-track-resource-pubsub
+  labels:
+    {{ template "crljanitor.labels" . }}
+spec:
+  name: crl-janitor-track-resource-pubsub
+  keysMap:
+    project:
+      path: {{ .Values.vault.configPathPrefix }}/crl_janitor/pubsub
+      key: project
+    subscription:
+      path: {{ .Values.vault.configPathPrefix }}/crl_janitor/pubsub
+      key: subscription
 {{ end }}

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -27,6 +27,8 @@ vault:
   enabled: true
   # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
   pathPrefix:
+  # vault.configPathPrefix -- (string) Vault path prefix for configs. Required if vault.enabled.
+  configPathPrefix:
 
 # serviceIP -- (string) External IP of the service. Required.
 serviceIP:

--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.7.0
+version: 0.7.1
 type: application
 
 description: A Helm chart for Cromwell, the Terra Workflow Management System

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -67,7 +67,7 @@ spec:
           java ${JAVA_OPTS}
           -Dlogback.configurationFile=/etc/cromwell-cm/logback.xml
           -Dsystem.cromwell_id=gke-${K8S_POD_NAME}
-          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090
+          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:
           -jar /app/cromwell.jar
           ${CROMWELL_ARGS} ${*}
         - '--'

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -25,6 +25,7 @@ spec:
     metadata:
       labels:
         deployment: {{ $settings.name }}
+{{ include "cromwell.labels" . | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
         checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }}

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -53,7 +53,7 @@ spec:
           name: {{ $settings.name }}-cm
       - name: {{ $settings.name }}-gc-logs
         emptyDir: {}
-      - name: cromwell-prometheusJmx-jar
+      - name: cromwell-prometheusjmx-jar
         emptyDir: {}
       containers:
       - name: {{ $settings.name }}-app
@@ -67,7 +67,7 @@ spec:
           java ${JAVA_OPTS}
           -Dlogback.configurationFile=/etc/cromwell-cm/logback.xml
           -Dsystem.cromwell_id=gke-${K8S_POD_NAME}
-          -javaagent:/etc/prometheusJmx/prometheusJmx.jar=9090
+          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090
           -jar /app/cromwell.jar
           ${CROMWELL_ARGS} ${*}
         - '--'
@@ -108,9 +108,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/gc
           name: {{ $settings.name }}-gc-logs
-        - mountPath: /etc/prometheusJmx/prometheusJmx.jar
-          subPath: prometheusJmx.jar
-          name: cromwell-prometheusJmx-jar
+        - mountPath: /etc/prometheusjmx/prometheusjmx.jar
+          subPath: prometheusjmx.jar
+          name: cromwell-prometheusjmx-jar
         readinessProbe:
           httpGet:
             path: /engine/latest/version
@@ -161,10 +161,10 @@ spec:
           name: sqlproxy-ctmpls
           readOnly: true
       initContainers:
-      - name: download-prometheusJmx-jar
+      - name: download-prometheusjmx-jar
         image: alpine:3.12.0
-        command: ["wget", "-O", "/cromwell-prometheusJmx-jar/prometheusJmx.jar", "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar"]
+        command: ["wget", "-O", "/cromwell-prometheusjmx-jar/prometheusjmx.jar", "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar"]
         volumeMounts:
-        - mountPath: /cromwel-prometheusJmx-jar
-          name: cromwell-prometheusJmx-jar
+        - mountPath: /cromwel-prometheusjmx-jar
+          name: cromwell-prometheusjmx-jar
 {{- end -}}

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -165,6 +165,6 @@ spec:
         image: alpine:3.12.0
         command: ["wget", "-O", "/cromwell-prometheusjmx-jar/prometheusjmx.jar", "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar"]
         volumeMounts:
-        - mountPath: /cromwel-prometheusjmx-jar
+        - mountPath: /cromwell-prometheusjmx-jar
           name: cromwell-prometheusjmx-jar
 {{- end -}}

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -70,7 +70,7 @@ spec:
           java ${JAVA_OPTS}
           -Dlogback.configurationFile=/etc/cromwell-cm/logback.xml
           -Dsystem.cromwell_id=gke-${K8S_POD_NAME}
-          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:
+          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:prometheusJmx.yaml
           -jar /app/cromwell.jar
           ${CROMWELL_ARGS} ${*}
         - '--'
@@ -114,8 +114,7 @@ spec:
         - mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
           name: cromwell-prometheusjmx-jar
-        - mountPath: /etc/prometheusjmx/prometheusjmxconf.yaml
-          subPath: prometheusjmxconf.yaml
+        - mountPath: /etc/prometheusjmx
           name: jmx-exporter-cm
           readOnly: true
         readinessProbe:

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -58,6 +58,8 @@ spec:
       containers:
       - name: {{ $settings.name }}-app
         image: "broadinstitute/cromwell:{{ $imageTag }}"
+        ports:
+          - containerPort: 9090
         command: ["/bin/bash"]
         args:
         - '-c'

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -70,7 +70,7 @@ spec:
           java ${JAVA_OPTS}
           -Dlogback.configurationFile=/etc/cromwell-cm/logback.xml
           -Dsystem.cromwell_id=gke-${K8S_POD_NAME}
-          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:prometheusJmx.yaml
+          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/prometheusjmx/conf/prometheusJmx.yaml
           -jar /app/cromwell.jar
           ${CROMWELL_ARGS} ${*}
         - '--'

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -114,7 +114,7 @@ spec:
         - mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
           name: cromwell-prometheusjmx-jar
-        - mountPath: /etc/prometheusjmx
+        - mountPath: /etc/prometheusjmx/conf
           name: jmx-exporter-cm
           readOnly: true
         readinessProbe:

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -55,7 +55,7 @@ spec:
         emptyDir: {}
       - name: cromwell-prometheusjmx-jar
         emptyDir: {}
-      - name: cromwell-prometheusjmx-cm
+      - name: jmx-exporter-cm
         configMap:
           name: jmx-exporter-cm
       containers:

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -57,7 +57,7 @@ spec:
         emptyDir: {}
       - name: cromwell-prometheusjmx-cm
         configMap:
-          name: cromwell-prometheusjmx-cm
+          name: jmx-exporter-cm
       containers:
       - name: {{ $settings.name }}-app
         image: "broadinstitute/cromwell:{{ $imageTag }}"
@@ -116,7 +116,7 @@ spec:
           name: cromwell-prometheusjmx-jar
         - mountPath: /etc/prometheusjmx/prometheusjmxconf.yaml
           subPath: prometheusjmxconf.yaml
-          name: cromwell-prometheusjmx-cm
+          name: jmx-exporter-cm
           readOnly: true
         readinessProbe:
           httpGet:

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -55,6 +55,9 @@ spec:
         emptyDir: {}
       - name: cromwell-prometheusjmx-jar
         emptyDir: {}
+      - name: cromwell-prometheusjmx-cm
+        configMap:
+          name: cromwell-prometheusjmx-cm
       containers:
       - name: {{ $settings.name }}-app
         image: "broadinstitute/cromwell:{{ $imageTag }}"
@@ -111,6 +114,10 @@ spec:
         - mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
           name: cromwell-prometheusjmx-jar
+        - mountPath: /etc/prometheusjmx/prometheusjmxconf.yaml
+          subPath: prometheusjmxconf.yaml
+          name: cromwell-prometheusjmx-cm
+          readOnly: true
         readinessProbe:
           httpGet:
             path: /engine/latest/version

--- a/charts/cromwell/templates/_service.tpl
+++ b/charts/cromwell/templates/_service.tpl
@@ -11,9 +11,14 @@ spec:
   selector:
     deployment: {{ $settings.name }}
   ports:
-  - protocol: TCP
+  - name: https
+    protocol: TCP
     port: 443
     targetPort: 443
+  - name: metrics
+    protocol: TCP
+    port: 9090
+    targetPort: 9090
   {{- if $settings.serviceIP }}
   type: LoadBalancer
   loadBalancerIP: {{ $settings.serviceIP }}

--- a/charts/cromwell/templates/_service.tpl
+++ b/charts/cromwell/templates/_service.tpl
@@ -15,10 +15,6 @@ spec:
     protocol: TCP
     port: 443
     targetPort: 443
-  - name: metrics
-    protocol: TCP
-    port: 9090
-    targetPort: 9090
   {{- if $settings.serviceIP }}
   type: LoadBalancer
   loadBalancerIP: {{ $settings.serviceIP }}

--- a/charts/cromwell/templates/jmxExporterCm.yaml
+++ b/charts/cromwell/templates/jmxExporterCm.yaml
@@ -5,5 +5,6 @@ metadata:
   labels:
 {{ include "cromwell.labels" . | indent 4 }}
 data:
-  rules:
-  - pattern: ".*"
+  prometheusJmx.yaml:
+    rules:
+    - pattern: ".*"

--- a/charts/cromwell/templates/jmxExporterCm.yaml
+++ b/charts/cromwell/templates/jmxExporterCm.yaml
@@ -5,3 +5,5 @@ metadata:
   labels:
 {{ include "cromwell.labels" . | indent 4 }}
 data:
+  rules:
+  - pattern: ".*"

--- a/charts/cromwell/templates/jmxExporterCm.yaml
+++ b/charts/cromwell/templates/jmxExporterCm.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
 {{ include "cromwell.labels" . | indent 4 }}
 data:
-  prometheusJmx.yaml:
+  prometheusJmx.yaml: |
     rules:
     - pattern: ".*"

--- a/charts/cromwell/templates/jmxExporterCm.yaml
+++ b/charts/cromwell/templates/jmxExporterCm.yaml
@@ -8,3 +8,4 @@ data:
   prometheusJmx.yaml: |
     rules:
     - pattern: ".*"
+    

--- a/charts/cromwell/templates/jmxExporterCm.yaml
+++ b/charts/cromwell/templates/jmxExporterCm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jmx-exporter-cm
+  labels:
+{{ include "cromwell.labels" . | indent 4 }}
+data:

--- a/charts/cromwell/templates/metricsService.yaml
+++ b/charts/cromwell/templates/metricsService.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cromwell-metrics
+  labels:
+    prometheus.io/scrape: true
+{{ include "cromwell.labels" . | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/component: cromwell
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 9090
+    targetPort: 9090
+  type: ClusterIp

--- a/charts/cromwell/templates/metricsService.yaml
+++ b/charts/cromwell/templates/metricsService.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: cromwell-metrics
   labels:
-    prometheus.io/scrape: true
+    prometheus.io/scrape: "true"
 {{ include "cromwell.labels" . | indent 4 }}
 spec:
   selector:

--- a/charts/cromwell/templates/metricsService.yaml
+++ b/charts/cromwell/templates/metricsService.yaml
@@ -13,4 +13,4 @@ spec:
     protocol: TCP
     port: 9090
     targetPort: 9090
-  type: ClusterIp
+  type: ClusterIP

--- a/charts/cromwell/templates/metricsService.yaml
+++ b/charts/cromwell/templates/metricsService.yaml
@@ -14,3 +14,4 @@ spec:
     port: 9090
     targetPort: 9090
   type: ClusterIP
+  

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cromwell-jvm-monitor
+  labels:
+    app: prometheus
+{{ include "cromwell.labels" . | indent 4 }}
+spec:
+  jobLabel: cromwell-jvm
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: cromwell
+      app.kubernetes.io/name: cromwell
+  namespaceSelector:
+    matchNames:
+    - terra-dev
+  endpoints:
+  - port: metrics
+    interval: 15s

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -15,3 +15,4 @@ spec:
   endpoints:
   - port: metrics
     interval: 15s
+    

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -2,9 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cromwell-jvm-monitor
-  namespace: monitoring # service monitors must be deployed in same namespace as prometheus
-  labels:
-    release: terra-cluster-dev 
+  labels: 
 {{ include "cromwell.labels" . | indent 4 }}
 spec:
   jobLabel: cromwell-jvm

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -11,6 +11,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: cromwell
+  namespaceSelector:
+    matchNames:
+    - terra-dev
   endpoints:
   - port: metrics
     interval: 15s

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -11,10 +11,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: cromwell
-      app.kubernetes.io/name: cromwell
-  namespaceSelector:
-    matchNames:
-    - terra-dev
   endpoints:
   - port: metrics
     interval: 15s

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cromwell-jvm-monitor
+  namespace: monitoring # service monitors must be deployed in same namespace as prometheus
   labels:
     app: prometheus
 {{ include "cromwell.labels" . | indent 4 }}

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -10,7 +10,7 @@ spec:
   jobLabel: cromwell-jvm
   selector:
     matchLabels:
-      app.kubernetes.io/component: cromwell
+      prometheus.io/scrape: true
   namespaceSelector:
     matchNames:
     - terra-dev

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -10,7 +10,7 @@ spec:
   jobLabel: cromwell-jvm
   selector:
     matchLabels:
-      prometheus.io/scrape: true
+      prometheus.io/scrape: "true"
   namespaceSelector:
     matchNames:
     - terra-dev

--- a/charts/cromwell/templates/serviceMonitor.yaml
+++ b/charts/cromwell/templates/serviceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cromwell-jvm-monitor
   namespace: monitoring # service monitors must be deployed in same namespace as prometheus
   labels:
-    app: prometheus
+    release: terra-cluster-dev 
 {{ include "cromwell.labels" . | indent 4 }}
 spec:
   jobLabel: cromwell-jvm

--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: workspacemanager
-version: 0.3.1
+version: 0.3.2
 
 description: Chart for Terra Workspace Manager
 type: application
@@ -14,3 +14,9 @@ keywords:
 sources:
 - https://github.com/broadinstitute/terra-helm/tree/master/charts
 - https://github.com/DataBiosphere/terra-workspace-manager
+
+dependencies:
+- name: postgres
+  condition: postgres.enabled
+  version: 0.1.0
+  repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -3,7 +3,11 @@ workspacemanager
 
 Chart for Terra Workspace Manager
 
+## Chart Requirements
 
+| Repository | Name | Version |
+|------------|------|---------|
+| https://broadinstitute.github.io/terra-helm/ | postgres | 0.1.0 |
 
 ## Chart Values
 
@@ -24,6 +28,8 @@ Chart for Terra Workspace Manager
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/terra-workspace-manager"` | Image repository |
 | imageConfig.tag | string | The chart's appVersion value will be used | Image tag. |
+| postgres.dbs | list | `["workspace","stairway"]` | (array(string)) List of databases to create.  |
+| postgres.enabled | bool | `false` | Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options. |
 | proxy.enabled | bool | `true` |  |
 | proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Proxy image repository |
 | proxy.image.version | string | `"bernick_tcell"` | Proxy image tag |

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: terra-workspace-manager-deployment
+  name: {{ .Chart.Name }}-deployment
   labels:
     {{ template "workspacemanager.labels" . }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: terra-workspace-manager
+      app: {{ .Chart.Name }}
   template:
     metadata:
-      name: terra-workspace-manager-service
+      name: {{ .Chart.Name }}-service
       labels:
-        app: terra-workspace-manager
+        app: {{ .Chart.Name }}
     spec:
-      serviceAccountName: terra-workspace-manager-service-sa
+      serviceAccountName: {{ .Chart.Name }}-service-sa
       containers:
-      - name: terra-workspace-manager
+      - name: {{ .Chart.Name }}
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
@@ -29,6 +29,7 @@ spec:
         - containerPort: 8080
         {{- end}}
         env:
+        {{- if not .Values.postgres.enabled }}
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
@@ -59,6 +60,22 @@ spec:
             secretKeyRef:
               name: workspace-stairway-db-creds
               key: db
+        {{- else }}
+        - name: DATABASE_HOSTNAME
+          value: {{ .Chart.Name }}-postgres-service.{{ .Release.Namespace }}.svc.cluster.local
+        - name: DATABASE_USER
+          value: postgres
+        - name: DATABASE_USER_PASSWORD
+          value: {{ .Values.postgres.password }}
+        - name: DATABASE_NAME
+          value: {{ index .Values.postgres.dbs 0 }}
+        - name: STAIRWAY_DATABASE_USER
+          value: postgres
+        - name: STAIRWAY_DATABASE_USER_PASSWORD
+          value: {{ .Values.postgres.password }}
+        - name: STAIRWAY_DATABASE_NAME
+          value: {{ index .Values.postgres.dbs 1 }}
+        {{- end }}
         - name: SAM_ADDRESS
           value: {{ .Values.samAddress }}
         - name: SERVICE_GOOGLE_PROJECT
@@ -71,6 +88,7 @@ spec:
           - name: cloud-trace-sa-creds
             mountPath: /secrets/cloudtrace
             readOnly: true
+      {{- if not .Values.postgres.enabled }}
       - name: cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.16
         env:
@@ -99,6 +117,7 @@ spec:
         - name: cloudsql-sa-creds
           mountPath: /secrets/cloudsql
           readOnly: true
+      {{- end }}
       {{- if .Values.proxy.enabled }}
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
@@ -125,16 +144,18 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
+        {{- if not .Values.postgres.enabled }}
         - name: cloudsql-sa-creds
           secret:
             secretName: workspace-sqlproxy-sa
+        {{- end }}
         - name: cloud-trace-sa-creds
           secret:
             secretName: workspace-cloud-trace-sa
         {{- if .Values.proxy.enabled }}
         - name: apache-httpd-proxy-config
           configMap:
-            name: terra-workspace-manager-proxy-configmap
+            name: {{ .Chart.Name }}-proxy-configmap
             items:
             - key: apache-httpd-proxy-config
               path: workspace-manager-proxy.conf
@@ -142,3 +163,13 @@ spec:
           secret:
             secretName: {{ .Chart.Name }}-cert
         {{- end }}
+---
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}-postgres-deployment
+  labels:
+    {{ template "workspacemanager.labels" . }}
+{{- include "postgres.deployment.tpl" . }}
+{{- end }}

--- a/charts/workspacemanager/templates/postgres-init-db-configmap.yaml
+++ b/charts/workspacemanager/templates/postgres-init-db-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-postgres-initdb
+  labels:
+    {{ template "workspacemanager.labels" . }}
+{{- template "postgres.init-db-configmap.tpl" . }}
+{{- end }}

--- a/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: terra-workspace-manager-proxy-configmap
+  name: {{ .Chart.Name }}-proxy-configmap
   labels:
     {{ template "workspacemanager.labels" . }}
 data:

--- a/charts/workspacemanager/templates/role.yaml
+++ b/charts/workspacemanager/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: terra-workspace-manager-service-role
+  name: {{ .Chart.Name }}-service-role
   labels:
     {{ template "workspacemanager.labels" . }}
 rules:

--- a/charts/workspacemanager/templates/rolebinding.yaml
+++ b/charts/workspacemanager/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: terra-workspace-manager-service-role-binding
+  name: {{ .Chart.Name }}-service-role-binding
   labels:
     {{ template "workspacemanager.labels" . }}
 roleRef:
   kind: Role
-  name: terra-workspace-manager-service-role
+  name: {{ .Chart.Name }}-service-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:
 - kind: ServiceAccount
-  name: terra-workspace-manager-service-sa
+  name: {{ .Chart.Name }}-service-sa

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.vault.enabled }}
+{{- if not .Values.postgres.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
@@ -70,6 +71,7 @@ spec:
       encoding: base64
       key: key
 ---
+{{- end }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:

--- a/charts/workspacemanager/templates/service-account.yaml
+++ b/charts/workspacemanager/templates/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: terra-workspace-manager-service-sa
+  name: {{ .Chart.Name }}-service-sa
   labels:
     {{ template "workspacemanager.labels" . }}

--- a/charts/workspacemanager/templates/service.yaml
+++ b/charts/workspacemanager/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: terra-workspace-manager-service
+  name: {{ .Chart.Name }}-service
   labels:
     {{ template "workspacemanager.labels" . }}
 spec:
@@ -12,7 +12,7 @@ spec:
   {{- template "workspacemanager.servicefirewall" . }}
   {{- end }}
   selector:
-    app: terra-workspace-manager
+    app: {{ .Chart.Name }}
   {{- if .Values.proxy.enabled }}
   ports:
   - name: http
@@ -26,3 +26,13 @@ spec:
   - name: http
     port: 8080
   {{- end}}
+{{- if .Values.postgres.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-postgres-service
+  labels:
+    {{ template "workspacemanager.labels" . }}
+{{- include "postgres.service.tpl" . }}
+{{- end }}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -94,3 +94,10 @@ proxy:
     # proxy.image.version -- Proxy image tag
     version: bernick_tcell
 
+postgres:
+  # postgres.enabled -- Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options.
+  enabled: false
+  # postgres.dbs -- (array(string)) List of databases to create. 
+  dbs:
+    - workspace
+    - stairway


### PR DESCRIPTION
This pr aims to enable jvm monitoring via prometheus for cromwell running in k8s. To do this we will run [prometheus-jmx exporter](https://github.com/prometheus/jmx_exporter) as a javaagent. It will expose a small http server which can be scraped for jvm metrics by a prometheus server.