### PR TITLE
DDO-662 Add support for jvm monitoring via prometheus

### DIFF
--- a/charts/crljanitor/Chart.yaml
+++ b/charts/crljanitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: crljanitor
-version: 0.1.10
+version: 0.1.11
 
 description: Chart for Cloud Resource Manager Janitor
 type: application

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -73,6 +73,13 @@ spec:
               key: subscription
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/app/service-account.json
+        - name: CONFIG_BASED_AUTHZ_ENABLED
+          value: "{{ .Values.configBasedAuthzEnabled }}"
+        - name: ADMIN_USER_LIST
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-admin-user-list
+              key: admin-users
         # Environment variables for OpenCensus resource auto detection.
         - name: CONTAINER_NAME
           valueFrom:

--- a/charts/crljanitor/templates/secrets.yaml
+++ b/charts/crljanitor/templates/secrets.yaml
@@ -99,4 +99,17 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/crl_janitor/app-sa
       encoding: base64
       key: key
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-crl-janitor-admin-user-list
+  labels:
+    {{ template "crljanitor.labels" . }}
+spec:
+  name: crl-janitor-admin-user-list
+  keysMap:
+    admin-users:
+      path: {{ .Values.vault.adminUserFilePath }}
+      key: admin-users
 {{ end }}

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -29,6 +29,9 @@ vault:
   pathPrefix:
   # vault.configPathPrefix -- (string) Vault path prefix for configs. Required if vault.enabled.
   configPathPrefix:
+  # vault.adminUserFilePath -- (string) Vault path prefix for admin user list. Required if vault.enabled.
+  # Use the same users as admin for all env by default. Override if needed in helmfile repo.
+  adminUserFilePath: config/terra/crl-janitor/common/iam
 
 # serviceIP -- (string) External IP of the service. Required.
 serviceIP:
@@ -41,6 +44,9 @@ serviceAllowedAddresses: {}
 
 # trackResourcePubsubEnabled -- Whether to enable using pubsub to receive new tracked resources.
 trackResourcePubsubEnabled: true
+# configBasedAuthzEnabled -- Whether to use static file with admin users email for authorization.
+# TODO(PF-81): Switch to use SAM instead of config file for user authZ.
+configBasedAuthzEnabled: true
 # DNS/TLS Values
 domain:
   # domain.hostname -- Hostname of this deployment

--- a/charts/leonardo/Chart.yaml
+++ b/charts/leonardo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: leonardo
-version: 0.0.1
+version: 0.0.2
 type: application
 
 description: A Helm chart for Leonardo, Terra's Jupyter notebook integration service
@@ -13,3 +13,4 @@ keywords:
 sources:
 - https://github.com/broadinstitute/terra-helm/
 - https://github.com/DataBiosphere/leonardo
+- https://github.com/broadinstitute/resource-validator

--- a/charts/leonardo/Chart.yaml
+++ b/charts/leonardo/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: leonardo
+version: 0.0.1
+type: application
+
+description: A Helm chart for Leonardo, Terra's Jupyter notebook integration service
+
+keywords:
+- dsp
+- broadinstitute
+- leonardo
+
+sources:
+- https://github.com/broadinstitute/terra-helm/
+- https://github.com/DataBiosphere/leonardo

--- a/charts/leonardo/Chart.yaml
+++ b/charts/leonardo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: leonardo
-version: 0.0.2
+version: 0.0.3-RC1
 type: application
 
 description: A Helm chart for Leonardo, Terra's Jupyter notebook integration service

--- a/charts/leonardo/README.md
+++ b/charts/leonardo/README.md
@@ -1,0 +1,26 @@
+leonardo
+========
+A Helm chart for Leonardo, Terra's Jupyter notebook integration service
+
+Current chart version is `0.0.1`
+
+
+
+
+
+## Chart Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| deploymentDefaults.enabled | bool | `true` | Whether a declared deployment is enabled. If false, no resources will be created |
+| deploymentDefaults.expose | bool | `false` | Whether to create a Service + Ingress for this deployment |
+| deploymentDefaults.imageRepository | string | `"gcr.io/broad-dsp-gcr-public/leonardo"` | Image repo to pull Leonardo images from |
+| deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @default global.applicationVersion |
+| deploymentDefaults.name | Required | `nil` | A name for the deployment that will be substituted into resource definitions. Example: `"leonardo-backend"` |
+| deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
+| deploymentDefaults.serviceIP | string | `nil` | Static IP to use for the Service. (optional) |
+| deployments.standalone.expose | bool | `true` | Whether to expose the default standalone Leonardo deployment as a service |
+| deployments.standalone.name | string | `"leonardo"` | Name to use for the default standalone Leonardo deployment |
+| deployments.standalone.replicas | int | `1` | Number of replicas in the default standalone Leonardo deployment |
+| deployments.standalone.serviceName | string | `"leonardo"` | Name of the default standalone Leonardo service |
+| global.applicationVersion | string | `"latest"` | What version of the Leonardo application to deploy |

