### PR TITLE
DDO-363 Add BackendConfig to ArgoCD namespace

### DIFF
--- a/charts/ap-argocd-preinstall/Chart.yaml
+++ b/charts/ap-argocd-preinstall/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ap-argocd-preinstall
-version: 0.0.2
+version: 0.1.0
 
 description: Helm Chart with extra resources for the ap-devops argocd instance
 type: application

--- a/charts/ap-argocd-preinstall/templates/backendconfig.yaml
+++ b/charts/ap-argocd-preinstall/templates/backendconfig.yaml
@@ -6,7 +6,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ .Chart.Name }}
-  name: {{ .Release.Namespace }}-backendconfig
+  name: argocd-backendconfig
 spec:
   securityPolicy:
     name: "argocd-policy" # Configure ArgoCD ingress to use CloudArmor policy

--- a/charts/ap-argocd-preinstall/templates/backendconfig.yaml
+++ b/charts/ap-argocd-preinstall/templates/backendconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  name: {{ .Release.Namespace }}-backendconfig
+spec:
+  securityPolicy:
+    name: "argocd-policy" # Configure ArgoCD ingress to use CloudArmor policy

--- a/charts/ap-argocd-preinstall/templates/backendconfig.yaml
+++ b/charts/ap-argocd-preinstall/templates/backendconfig.yaml
@@ -1,12 +1,12 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
+  name: argocd-backendconfig
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ .Chart.Name }}
-  name: argocd-backendconfig
 spec:
   securityPolicy:
     name: "argocd-policy" # Configure ArgoCD ingress to use CloudArmor policy

--- a/charts/ap-argocd-preinstall/templates/certificate.yaml
+++ b/charts/ap-argocd-preinstall/templates/certificate.yaml
@@ -1,12 +1,12 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
+  name: argocd-cert
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ .Chart.Name }}
-  name: argocd-cert
 spec:
   dnsNames:
   - ap-argocd.dsp-devops.broadinstitute.org

--- a/charts/ap-argocd-preinstall/templates/certificate.yaml
+++ b/charts/ap-argocd-preinstall/templates/certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: argocd-cert
+  name: argocd-certificate
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}

--- a/charts/ap-argocd-preinstall/templates/psp.yaml
+++ b/charts/ap-argocd-preinstall/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Release.Namespace }}-psp
+  name: argocd-psp
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}

--- a/charts/ap-argocd-preinstall/templates/role.yaml
+++ b/charts/ap-argocd-preinstall/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Namespace }}-pod-runner
+  name: argocd-pod-runner
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}
@@ -12,4 +12,4 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-    - {{ .Release.Namespace }}-psp
+  - argocd-psp

--- a/charts/ap-argocd-preinstall/templates/roleBinding.yaml
+++ b/charts/ap-argocd-preinstall/templates/roleBinding.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Namespace }}-pod-runner-binding
-  namespace: {{ .Release.Namespace }}
+  name: argocd-pod-runner-binding
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}
@@ -23,5 +22,5 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Release.Namespace }}-pod-runner
+  name: argocd-pod-runner
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Associate a CloudArmor policy with ArgoCD Ingress using a BackendConfig.

Related:
https://github.com/broadinstitute/terraform-dsp-tools-k8s/pull/11
