### PR TITLE
DDO-761 Ontology Liveness Probe

### DIFF
--- a/charts/ontology/Chart.yaml
+++ b/charts/ontology/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ontology
-version: 0.1.2
+version: 0.1.3
 type: application
 
 description: A Helm chart for DUOS Ontology, the DUOS Algorithmic Matching System

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -76,8 +76,16 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 1
-            failureThreshold: 10
+            failureThreshold: 6 # mark pod unavaible for traffic after 60s
             successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+            timeoutSeconds: 5
+            intialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 30 # Restart container after 5 minutes
         - name: oidc-proxy
           image: "{{ .Values.proxyImageRepository }}:{{ .Values.proxyImageVersion }}"
           ports:

--- a/release-strategy.json
+++ b/release-strategy.json
@@ -1,6 +1,7 @@
 {
     "crljanitor":       {"dev_only": false},
     "cromwell":         {"dev_only": false},
+    "ontology":         {"dev_only": false},
     "poc":              {"dev_only": false},
     "workspacemanager": {"dev_only": true}
 }


### PR DESCRIPTION
In Addition to the existing readiness probe which will prevent an ontology pod from
receiving traffic if the status endpoint is unresponsive, this pr adds a liveness probe.
The liveness probe will automatically restart the ontology container after 5 minutes of status check
failues.
﻿- Add liveness probe
- bump chart version