--- a/charts/leonardo/templates/_configMap.tpl
+++ b/charts/leonardo/templates/_configMap.tpl
@@ -1,0 +1,27 @@
+{{- /* Generate the data component of a Cromwell config map */ -}}
+{{- define "leonardo.configmap.data" -}}
+data:
+  logback.xml: |
+{{ include "leonardo.config.logback" . | indent 4 }}
+{{- end -}}
+
+{{- /* Generate a configmap for a Cromwell deployment */ -}}
+{{- define "leonardo.configmap" -}}
+{{- $settings := ._deploymentSettings -}}
+
+{{- /*
+  Render ConfigMap data, then checksum it, and store the checksum
+  in the deploymentOutputs dictionary so that it be included as an annotation
+  on the deployment's pod template. (see _deployment.tpl)
+
+  This is used to automatically restart Leonardo pods when the ConfigMap
+  changes.
+*/ -}}
+{{- $data := include "leonardo.configmap.data" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resource-validator-cm
+  labels: {}
+{{ $data }}
+{{ end -}}

--- a/charts/leonardo/templates/_labels.tpl
+++ b/charts/leonardo/templates/_labels.tpl
@@ -1,0 +1,14 @@
+{{- /*
+Create labels to use for resources in this chart
+
+See
+https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+*/ -}}
+{{- define "leonardo.labels" -}}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/component: leonardo
+app.kubernetes.io/part-of: terra
+{{- end -}}

--- a/charts/leonardo/templates/config/_logback.xml.tpl
+++ b/charts/leonardo/templates/config/_logback.xml.tpl
@@ -1,0 +1,16 @@
+{{- define "leonardo.config.logback" -}}
+<configuration>
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
+    <param name="Threshold" value="INFO"/>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+      <fieldNames>
+        <level>severity</level>
+      </fieldNames>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
+  </root>
+</configuration>
+{{ end -}}

--- a/charts/leonardo/templates/cronjob.yaml
+++ b/charts/leonardo/templates/cronjob.yaml
@@ -1,0 +1,102 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "{{ .Values.cronjob.name }}"
+  labels: {}
+spec:
+  schedule: "30 4 * * *"
+  startingDeadlineSeconds: 100
+  successfulJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: leonardo-sa
+          containers:
+          - image: "{{ .Values.cronjob.imageRepository }}:{{ .Values.cronjob.imageTag }}"
+            name: "{{ .Values.cronjob.name }}"
+            command: ["/bin/bash", "-c"]
+            # This is workaround for terminating sidecar container when the main container terminates
+            # See https://github.com/kubernetes/kubernetes/issues/25908#issuecomment-597799679
+            args:
+              - |
+                trap "touch /tmp/pod/main-terminated" EXIT
+                /opt/docker/bin/resource-validator --dryRun --all
+            env:
+            # Not really needed for cron job. Leaving it here for future reference when we create leonardo chart
+            - name: JAVA_OPTS
+              value: -Dlogback.configurationFile=file:/opt/docker/resource-validator-config/logback.xml
+            - name: LEONARDO_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: leonardo-db-creds
+                  key: username              
+            - name: LEONARDO_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: leonardo-db-creds
+                  key: password
+            - name: LEONARDO_PATH_TO_CREDENTIAL
+              value: /secrets/service-account.json
+            - name: REPORT_DESTINATION_BUCKET
+              value: "{{ .Values.cronjob.reportDestinationBucket }}"
+            volumeMounts:
+            - name: leonardo-sa-json-file
+              mountPath: /secrets
+              readOnly: true
+            - mountPath: /tmp/pod
+              name: tmp-pod
+            - mountPath: /opt/docker/resource-validator-config
+              name: logback-config
+          - name: leonardo-cloudsql-proxy
+            image: gcr.io/cloudsql-docker/gce-proxy:1.15
+            env:
+            - name: SQL_INSTANCE_PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: leonardo-db-creds
+                  key: instance_project
+            - name: SQL_INSTANCE_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: leonardo-db-creds
+                  key: instance_region
+            - name: SQL_INSTANCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: leonardo-db-creds
+                  key: instance_name
+            command: ["/bin/sh", "-c"]
+            # This is workaround for terminating sidecar container when the main container terminates
+            # See https://github.com/kubernetes/kubernetes/issues/25908#issuecomment-597799679
+            args:
+            - |
+              /cloud_sql_proxy --dir=/cloudsql -instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:0.0.0.0:3306 -credential_file=/secrets/service-account.json &
+              CHILD_PID=$!
+              (while true; do if [[ -f "/tmp/pod/main-terminated" ]]; then kill $CHILD_PID; echo "Killed $CHILD_PID as the main container terminated."; fi; sleep 1; done) &
+              wait $CHILD_PID
+              if [[ -f "/tmp/pod/main-terminated" ]]; then exit 0; echo "Job completed. Exiting..."; fi
+            volumeMounts:
+            - name: leonardo-sa-json-file
+              mountPath: /secrets
+              readOnly: true
+            - mountPath: /tmp/pod
+              name: tmp-pod
+              readOnly: true
+          volumes:
+          - name: leonardo-sa-json-file
+            secret:
+              secretName: leonardo-sa-json
+          # This is workaround for terminating sidecar container when the main container terminates
+          # See https://github.com/kubernetes/kubernetes/issues/25908#issuecomment-597799679
+          - name: tmp-pod
+            emptyDir: {}
+          # Not really needed for cron job. Leaving it here for future reference when we create leonardo chart
+          - name: logback-config
+            configMap:
+              name: resource-validator-cm
+---
+# Not really needed for cron job. Leaving it here for future reference when we create leonardo chart
+{{- $templateScope := $ | deepCopy -}}
+{{ template "leonardo.configmap" $templateScope }}

--- a/charts/leonardo/templates/cronjob.yaml
+++ b/charts/leonardo/templates/cronjob.yaml
@@ -98,5 +98,5 @@ spec:
               name: resource-validator-cm
 ---
 # Not really needed for cron job. Leaving it here for future reference when we create leonardo chart
-{{- $templateScope := $ | deepCopy -}}
+{{- $templateScope := $ | deepCopy }}
 {{ template "leonardo.configmap" $templateScope }}

--- a/charts/leonardo/templates/role.yaml
+++ b/charts/leonardo/templates/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leonardo-role
+  labels:
+{{ include "leonardo.labels" . | indent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - terra-default-psp

--- a/charts/leonardo/templates/roleBinding.yaml
+++ b/charts/leonardo/templates/roleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leonardo-sa-binding
+  labels:
+{{ include "leonardo.labels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: leonardo-sa
+roleRef:
+  kind: Role
+  name: leonardo-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/leonardo/templates/secrets.yaml
+++ b/charts/leonardo/templates/secrets.yaml
@@ -1,0 +1,35 @@
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-leonardo-mysql-db-creds
+  labels: {}
+spec:
+  name: leonardo-db-creds
+  keysMap:
+    username:
+      path: {{ .Values.vault.pathPrefix }}/secrets
+      key: db_user
+    password:
+      path: {{ .Values.vault.pathPrefix }}/secrets
+      key: db_password
+    instance_project:
+      path: {{ .Values.vault.pathPrefix }}/secrets
+      key: mysql_instance_project
+    instance_region:
+      path: {{ .Values.vault.pathPrefix }}/secrets
+      key: mysql_instance_region
+    instance_name:
+      path: {{ .Values.vault.pathPrefix }}/secrets
+      key: mysql_instance_name
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-leonardo-sa
+  labels: {}
+spec:
+  name: leonardo-sa-json
+  keysMap:
+    service-account.json:
+      path: {{ .Values.vault.pathPrefix }}/leonardo-sa.json
+      key: sa

--- a/charts/leonardo/templates/serviceAccount.yaml
+++ b/charts/leonardo/templates/serviceAccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: leonardo-sa
+  labels:
+{{ include "leonardo.labels" . | indent 4 }}

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -39,3 +39,14 @@ deployments:
     expose: true
     # deployments.standalone.serviceName -- Name of the default standalone Leonardo service
     serviceName: leonardo
+
+cronjob:
+  # deployments.standalone.name -- Name to use for the default standalone Leonardo deployment
+  name: leonardo-resource-validator-cronjob
+  imageRepository: us.gcr.io/broad-dsp-gcr-public/resource-validator
+  imageTag: 0.0.1-rc3
+  reportDestinationBucket:
+
+vault:
+  # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
+  pathPrefix:

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -1,0 +1,41 @@
+global:
+  # global.applicationVersion -- What version of the Leonardo application to deploy
+  applicationVersion: latest
+
+# Leonardo can be run in multiple deployments. This key contains default
+# settings for all deployments configured under the `deployments` key.
+deploymentDefaults:
+  # deploymentDefaults.enabled -- Whether a declared deployment is enabled. If false, no resources will be created
+  enabled: true
+  # deploymentDefaults.name -- (Required) A name for the deployment that will be substituted into resource definitions.
+  # Example: `"leonardo-backend"`
+  name: null
+  # deploymentDefaults.imageRepository -- Image repo to pull Leonardo images from
+  imageRepository: gcr.io/broad-dsp-gcr-public/leonardo
+  # deploymentDefaults.imageTag -- Image tag to be used when deploying Pods
+  # @default global.applicationVersion
+  imageTag: null
+  # deploymentDefaults.replicas -- Number of replicas for the deployment
+  replicas: 0
+  # deploymentDefaults.expose -- Whether to create a Service + Ingress for this deployment
+  expose: false
+  # deploymentDefaults.serviceIP -- Static IP to use for the Service. (optional)
+  serviceIP: null
+
+
+# A map of Leonardo deployments. In Terra's production environment,
+# Leonardo is deployed as two services (backend and frontend)
+# with different configurations.
+#
+# Here, we configure it as a single standalone deployment, similar to how a
+# developer might run Leonardo.
+deployments:
+  standalone:
+    # deployments.standalone.name -- Name to use for the default standalone Leonardo deployment
+    name: leonardo
+    # deployments.standalone.replicas -- Number of replicas in the default standalone Leonardo deployment
+    replicas: 1
+    # deployments.standalone.expose -- Whether to expose the default standalone Leonardo deployment as a service
+    expose: true
+    # deployments.standalone.serviceName -- Name of the default standalone Leonardo service
+    serviceName: leonardo

--- a/charts/ontology/Chart.yaml
+++ b/charts/ontology/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ontology
-version: 0.1.0
+version: 0.1.1
 type: application
 
 description: A Helm chart for DUOS Ontology, the DUOS Algorithmic Matching System

--- a/charts/ontology/templates/_prometheusJmx.yaml.tpl
+++ b/charts/ontology/templates/_prometheusJmx.yaml.tpl
@@ -1,0 +1,5 @@
+{{- /* Configuration for Prometheus JMX exporter javaagent */ -}}
+{{- define "ontology.config.prometheusJmx" -}}
+rules:
+- pattern: ".*"
+{{ end -}}

--- a/charts/ontology/templates/configmap.yaml
+++ b/charts/ontology/templates/configmap.yaml
@@ -10,4 +10,4 @@ data:
   site.conf: |
 {{ include "ontology.site.conf" . | indent 4 }}
   prometheusJmx.yaml: |
-{{ include "ontology.config.prometheusJmx". |  indent 4 }}
+{{ include "ontology.config.prometheusJmx" . |  indent 4 }}

--- a/charts/ontology/templates/configmap.yaml
+++ b/charts/ontology/templates/configmap.yaml
@@ -9,3 +9,5 @@ data:
 {{ include "ontology.config.yaml" . | indent 4 }}
   site.conf: |
 {{ include "ontology.site.conf" . | indent 4 }}
+  prometheusJmx.yaml: |
+{{ include "ontology.config.prometheusJmx". |  indent 4 }}

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
               mountPath: /etc/service-account.json
               subPath: service-account.json
               readOnly: true
+            - name: ontology-prometheus-jmx-jar
+              mountPath: /etc/prometheusjmx/prometheusjmx.jar
+              subPath: prometheusjmx.jar
           readinessProbe:
             httpGet:
               path: /status
@@ -92,3 +95,12 @@ spec:
                 path: private/server.key
               - key: ca-bundle.crt
                 path: certs/ca-bundle.crt
+        - name: ontology-prometheusjmx-jar
+          emptyDir: {}
+      initContainers:
+      - name: download-prometheus-jmx-jar
+        image: alpine:3.12.0
+        command: ["wget", "-O", "/ontology-prometheusjmx-jar/prometheusjmx.jar", "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar"]
+        volumeMounts:
+        - name: ontology-prometheujmx-jar
+          mountPath: /ontology-prometheusjmx-jar

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -51,8 +51,10 @@ spec:
           - -Dsentry.stacktrace.app.packages=org.broadinstitute
           - -Dsentry.dsn=$(SENTRY_DSN)
           # - -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
-          - -jar /opt/consent-ontology.jar 
-          - server /etc/ontology-cm/ontology.yaml
+          - -jar 
+          - /opt/consent-ontology.jar 
+          - server 
+          - /etc/ontology-cm/ontology.yaml
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -46,11 +46,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Chart.Name }}-secrets
                   key: dsn
+            -name: PROMETHEUS_ARGS
+              value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml"
           command: ["java"]
           args: 
           - -Dsentry.stacktrace.app.packages=org.broadinstitute
           - -Dsentry.dsn=$(SENTRY_DSN)
-          # - -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
+          - $(PROMETHEUS_ARGS)
           - -jar 
           - /opt/consent-ontology.jar 
           - server 

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -106,3 +106,4 @@ spec:
         volumeMounts:
         - name: ontology-prometheujmx-jar
           mountPath: /ontology-prometheusjmx-jar
+          

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -53,7 +53,6 @@ spec:
             -Dsentry.dsn=$(SENTRY_DSN)
             -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
             -jar /opt/consent-ontology.jar server /etc/ontology-cm/ontology.yaml
-          - '--'
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -44,11 +44,10 @@ spec:
                   name: {{ .Chart.Name }}-secrets
                   key: dsn
           command: ["java"]
-          args: ["-Dsentry.stacktrace.app.packages=org.broadinstitute", "-Dsentry.dsn=$(SENTRY_DSN)", "-jar", "/opt/consent-ontology.jar", "server", "/etc/ontology.yaml"]
+          args: ["-Dsentry.stacktrace.app.packages=org.broadinstitute", "-Dsentry.dsn=$(SENTRY_DSN)", "-jar", "/opt/consent-ontology.jar", "server", "/etc/ontology-cm/ontology.yaml", "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml"]
           volumeMounts:
             - name: configs
-              mountPath: /etc/ontology.yaml
-              subPath: ontology.yaml
+              mountPath: /etc/ontology-cm
               readOnly: true
             - name: app-secrets
               mountPath: /etc/service-account.json

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -46,8 +46,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Chart.Name }}-secrets
                   key: dsn
-          command: ["java"]
-          args: ["-Dsentry.stacktrace.app.packages=org.broadinstitute", "-Dsentry.dsn=$(SENTRY_DSN)", "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml", "-jar", "/opt/consent-ontology.jar", "server", "/etc/ontology-cm/ontology.yaml"]
+          command: ["/bin/bash"]
+          args: 
+          - '-c'
+          - >-
+            java
+            -Dsentry.stacktrace.app.packages=org.broadinstitute
+            -Dsentry.dsn=$(SENTRY_DSN)
+            -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
+            -jar /opt/consent-ontology.jar server /etc/ontology-cm/ontology.yaml"
+          - '--'
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -48,11 +48,11 @@ spec:
                   key: dsn
           command: ["java"]
           args: 
-          - >-
-            -Dsentry.stacktrace.app.packages=org.broadinstitute
-            -Dsentry.dsn=$(SENTRY_DSN)
-            -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
-            -jar /opt/consent-ontology.jar server /etc/ontology-cm/ontology.yaml
+          - -Dsentry.stacktrace.app.packages=org.broadinstitute
+          - -Dsentry.dsn=$(SENTRY_DSN)
+          # - -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
+          - -jar /opt/consent-ontology.jar 
+          - server /etc/ontology-cm/ontology.yaml
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -54,7 +54,8 @@ spec:
             -Dsentry.stacktrace.app.packages=org.broadinstitute
             -Dsentry.dsn=$(SENTRY_DSN)
             -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
-            -jar /opt/consent-ontology.jar server /etc/ontology-cm/ontology.yaml"
+            -jar /opt/consent-ontology.jar 
+            server /etc/ontology-cm/ontology.yaml"
           - '--'
           volumeMounts:
             - name: configs

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: /etc/service-account.json
               subPath: service-account.json
               readOnly: true
-            - name: ontology-prometheus-jmx-jar
+            - name: ontology-prometheusjmx-jar
               mountPath: /etc/prometheusjmx/prometheusjmx.jar
               subPath: prometheusjmx.jar
           readinessProbe:
@@ -104,6 +104,5 @@ spec:
         image: alpine:3.12.0
         command: ["wget", "-O", "/ontology-prometheusjmx-jar/prometheusjmx.jar", "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar"]
         volumeMounts:
-        - name: ontology-prometheujmx-jar
+        - name: ontology-prometheusjmx-jar
           mountPath: /ontology-prometheusjmx-jar
-          

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
                   name: {{ .Chart.Name }}-secrets
                   key: dsn
           command: ["java"]
-          args: ["-Dsentry.stacktrace.app.packages=org.broadinstitute", "-Dsentry.dsn=$(SENTRY_DSN)", "-jar", "/opt/consent-ontology.jar", "server", "/etc/ontology-cm/ontology.yaml", "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml"]
+          args: ["-Dsentry.stacktrace.app.packages=org.broadinstitute", "-Dsentry.dsn=$(SENTRY_DSN)", "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml", "-jar", "/opt/consent-ontology.jar", "server", "/etc/ontology-cm/ontology.yaml"]
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -54,8 +54,7 @@ spec:
             -Dsentry.stacktrace.app.packages=org.broadinstitute
             -Dsentry.dsn=$(SENTRY_DSN)
             -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml
-            -jar /opt/consent-ontology.jar 
-            server /etc/ontology-cm/ontology.yaml"
+            -jar /opt/consent-ontology.jar server /etc/ontology-cm/ontology.yaml
           - '--'
           volumeMounts:
             - name: configs

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -46,11 +46,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Chart.Name }}-secrets
                   key: dsn
