### PR TITLE
Use the sqlproxy-sa secret for the Janitor deployments of the cloudsql proxy.

### DIFF
--- a/charts/crljanitor/Chart.yaml
+++ b/charts/crljanitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crljanitor
-version: 0.1.9
+version: 0.1.10
 
 description: Chart for Cloud Resource Manager Janitor
 type: application

--- a/charts/crljanitor/templates/secrets.yaml
+++ b/charts/crljanitor/templates/secrets.yaml
@@ -56,7 +56,6 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/crl_janitor/postgres/instance
       key: name
 ---
-# TODO: Create another service account in terraform for cloudsql proxy.
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
@@ -67,7 +66,7 @@ spec:
   name: crl-janitor-cloudsql-sa
   keysMap:
     service-account.json:
-      path: {{ .Values.vault.pathPrefix }}/crl_janitor/app-sa
+      path: {{ .Values.vault.pathPrefix }}/crl_janitor/sqlproxy-sa
       encoding: base64
       key: key
 ---


### PR DESCRIPTION
SA & vault secret added in https://github.com/broadinstitute/terraform-ap-deployments/pull/88.
Manually tested with skaffold, janitor able to start up.