### PR TITLE
[PF-9] Add configs in Janitor to support admin user authZ.

### DIFF
--- a/charts/crljanitor/Chart.yaml
+++ b/charts/crljanitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crljanitor
-version: 0.1.10
+version: 0.1.11
 
 description: Chart for Cloud Resource Manager Janitor
 type: application

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/app/service-account.json
         - name: CONFIG_BASED_AUTHZ_ENABLED
-          value: "{{ .Values.configBasedAuthZEnabled }}"
+          value: "{{ .Values.configBasedAuthzEnabled }}"
         - name: ADMIN_USER_LIST
           valueFrom:
             secretKeyRef:

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -73,6 +73,11 @@ spec:
               key: subscription
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/app/service-account.json
+        - name: ADMIN_USER_LIST
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-admin-user-list
+              key: admin-users
         # Environment variables for OpenCensus resource auto detection.
         - name: CONTAINER_NAME
           valueFrom:

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               key: subscription
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/app/service-account.json
+        - name: CONFIG_BASED_AUTHZ_ENABLED
+          value: "{{ .Values.configBasedAuthZEnabled }}"
         - name: ADMIN_USER_LIST
           valueFrom:
             secretKeyRef:

--- a/charts/crljanitor/templates/secrets.yaml
+++ b/charts/crljanitor/templates/secrets.yaml
@@ -99,4 +99,17 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/crl_janitor/app-sa
       encoding: base64
       key: key
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-crl-janitor-admin-user-list
+  labels:
+    {{ template "crljanitor.labels" . }}
+spec:
+  name: crl-janitor-admin-user-list
+  keysMap:
+    admin-users:
+      path: {{ .Values.vault.adminUserFilePath }}
+      key: admin-users
 {{ end }}

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -44,9 +44,9 @@ serviceAllowedAddresses: {}
 
 # trackResourcePubsubEnabled -- Whether to enable using pubsub to receive new tracked resources.
 trackResourcePubsubEnabled: true
-# configBasedAuthZEnabled -- Whether to use static file with admin users email for authorization.
+# configBasedAuthzEnabled -- Whether to use static file with admin users email for authorization.
 # TODO(PF-81): Switch to use SAM instead of config file for user authZ.
-configBasedAuthZEnabled: true
+configBasedAuthzEnabled: true
 # DNS/TLS Values
 domain:
   # domain.hostname -- Hostname of this deployment

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -29,6 +29,9 @@ vault:
   pathPrefix:
   # vault.configPathPrefix -- (string) Vault path prefix for configs. Required if vault.enabled.
   configPathPrefix:
+  # vault.adminUserFilePath -- (string) Vault path prefix for admin user list. Required if vault.enabled.
+  # Use the same users as admin for all env by default. Override if needed in helmfile repo.
+  adminUserFilePath: config/terra/crl-janitor/common/iam
 
 # serviceIP -- (string) External IP of the service. Required.
 serviceIP:

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -44,6 +44,9 @@ serviceAllowedAddresses: {}
 
 # trackResourcePubsubEnabled -- Whether to enable using pubsub to receive new tracked resources.
 trackResourcePubsubEnabled: true
+# configBasedAuthZEnabled -- Whether to use static file with admin users email for authorization.
+# TODO(PF-81): Switch to use SAM instead of config file for user authZ.
+configBasedAuthZEnabled: true
 # DNS/TLS Values
 domain:
   # domain.hostname -- Hostname of this deployment


### PR DESCRIPTION
Those two configs are:

1. CONFIG_BASED_AUTHZ_ENABLED - boolean value to control whether this feature is enabled
2. ADMIN_USER_LIST - List of Janitor admin users
