### PR TITLE
[AS-484] Add tcell, LDAP support, ID whitelisting to WM proxy

### DIFF
--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: workspacemanager
-version: 0.3.3
+version: 0.4.0
 
 description: Chart for Terra Workspace Manager
 type: application

--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -44,3 +44,52 @@ LDAP base domain template
 {{- define "workspacemanager.ldapbasedomain" -}}
   dc=dsde-{{ .Values.global.terraEnv }},dc=broadinstitute,dc=org
 {{- end }}
+
+{{/*
+AoU Preprod Conditional
+*/}}
+{{- define "workspacemanager.aoupreprodconditional" -}}
+  ((.email|endswith("@preprod.researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PREPROD_WHITELIST}" | split(",") | any(contains($idkey))))
+{{- end }}
+{{/*
+AoU Perf Conditional
+*/}}
+{{- define "workspacemanager.aouperfconditional" -}}
+  ((.email|endswith("@perf.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PERF_WHITELIST}" | split(",") | any(contains($idkey))))
+{{- end }}
+{{/*
+AoU Prod Conditional
+*/}}
+{{- define "workspacemanager.aouprodconditional" -}}
+  ((.email|endswith("@researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PROD_WHITELIST}" | split(",") | any(contains($idkey))))
+{{- end }}
+{{/*
+AoU Dev Conditional
+*/}}
+{{- define "workspacemanager.aoudevconditional" -}}
+  ((.email|endswith("@fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_DEV_WHITELIST}" | split(",") | any(contains($idkey))))
+{{- end }}
+{{/*
+AoU Stable Conditional
+*/}}
+{{- define "workspacemanager.aoustableconditional" -}}
+  ((.email|endswith("@stable.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STABLE_WHITELIST}" | split(",") | any(contains($idkey))))
+{{- end }}
+{{/*
+AoU Staging Conditional
+*/}}
+{{- define "workspacemanager.aoustagingconditional" -}}
+  ((.email|endswith("@staging.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STAGING_WHITELIST}" | split(",") | any(contains($idkey))))
+{{- end }}
+{{/*
+Terra ID Whitelist
+*/}}
+{{- define "workspacemanager.terraidwhitelist" -}}
+  (.audience | split(".")[0] as $idkey | "${TERRA_ID_WHITELIST}" | split(",") | any(contains($idkey)))
+{{- end }}
+{{/*
+Terra Conditional
+*/}}
+{{- define "workspacemanager.terraconditional" -}}
+  (((.email|endswith("@researchallofus.org")|not) and (.email|endswith("@preprod.researchallofus.org")|not) and (.email|endswith("@staging.fake-research-aou.org")|not) and (.email|endswith("@stable.fake-research-aou.org")|not) and (.email|endswith("@perf.fake-research-aou.org")|not) and (.email|endswith("@fake-research-aou.org")|not)) and {{ template "workspacemanager.terraidwhitelist" . }})
+{{- end }}

--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -37,3 +37,18 @@ Service firewall
   {{- end -}}
   {{- end -}}
 {{- end }}
+
+{{/*
+rawTerraAudiences
+*/}}
+{{- define "workspacemanager.rawTerraAudiences" -}}
+{{- range $index, $element := "a,a,a,a,a,a" }} or (.audience|startswith("$element")) {{- end -}}
+{{- end }}
+
+{{/*
+rawTerraConditional
+*/}}
+{{- define "workspacemanager.rawTerraConditional" -}}
+  (((.email|endswith("@researchallofus.org")|not) and (.email|endswith("@preprod.researchallofus.org")|not) and (.email|endswith("@staging.fake-research-aou.org")|not) and (.email|endswith("@stable.fake-research-aou.org")|not) and (.email|endswith("@perf.fake-research-aou.org")|not) and (.email|endswith("@fake-research-aou.org")|not)) and (${TERRA_OIDC_CLIENT_IDS}|endswith("fakeval")|not))
+{{- end }}
+

--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -39,16 +39,8 @@ Service firewall
 {{- end }}
 
 {{/*
-rawTerraAudiences
+LDAP base domain template
 */}}
-{{- define "workspacemanager.rawTerraAudiences" -}}
-{{- range $index, $element := "a,a,a,a,a,a" }} or (.audience|startswith("$element")) {{- end -}}
+{{- define "workspacemanager.ldapbasedomain" -}}
+  dc=dsde-{{ .Values.global.terraEnv }},dc=broadinstitute,dc=org
 {{- end }}
-
-{{/*
-rawTerraConditional
-*/}}
-{{- define "workspacemanager.rawTerraConditional" -}}
-  (((.email|endswith("@researchallofus.org")|not) and (.email|endswith("@preprod.researchallofus.org")|not) and (.email|endswith("@staging.fake-research-aou.org")|not) and (.email|endswith("@stable.fake-research-aou.org")|not) and (.email|endswith("@perf.fake-research-aou.org")|not) and (.email|endswith("@fake-research-aou.org")|not)) and (${TERRA_OIDC_CLIENT_IDS}|endswith("fakeval")|not))
-{{- end }}
-

--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -39,13 +39,6 @@ Service firewall
 {{- end }}
 
 {{/*
-LDAP base domain template
-*/}}
-{{- define "workspacemanager.ldapbasedomain" -}}
-  dc=dsde-{{ .Values.global.terraEnv }},dc=broadinstitute,dc=org
-{{- end }}
-
-{{/*
 AoU Preprod Conditional
 */}}
 {{- define "workspacemanager.aoupreprodconditional" -}}

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -242,11 +242,11 @@ spec:
             secretName: {{ .Chart.Name }}-cert
         {{- if .Values.proxy.tcell.enabled }}
         - name: tcell-config
-        configMap:
-          name: {{ .Chart.Name }}-tcell-configmap
-          items:
-          - key: tcell-config
-            path: tcell-config.conf
+          configMap:
+            name: {{ .Chart.Name }}-tcell-configmap
+            items:
+            - key: tcell-config
+              path: tcell-config.conf
         {{- end }}
         {{- end }}
 ---

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -126,11 +126,37 @@ spec:
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
         env:
-        - name: TERRA_OIDC_CLIENT_IDS
+        {{- if .Values.proxy.ldap.enabled }}
+        - name: LDAP_BASE_DOMAIN
+          value: {{ template "workspacemanager.ldapbasedomain" . }}
+        - name: AUTH_LDAP_URL2
+          value: 'AuthLDAPURL "ldaps://opendj.dsde-{{ .Values.global.terraEnv }}.broadinstitute.org/ou=people,{{ template "workspacemanager.ldapbasedomain" . }}?googleSubjectId?sub?(objectClass=*)"'
+        - name: AUTH_LDAP_GROUP_ATTR2
+          value: 'AuthLDAPGroupAttribute member'
+        - name: AUTH_LDAP_BIND_DN2
+          value: 'AuthLDAPBindDN "cn=proxy-ro,ou=people,{{ template "workspacemanager.ldapbasedomain" . }}"'
+        - name: AUTH_REQUIRE2
+          value: 'Require ldap-group cn=enabled-users,ou=groups,{{ template "workspacemanager.ldapbasedomain" . }}'
+        - name: PROXY_LDAP_BIND_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: proxy-oauth-client-ids
-              key: terra
+              name: proxy-ldap-bind-password
+              key: password
+        {{- end }}
+        {{- if .Values.proxy.tcell.enabled }}
+        - name: TCELL_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: proxy-tcell-secrets
+              key: app-id
+        - name: TCELL_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: proxy-tcell-secrets
+              key: api-key
+        - name: ENABLE_TCELL
+          value: 'yes'
+        {{- end }}
         ports:
         - containerPort: 443
         - containerPort: 80
@@ -152,6 +178,11 @@ spec:
           name: cert
           readOnly: true
         {{- end }}
+        {{- if .Values.proxy.tcell.enabled }}
+        - mountPath: /etc/apache2/tcell_agent.config
+          name: tcell-config
+          subPath: tcell-config.conf
+        {{- end }}
       {{- end }}
       volumes:
         {{- if not .Values.postgres.enabled }}
@@ -172,6 +203,15 @@ spec:
         - name: cert
           secret:
             secretName: {{ .Chart.Name }}-cert
+        {{- if .Values.proxy.tcell.enabled }}
+        - name: tcell-config
+        configMap:
+          name: {{ .Chart.Name }}-tcell-configmap
+          items:
+          - key: tcell-config
+            path: tcell-config.conf
+        {{- end }}
+        {{- end }}
         {{- end }}
 ---
 {{- if .Values.postgres.enabled }}

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -165,15 +165,15 @@ spec:
           value: sub
         {{- if .Values.proxy.ldap.enabled }}
         - name: LDAP_BASE_DOMAIN
-          value: {{ template "workspacemanager.ldapbasedomain" . }}
+          value: {{ .Values.proxy.ldap.baseDomain }}
         - name: AUTH_LDAP_URL2
-          value: 'AuthLDAPURL "ldaps://opendj.dsde-{{ .Values.global.terraEnv }}.broadinstitute.org/ou=people,{{ template "workspacemanager.ldapbasedomain" . }}?googleSubjectId?sub?(objectClass=*)"'
+          value: 'AuthLDAPURL "ldaps://{{ .Values.proxy.ldap.url }}.broadinstitute.org/ou=people,{{ .Values.proxy.ldap.baseDomain }}?googleSubjectId?sub?(objectClass=*)"'
         - name: AUTH_LDAP_GROUP_ATTR2
           value: 'AuthLDAPGroupAttribute member'
         - name: AUTH_LDAP_BIND_DN2
-          value: 'AuthLDAPBindDN "cn=proxy-ro,ou=people,{{ template "workspacemanager.ldapbasedomain" . }}"'
+          value: 'AuthLDAPBindDN "cn=proxy-ro,ou=people,{{ .Values.proxy.ldap.baseDomain }}"'
         - name: AUTH_REQUIRE2
-          value: 'Require ldap-group cn=enabled-users,ou=groups,{{ template "workspacemanager.ldapbasedomain" . }}'
+          value: 'Require ldap-group cn=enabled-users,ou=groups,{{ .Values.proxy.ldap.baseDomain }}'
         - name: PROXY_LDAP_BIND_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -249,7 +249,6 @@ spec:
             path: tcell-config.conf
         {{- end }}
         {{- end }}
-        {{- end }}
 ---
 {{- if .Values.postgres.enabled }}
 apiVersion: apps/v1

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -167,7 +167,7 @@ spec:
         - name: LDAP_BASE_DOMAIN
           value: {{ .Values.proxy.ldap.baseDomain }}
         - name: AUTH_LDAP_URL2
-          value: 'AuthLDAPURL "ldaps://{{ .Values.proxy.ldap.url }}.broadinstitute.org/ou=people,{{ .Values.proxy.ldap.baseDomain }}?googleSubjectId?sub?(objectClass=*)"'
+          value: 'AuthLDAPURL "ldaps://{{ .Values.proxy.ldap.url }}/ou=people,{{ .Values.proxy.ldap.baseDomain }}?googleSubjectId?sub?(objectClass=*)"'
         - name: AUTH_LDAP_GROUP_ATTR2
           value: 'AuthLDAPGroupAttribute member'
         - name: AUTH_LDAP_BIND_DN2

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -126,6 +126,43 @@ spec:
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
         env:
+        - name: AOU_PREPROD_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: aou-preprod
+        - name: AOU_PERF_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: aou-perf
+        - name: AOU_PROD_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: aou-prod
+        - name: AOU_DEV_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: aou-dev
+        - name: AOU_STABLE_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: aou-stable
+        - name: AOU_STAGING_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: aou-staging
+        - name: TERRA_ID_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-whitelist
+              key: terra
+        - name: REMOTE_USER_CLAIM
+          value: sub
         {{- if .Values.proxy.ldap.enabled }}
         - name: LDAP_BASE_DOMAIN
           value: {{ template "workspacemanager.ldapbasedomain" . }}

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -125,6 +125,12 @@ spec:
       {{- if .Values.proxy.enabled }}
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
+        env:
+        - name: TERRA_OIDC_CLIENT_IDS
+          valueFrom:
+            secretKeyRef:
+              name: proxy-oauth-client-ids
+              key: terra
         ports:
         - containerPort: 443
         - containerPort: 80

--- a/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
@@ -22,9 +22,19 @@ data:
 
     Header unset X-Frame-Options
     Header always set X-Frame-Options SAMEORIGIN
+    Header unset X-XSS-Protection
+    Header always set X-XSS-Protection "1; mode=block"
+    Header unset X-Content-Type-Options
+    Header always set X-Content-Type-Options: nosniff
+    Header unset Strict-Transport-Security
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
 
     ProxyTimeout ${PROXY_TIMEOUT}
     OIDCOAuthTokenIntrospectionInterval 60
+    LDAPCacheTTL ${LDAP_CACHE_TTL}
+    LDAPRetries 5
+    LDAPRetryDelay 1
+    LDAPConnectionPoolTTL 30
 
     <VirtualHost _default_:${HTTPD_PORT}>
       ErrorLog /dev/stdout
@@ -63,6 +73,15 @@ data:
         </Location>
 
         <Location ${PROXY_PATH2}>
+          Header unset Access-Control-Allow-Origin
+          Header always set Access-Control-Allow-Origin "*"
+          Header unset Access-Control-Allow-Headers
+          Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin,x-app-id"
+          Header unset Access-Control-Allow-Methods
+          Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+          Header unset Access-Control-Max-Age
+          Header always set Access-Control-Max-Age 1728000
+
           RewriteEngine On
           RewriteCond %{REQUEST_METHOD} OPTIONS
           RewriteRule ^(.*)$ $1 [R=204,L]
@@ -72,7 +91,21 @@ data:
           </Limit>
 
           ${AUTH_TYPE2}
-          ${AUTH_REQUIRE2}
+          ${AUTH_LDAP_URL2}
+          ${AUTH_LDAP_GROUP_ATTR2}
+          ${AUTH_LDAP_BIND_DN2}
+          ${AUTH_LDAP_BIND_PASSWORD2}
+
+          AuthLDAPMaxSubGroupDepth 0
+
+          <RequireAll>
+            <RequireAll>
+              ${AUTH_REQUIRE2}
+            </RequireAll>
+            <RequireAny>
+             Require claims_expr '((.email|endswith("@test.firecloud.org")) and (.email|endswith("${TERRA_OIDC_CLIENT_IDS}")|not))'
+            </RequireAny>
+          </RequireAll>
 
           ProxyPass http://localhost:8080/api
           ProxyPassReverse http://localhost:8080/api
@@ -80,4 +113,4 @@ data:
           AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript
         </Location>
     </VirtualHost>
-{{- end }}
+  {{- end }}

--- a/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
@@ -94,18 +94,9 @@ data:
           ${AUTH_LDAP_URL2}
           ${AUTH_LDAP_GROUP_ATTR2}
           ${AUTH_LDAP_BIND_DN2}
-          ${AUTH_LDAP_BIND_PASSWORD2}
-
+          AuthLDAPBindPassword ${PROXY_LDAP_BIND_PASSWORD}
+          ${AUTH_REQUIRE2}
           AuthLDAPMaxSubGroupDepth 0
-
-          <RequireAll>
-            <RequireAll>
-              ${AUTH_REQUIRE2}
-            </RequireAll>
-            <RequireAny>
-             Require claims_expr '((.email|endswith("@test.firecloud.org")) and (.email|endswith("${TERRA_OIDC_CLIENT_IDS}")|not))'
-            </RequireAny>
-          </RequireAll>
 
           ProxyPass http://localhost:8080/api
           ProxyPassReverse http://localhost:8080/api

--- a/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
@@ -95,8 +95,16 @@ data:
           ${AUTH_LDAP_GROUP_ATTR2}
           ${AUTH_LDAP_BIND_DN2}
           AuthLDAPBindPassword ${PROXY_LDAP_BIND_PASSWORD}
-          ${AUTH_REQUIRE2}
           AuthLDAPMaxSubGroupDepth 0
+
+          <RequireAll>
+            <RequireAll>
+              ${AUTH_REQUIRE2}
+            </RequireAll>
+            <RequireAny>
+              Require claims_expr '((.email|endswith(".gserviceaccount.com")) or {{ template "workspacemanager.aoupreprodconditional" . }} or {{ template "workspacemanager.aouperfconditional" . }} or {{ template "workspacemanager.aouprodconditional" . }} or {{ template "workspacemanager.aoudevconditional" . }} or {{ template "workspacemanager.aoustableconditional" . }} or {{ template "workspacemanager.aoustagingconditional" . }} or {{ template "workspacemanager.terraconditional" . }})'
+            </RequireAny>
+          </RequireAll>
 
           ProxyPass http://localhost:8080/api
           ProxyPassReverse http://localhost:8080/api

--- a/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/proxy-apache-httpd-configmap.yaml
@@ -112,4 +112,4 @@ data:
           AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript
         </Location>
     </VirtualHost>
-  {{- end }}
+{{- end }}

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -71,7 +71,40 @@ spec:
       encoding: base64
       key: key
 ---
-  {{- end }}
+{{- end }}
+{{- if .Values.proxy.enabled }}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-proxy-ldap-bind-password
+  labels:
+    {{ template "workspacemanager.labels" . }}
+spec:
+  name: proxy-ldap-bind-password
+  keysMap:
+    password:
+      path: {{ .Values.proxy.ldap.passwordVaultPath }}
+      key: proxy_ldap_bind_password
+---
+{{- if .Values.proxy.tcell.enabled }}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-proxy-tcell-secrets
+  labels:
+    {{ template "workspacemanager.labels" . }}
+spec:
+  name: proxy-tcell-secrets
+  keysMap:
+    app-id:
+      path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_app_id
+      key: tcell_app_id
+    api-key:
+      path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_api_key
+      key: tcell_api_key
+---
+{{- end }}
+{{- end }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
@@ -85,18 +118,4 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/workspace/cloud-trace-sa
       encoding: base64
       key: key
----
-apiVersion: secrets-manager.tuenti.io/v1alpha1
-kind: SecretDefinition
-metadata:
-  name: secretdefinition-proxy-oauth-client-ids-second-try
-  labels:
-    {{ template "workspacemanager.labels" . }}
-spec:
-  name: proxy-oauth-client-ids-second-try
-  keysMap:
-    terra:
-      path: secret/dsde/firecloud/common/non_aou_oauth_client_ids
-      key: client_ids
----
 {{ end }}

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.vault.enabled }}
-  {{- if not .Values.postgres.enabled }}
+{{- if not .Values.postgres.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -72,7 +72,7 @@ spec:
       key: key
 ---
 {{- end }}
-{{- if .Values.proxy.enabled }}
+{{- if .Values.proxy.ldap.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -72,6 +72,38 @@ spec:
       key: key
 ---
 {{- end }}
+{{- if .Values.proxy.enabled }}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-proxy-oauth-whitelist
+  labels:
+    {{ template "workspacemanager.labels" . }}
+spec:
+  name: proxy-oauth-whitelist
+  keysMap:
+    aou-preprod:
+      path: secret/dsde/firecloud/common/preprod_researchallofus_oauth_client_ids
+      key: client_ids.list
+    aou-perf:
+      path: secret/dsde/firecloud/common/perf_fake_research_aou_oauth_client_ids
+      key: client_ids.list
+    aou-prod:
+      path: secret/dsde/firecloud/common/research_aou_oauth_client_ids
+      key: client_ids.list
+    aou-dev:
+      path: secret/dsde/firecloud/common/fake_research_aou_oauth_client_ids
+      key: client_ids.list
+    aou-stable:
+      path: secret/dsde/firecloud/common/stable_fake_research_aou_oauth_client_ids
+      key: client_ids.list
+    aou-staging:
+      path: secret/dsde/firecloud/common/staging_fake_research_aou_oauth_client_ids
+      key: client_ids.list
+    terra:
+      path: secret/dsde/firecloud/common/non_aou_oauth_client_ids
+      key: client_ids.list
+---
 {{- if .Values.proxy.ldap.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
@@ -86,6 +118,7 @@ spec:
       path: {{ .Values.proxy.ldap.passwordVaultPath }}
       key: proxy_ldap_bind_password
 ---
+{{- end }}
 {{- if .Values.proxy.tcell.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.vault.enabled }}
-{{- if not .Values.postgres.enabled }}
+  {{- if not .Values.postgres.enabled }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
@@ -71,7 +71,7 @@ spec:
       encoding: base64
       key: key
 ---
-{{- end }}
+  {{- end }}
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
@@ -85,4 +85,18 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/workspace/cloud-trace-sa
       encoding: base64
       key: key
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-proxy-oauth-client-ids-second-try
+  labels:
+    {{ template "workspacemanager.labels" . }}
+spec:
+  name: proxy-oauth-client-ids-second-try
+  keysMap:
+    terra:
+      path: secret/dsde/firecloud/common/non_aou_oauth_client_ids
+      key: client_ids
+---
 {{ end }}

--- a/charts/workspacemanager/templates/tcell_configmap.yaml
+++ b/charts/workspacemanager/templates/tcell_configmap.yaml
@@ -16,7 +16,7 @@ data:
           "tcell_api_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
           "tcell_input_url": "https://us.input.tcell.insight.rapid7.com/api/v1",
           "js_agent_api_base_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
-          "host_identifier":"workspace-manager-{{ .Values.global.terraEnv }}",
+          "host_identifier":"{{ .Values.proxy.tcell.hostIdentifier }}",
           "logging_options":{"enabled":true,"level":"INFO","filename":"mytcell.log"}
         }
       ]

--- a/charts/workspacemanager/templates/tcell_configmap.yaml
+++ b/charts/workspacemanager/templates/tcell_configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.proxy.tcell.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-tcell-configmap
+  labels:
+    {{ template "workspacemanager.labels" . }}
+data:
+  tcell-config: |-
+    {
+      "version": 1,
+      "applications": [
+        {
+          "app_id": "$(TCELL_APP_ID)",
+          "api_key": "$(TCELL_API_KEY)",
+          "tcell_api_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
+          "tcell_input_url": "https://us.input.tcell.insight.rapid7.com/api/v1",
+          "js_agent_api_base_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
+          "host_identifier":"workspace-manager-{{ .Values.global.terraEnv }}",
+          "logging_options":{"enabled":true,"level":"INFO","filename":"mytcell.log"}
+        }
+      ]
+    }
+{{- end}}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -98,11 +98,17 @@ proxy:
     enabled: true
     # proxy.tcell.vaultPrefix -- Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true.
     vaultPrefix:
+    # proxy.tcell.hostIdentifier -- Identifier used for logging to TCell. Required if proxy.tcell.enabled is true
+    hostIdentifier:
   ldap:
     # proxy.ldap.enabled -- Enables LDAP authorization checks in the proxy
     enabled: true
     # proxy.ldap.passwordVaultPath -- Vault path for LDAP binding password. Required if proxy.ldap.enabled is true
     passwordVaultPath:
+    # proxy.ldap.url -- URL of LDAP server to use for auth. Required if proxy.ldap.enabled is true
+    url:
+    # proxy.ldap.baseDomain -- Base domain for LDAP. Required if proxy.ldap.enabled is true
+    baseDomain:
 
 # initDB -- Whether the WSM and Stairway DBs should be initialized on startup. Used for preview environments.
 initDB: false

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -93,6 +93,16 @@ proxy:
     repository: broadinstitute/openidc-proxy
     # proxy.image.version -- Proxy image tag
     version: bernick_tcell
+  tcell:
+    # proxy.tcell.enabled -- Enables TCell
+    enabled: true
+    # proxy.tcell.vaultPrefix -- Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true.
+    vaultPrefix:
+  ldap:
+    # proxy.ldap.enabled -- Enables LDAP authorization checks in the proxy
+    enabled: true
+    # proxy.ldap.passwordVaultPath -- Vault path for LDAP binding password. Required if proxy.ldap.enabled is true
+    passwordVaultPath:
 
 # initDB -- Whether the WSM and Stairway DBs should be initialized on startup. Used for preview environments.
 initDB: false


### PR DESCRIPTION
See the [wiki page](https://broadinstitute.atlassian.net/wiki/spaces/GAWB/pages/1589608449/Apache+Proxy) for more background on the proxy.

This adds the configuration and settings to use TCell in Workspace Manager's proxy, to perform LDAP lookups for authorization, and to check OIDC audience whitelists.

Based heavily on existing ctmpl proxy configurations: see [Rawls configuration](https://github.com/broadinstitute/firecloud-develop/blob/dev/base-configs/rawls/site.conf.ctmpl) with [values file](https://github.com/broadinstitute/firecloud-develop/blob/dev/run-context/live/configs/rawls/proxy-compose.yaml.ctmpl).

Corresponding changes for values files are in [this helmfile PR](https://github.com/broadinstitute/terra-helmfile/pull/182)