-          command: ["/bin/bash"]
+          command: ["java"]
           args: 
-          - '-c'
           - >-
-            java
             -Dsentry.stacktrace.app.packages=org.broadinstitute
             -Dsentry.dsn=$(SENTRY_DSN)
             -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml

--- a/charts/ontology/templates/podMonitor.yaml
+++ b/charts/ontology/templates/podMonitor.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ontology-jvm-monitor
+  labels: 
+{{ include "ontology.labels" . | indent 4 }}
+spec:
+  jobLabel: ontology-jvm
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ontology
+  podMetricsEndpoints:
+    - port: metrics

--- a/charts/terra-argocd-env/Chart.yaml
+++ b/charts/terra-argocd-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terra-argocd-env
 description: A Helm chart for generating environment-wide ArgoCD resources for Terra environments
 type: application
-version: 0.0.8
+version: 0.0.9
 dependencies:
 - name: terra-argocd-templates
   version: 0.0.4

--- a/charts/terra-argocd-env/templates/project.yaml
+++ b/charts/terra-argocd-env/templates/project.yaml
@@ -26,4 +26,15 @@ spec:
     - local-notsuitable
     - broadinstitute:DSDE Engineering
 {{- end }}
+  - description: Service account permissions used by CI/CD tools to deploy applications in {{ $projectName }}
+    name: deploy
+    policies:
+    - p, proj:{{ $projectName }}:deploy, applications, sync, {{ $projectName }}/*, allow
+    - p, proj:{{ $projectName }}:deploy, applications, action/apps/Deployment/restart, {{ $projectName }}/*, allow
+    groups:
+{{- if .requireSuitable }}
+    - fcprod-jenkins
+{{- else }}
+    - fc-jenkins
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
This pr enables jvm profiling for k8s deployents of the ontology service. This is accomplished by running the [prometheus-jmx-exporter](https://github.com/prometheus/jmx_exporter) as a javaagent. This will expose detailed jvm profiling metrics which will then be sent to stackdriver by the prometheus deployment in the terra clusters.