### PR TITLE
PF-152 Use the WM app SA as the default GOOGLE_APPLICATION_CREDENTIALS.

### DIFF
--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: workspacemanager
-version: 0.7.0
+version: 0.8.0
 description: Chart for Terra Workspace Manager
 type: application
 keywords:

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
           value: {{ .Values.serviceGoogleProject }}
         - name: SAMPLING_PROBABILITY
           value: "{{ .Values.samplingProbability }}"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secrets/app/service-account.json
         - name: CLOUD_TRACE_SA_PATH
           value: /secrets/cloudtrace/service-account.json
         - name: CLOUD_TRACE_ENABLED
@@ -97,6 +99,9 @@ spec:
         - name: TERRA_DATAREPO_URL
           value: "{{ .Values.terraDataRepoUrl }}"
         volumeMounts:
+          - name: app-sa-creds
+            mountPath: /secrets/app
+            readOnly: true
           - name: cloud-trace-sa-creds
             mountPath: /secrets/cloudtrace
             readOnly: true
@@ -238,6 +243,9 @@ spec:
         - name: cloud-trace-sa-creds
           secret:
             secretName: workspace-cloud-trace-sa
+        - name: app-sa-creds
+          secret:
+            secretName: workspace-app-sa
         {{- if .Values.proxy.enabled }}
         - name: apache-httpd-proxy-config
           configMap:

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -141,6 +141,21 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
+  name: secretdefinition-workspace-app-sa
+  labels:
+    {{ template "workspacemanager.labels" . }}
+spec:
+  name: workspace-sqlproxy-sa
+  keysMap:
+    service-account.json:
+      path: {{ .Values.vault.pathPrefix }}/workspace/app-sa
+      encoding: base64
+      key: key
+---
+# TODO(wchamber): Remove cloudtrace SA once we're migrated to app SA.
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
   name: secretdefinition-workspace-cloud-trace-sa
   labels:
     {{ template "workspacemanager.labels" . }}

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -145,7 +145,7 @@ metadata:
   labels:
     {{ template "workspacemanager.labels" . }}
 spec:
-  name: workspace-sqlproxy-sa
+  name: workspace-app-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/workspace/app-sa


### PR DESCRIPTION
Change the helm for workspace manager to set the new app SA as the default Google SA with environment variable GOOGLE_APPLICATION_CREDENTIALS. This will match other MC Terra services.
This is a backwards compatible change with existing WM deployments: the app SA has a superset of the permissions in the cloud trace SA, including those needed for logging & monitoring in GKE. We also don't modify the cloudtrace SA volume or variables so that existing images can still use it.
Cleanup for the cloudtrace SA is tracked in PF-197.