### PR TITLE
DDO-694 Migrate Jenkins CI/CD permissions out of ArgoCD Helm chart values and into deploy project settings

### DIFF
--- a/charts/terra-argocd-env/Chart.yaml
+++ b/charts/terra-argocd-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terra-argocd-env
 description: A Helm chart for generating environment-wide ArgoCD resources for Terra environments
 type: application
-version: 0.0.8
+version: 0.0.9
 dependencies:
 - name: terra-argocd-templates
   version: 0.0.4

--- a/charts/terra-argocd-env/templates/project.yaml
+++ b/charts/terra-argocd-env/templates/project.yaml
@@ -26,4 +26,15 @@ spec:
     - local-notsuitable
     - broadinstitute:DSDE Engineering
 {{- end }}
+  - description: Service account permissions used by CI/CD tools to deploy applications in {{ $projectName }}
+    name: deploy
+    policies:
+    - p, proj:{{ $projectName }}:deploy, applications, sync, {{ $projectName }}/*, allow
+    - p, proj:{{ $projectName }}:deploy, applications, action/apps/Deployment/restart, {{ $projectName }}/*, allow
+    groups:
+{{- if .requireSuitable }}
+    - fcprod-jenkins
+{{- else }}
+    - fc-jenkins
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
This allows to adjust which service account can trigger deploys based on the requiresSuitability value.