### PR TITLE
add quote for imageTag

### DIFF
--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -43,13 +43,13 @@ cronjob:
   # deployments.standalone.name -- Name to use for the default standalone Leonardo deployment
   name: leonardo-resource-validator-cronjob
   imageRepository: us.gcr.io/broad-dsp-gcr-public/resource-validator
-  imageTag: 0042368
+  imageTag: "0042368"
   googleProject:
 zombieMonitorCron:
   # deployments.standalone.name -- Name to use for the default standalone Leonardo deployment
   name: leonardo-zombie-monitor-cronjob
   imageRepository: us.gcr.io/broad-dsp-gcr-public/zombie-monitor
-  imageTag: 154d778
+  imageTag: "154d778"
 vault:
   # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
   pathPrefix:


### PR DESCRIPTION
without quote, `helmfile` is truncating `00` in the beginning of `imageTag`, adding quota seems to fix it.

Rendering locally seems to work
```
          - image: "us.gcr.io/broad-dsp-gcr-public/resource-validator:0042368"
```