### PR TITLE
DDO-758 Add liveness check to Cromwell chart

### DIFF
--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.7.1
+version: 0.7.2
 type: application
 
 description: A Helm chart for Cromwell, the Terra Workflow Management System

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -118,10 +118,19 @@ spec:
           httpGet:
             path: /engine/latest/version
             port: 8000
-          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          initialDelaySeconds: 20
           periodSeconds: 10
-          timeoutSeconds: 1
-          failureThreshold: 6
+          failureThreshold: 6 # 60 seconds before unready
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /engine/latest/version
+            port: 8000
+          timeoutSeconds: 5
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          failureThreshold: 30 # 5 minutes before restarted
           successThreshold: 1
       - name: {{ $settings.name }}-proxy
         image: broadinstitute/openidc-proxy:modsecurity_2_9_2

--- a/release-strategy.json
+++ b/release-strategy.json
@@ -1,5 +1,6 @@
 {
     "crljanitor":       {"dev_only": false},
+    "cromwell":         {"dev_only": false},
     "poc":              {"dev_only": false},
     "workspacemanager": {"dev_only": true}
 }


### PR DESCRIPTION
Update Cromwell liveness/readiness checks so that:
* pod is taken out of service after 60s of failed polling
* pod is restarted after 300s of failed polling

Also use @gmalkov's awesome new workflow to auto-bump the Cromwell chart version in terra-helmfile