### PR TITLE
Use configMap in Janitor

### DIFF
--- a/charts/crljanitor/config.json
+++ b/charts/crljanitor/config.json
@@ -1,0 +1,6 @@
+{
+  "db.recreate-db-on-start": "false",
+  "db.update-db-on-start": "false",
+  "track-resource.enabled": "false",
+  "server.port": "8080"
+}

--- a/charts/crljanitor/templates/config.yaml
+++ b/charts/crljanitor/templates/config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-crl-janitor
+  labels:
+    {{ template "crljanitor.labels" . }}
+data:
+  config.json: |-
+  {{ .Files.Get "config.json" | indent 4 }}

--- a/charts/crljanitor/templates/config.yaml
+++ b/charts/crljanitor/templates/config.yaml
@@ -7,3 +7,13 @@ metadata:
 data:
   config.json: |-
   {{ .Files.Get "config.json" | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-crl-janitor-terraform
+  labels:
+    {{ template "crljanitor.labels" . }}
+data:
+  config.json: |-
+  {{ .Files.Get "terraform-generated-config.json" | indent 4 }}

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         env:
         - name: DATABASE_USER
           valueFrom:
-            secretKeyRef:
-              name: crl-janitor-postgres-db-creds
+            configMapKeyRef:
+              name: configmap-crl-janitor
               key: username
         - name: DATABASE_USER_PASSWORD
           valueFrom:

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -44,6 +44,16 @@ spec:
             secretKeyRef:
               name: crl-janitor-postgres-db-creds
               key: db
+        - name: RECREATE_DB_ON_START
+          valueFrom:
+            configMapKeyRef:
+              name: configmap-crl-janitor
+              key: db.recreate-db-on-start
+        - name: UPDATE_DB_ON_START
+          valueFrom:
+            configMapKeyRef:
+              name: configmap-crl-janitor
+              key: db.update-db-on-start
         - name: STAIRWAY_DATABASE_USER
           valueFrom:
             secretKeyRef:

--- a/charts/crljanitor/terraform-generated-config.json
+++ b/charts/crljanitor/terraform-generated-config.json
@@ -1,6 +1,3 @@
 {
-  "db.name": "false",
-  "db.update-db-on-start": "false",
-  "track-resource.enabled": "false",
-  "server.port": "8080"
+  "db.username": "crljanitor"
 }

--- a/charts/crljanitor/terraform-generated-config.json
+++ b/charts/crljanitor/terraform-generated-config.json
@@ -1,0 +1,6 @@
+{
+  "db.name": "false",
+  "db.update-db-on-start": "false",
+  "track-resource.enabled": "false",
+  "server.port": "8080"
+}


### PR DESCRIPTION
Idea: 

1. A central place for easier access all configs(hard-coded and terraform generated)
2. Helm loads files and generate ConfigMap during deployment
3. Human can manually update hard coded config file, and terraform can modify terraform-generated config file. 