### PR TITLE
No ticket Fix to /etc/ssl overwrite in consent proxy volume mounts

### DIFF
--- a/charts/consent/templates/deployment.yaml
+++ b/charts/consent/templates/deployment.yaml
@@ -129,8 +129,17 @@ spec:
               mountPath: /etc/apache2/sites-available/site.conf
               subPath: site.conf
               readOnly: true
-            - name: proxy-secrets
-              mountPath: "/etc/ssl"
+            - mountPath: /etc/ssl/certs/server.crt
+              subPath: server.crt
+              name: proxy-secrets
+              readOnly: true
+            - mountPath: /etc/ssl/private/server.key
+              subPath: server.key
+              name: proxy-secrets
+              readOnly: true
+            - mountPath: /etc/ssl/certs/ca-bundle.crt
+              subPath: ca-bundle.crt
+              name: proxy-secrets
               readOnly: true
         - name: {{ .Chart.Name }}-sqlproxy
           image: broadinstitute/cloudsqlproxy:1.11_20191120
@@ -167,13 +176,6 @@ spec:
         - name: proxy-secrets
           secret:
             secretName: {{ .Chart.Name }}-proxy-secrets
-            items:
-              - key: tls.crt
-                path: certs/server.crt
-              - key: tls.key
-                path: private/server.key
-              - key: ca-bundle.crt
-                path: certs/ca-bundle.crt
         - name: consent-prometheusjmx-jar
           emptyDir: {}
       initContainers:

--- a/charts/consent/templates/secrets.yaml
+++ b/charts/consent/templates/secrets.yaml
@@ -40,10 +40,10 @@ metadata:
 spec:
   name: {{ .Chart.Name }}-proxy-secrets
   keysMap:
-    tls.crt:
+    server.crt:
       path: {{ required "A valid vaultCertPath value is required when vaultCert is enabled" .Values.vaultCertPath }}
       key: {{ required "A valid vaultCertSecretKey value is required when vaultCert is enabled" .Values.vaultCertSecretKey }}
-    tls.key:
+    server.key:
       path: {{ required "A valid vaultKeyPath value is required when vaultCert is enabled" .Values.vaultKeyPath }}
       key: {{ required "A valid vaultKeySecretKey value is required when vaultCert is enabled" .Values.vaultKeySecretKey }}
     ca-bundle.crt:


### PR DESCRIPTION
The oidc proxy container has a bunch of files built into the image under `/etc/ssl` the pattern being used previously to mount tls credentials to the proxy container was overwriting the entire contents of `/etc/ssl` This pr adjust the mounting pattern for tls credentials so that they are inserted into the correct paths under `/etc/ssl/` rather than overwriting the entire directory.