### PR TITLE
fix chart name reference

### DIFF
--- a/charts/consent/Chart.yaml
+++ b/charts/consent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consent
-version: 0.2.0
+version: 0.3.0
 type: application
 description: A Helm chart for DUOS Consent
 keywords:

--- a/charts/consent/Chart.yaml
+++ b/charts/consent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consent
-version: 0.3.0
+version: 0.2.0
 type: application
 description: A Helm chart for DUOS Consent
 keywords:

--- a/charts/consent/templates/podMonitor.yaml
+++ b/charts/consent/templates/podMonitor.yaml
@@ -8,6 +8,6 @@ spec:
   jobLabel: consent-jvm
   selector:
     matchLabels:
-      app.kubernetes.io/component: {{ .Chart.name }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   podMetricsEndpoints:
     - port: metrics


### PR DESCRIPTION
Update the `Chart.Name` reference. For some reason, even though the key is named `name` with a lower case `n`, [it does not validate correctly](https://github.com/broadinstitute/terra-helmfile/pull/343/checks?check_run_id=1275364642):
```
  Error: template: consent/templates/podMonitor.yaml:11:44: executing "consent/templates/podMonitor.yaml" at <.Chart.name>: can't evaluate field name in type interface {}
```