### PR TITLE
No ticket Fix to /etc/ssl overwrite in ontology proxy volume mounts

### DIFF
--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -54,10 +54,10 @@ spec:
           - -Dsentry.stacktrace.app.packages=org.broadinstitute
           - -Dsentry.dsn=$(SENTRY_DSN)
           - $(PROMETHEUS_ARGS)
-          - -jar
-          - /opt/consent-ontology.jar
-          - server
-          - /etc/ontology-cm/ontology.yaml
+          - -jar 
+          - /opt/consent-ontology.jar 
+          - server 
+          - /etc/ontology-cm/ontology.yaml 
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -54,10 +54,10 @@ spec:
           - -Dsentry.stacktrace.app.packages=org.broadinstitute
           - -Dsentry.dsn=$(SENTRY_DSN)
           - $(PROMETHEUS_ARGS)
-          - -jar 
-          - /opt/consent-ontology.jar 
-          - server 
-          - /etc/ontology-cm/ontology.yaml 
+          - -jar
+          - /opt/consent-ontology.jar
+          - server
+          - /etc/ontology-cm/ontology.yaml
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm
@@ -95,8 +95,17 @@ spec:
               mountPath: /etc/apache2/sites-available/site.conf
               subPath: site.conf
               readOnly: true
-            - name: proxy-secrets
-              mountPath: "/etc/ssl"
+            - mountPath: /etc/ssl/certs/server.crt
+              subPath: server.crt
+              name: proxy-secrets
+              readOnly: true
+            - mountPath: /etc/ssl/private/server.key
+              subPath: server.key
+              name: proxy-secrets
+              readOnly: true
+            - mountPath: /etc/ssl/certs/ca-bundle.crt
+              subPath: ca-bundle.crt
+              name: proxy-secrets
               readOnly: true
       volumes:
         - name: configs
@@ -108,13 +117,6 @@ spec:
         - name: proxy-secrets
           secret:
             secretName: {{ .Chart.Name }}-proxy-secrets
-            items:
-              - key: tls.crt
-                path: certs/server.crt
-              - key: tls.key
-                path: private/server.key
-              - key: ca-bundle.crt
-                path: certs/ca-bundle.crt
         - name: ontology-prometheusjmx-jar
           emptyDir: {}
       initContainers:

--- a/charts/ontology/templates/secrets.yaml
+++ b/charts/ontology/templates/secrets.yaml
@@ -25,10 +25,10 @@ metadata:
 spec:
   name: {{ .Chart.Name }}-proxy-secrets
   keysMap:
-    tls.crt:
+    server.crt:
       path: {{ required "A valid vaultCertPath value is required when vaultCert is enabled" .Values.vaultCertPath }}
       key: {{ required "A valid vaultCertSecretKey value is required when vaultCert is enabled" .Values.vaultCertSecretKey }}
-    tls.key:
+    server.key:
       path: {{ required "A valid vaultKeyPath value is required when vaultCert is enabled" .Values.vaultKeyPath }}
       key: {{ required "A valid vaultKeySecretKey value is required when vaultCert is enabled" .Values.vaultKeySecretKey }}
     ca-bundle.crt:


### PR DESCRIPTION
See also: https://github.com/broadinstitute/terra-helm/pull/169

From that PR:
> The oidc proxy container has a bunch of files built into the image under /etc/ssl the pattern being used previously to mount tls credentials to the proxy container was overwriting the entire contents of /etc/ssl This pr adjust the mounting pattern for tls credentials so that they are inserted into the correct paths under /etc/ssl/ rather than overwriting the entire directory.