### PR TITLE
Consent: mount file where proxy is expecting it

### DIFF
--- a/charts/consent/templates/deployment.yaml
+++ b/charts/consent/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
               - key: tls.key
                 path: private/server.key
               - key: ca-bundle.crt
-                path: certs/ca-bundle.crt
+                path: certs/ca-certificates.crt
         - name: consent-prometheusjmx-jar
           emptyDir: {}
       initContainers:


### PR DESCRIPTION
Proxy is complaining about not being able to see `ca-certificates.crt`. Mount the file there.