### PR TITLE
[AS-524] Fix audience checking assumptions to use startswith

### DIFF
--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -42,43 +42,43 @@ Service firewall
 AoU Preprod Conditional
 */}}
 {{- define "workspacemanager.aoupreprodconditional" -}}
-  ((.email|endswith("@preprod.researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PREPROD_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
+  ((.email|endswith("@preprod.researchallofus.org")) and (.audience as $idkey | "${AOU_PREPROD_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Perf Conditional
 */}}
 {{- define "workspacemanager.aouperfconditional" -}}
-  ((.email|endswith("@perf.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PERF_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
+  ((.email|endswith("@perf.fake-research-aou.org")) and (.audience as $idkey | "${AOU_PERF_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Prod Conditional
 */}}
 {{- define "workspacemanager.aouprodconditional" -}}
-  ((.email|endswith("@researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PROD_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
+  ((.email|endswith("@researchallofus.org")) and (.audience as $idkey | "${AOU_PROD_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Dev Conditional
 */}}
 {{- define "workspacemanager.aoudevconditional" -}}
-  ((.email|endswith("@fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_DEV_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
+  ((.email|endswith("@fake-research-aou.org")) and (.audience as $idkey | "${AOU_DEV_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Stable Conditional
 */}}
 {{- define "workspacemanager.aoustableconditional" -}}
-  ((.email|endswith("@stable.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STABLE_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
+  ((.email|endswith("@stable.fake-research-aou.org")) and (.audience as $idkey | "${AOU_STABLE_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Staging Conditional
 */}}
 {{- define "workspacemanager.aoustagingconditional" -}}
-  ((.email|endswith("@staging.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STAGING_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
+  ((.email|endswith("@staging.fake-research-aou.org")) and (.audience as $idkey | "${AOU_STAGING_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 Terra ID Whitelist
 */}}
 {{- define "workspacemanager.terraidwhitelist" -}}
-  (.audience | split(".")[0] as $idkey | "${TERRA_ID_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element)))
+  (.audience as $idkey | "${TERRA_ID_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element)))
 {{- end }}
 {{/*
 Terra Conditional

--- a/charts/workspacemanager/templates/_helpers.tpl
+++ b/charts/workspacemanager/templates/_helpers.tpl
@@ -42,43 +42,43 @@ Service firewall
 AoU Preprod Conditional
 */}}
 {{- define "workspacemanager.aoupreprodconditional" -}}
-  ((.email|endswith("@preprod.researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PREPROD_WHITELIST}" | split(",") | any(contains($idkey))))
+  ((.email|endswith("@preprod.researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PREPROD_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Perf Conditional
 */}}
 {{- define "workspacemanager.aouperfconditional" -}}
-  ((.email|endswith("@perf.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PERF_WHITELIST}" | split(",") | any(contains($idkey))))
+  ((.email|endswith("@perf.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PERF_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Prod Conditional
 */}}
 {{- define "workspacemanager.aouprodconditional" -}}
-  ((.email|endswith("@researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PROD_WHITELIST}" | split(",") | any(contains($idkey))))
+  ((.email|endswith("@researchallofus.org")) and (.audience | split(".")[0] as $idkey | "${AOU_PROD_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Dev Conditional
 */}}
 {{- define "workspacemanager.aoudevconditional" -}}
-  ((.email|endswith("@fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_DEV_WHITELIST}" | split(",") | any(contains($idkey))))
+  ((.email|endswith("@fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_DEV_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Stable Conditional
 */}}
 {{- define "workspacemanager.aoustableconditional" -}}
-  ((.email|endswith("@stable.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STABLE_WHITELIST}" | split(",") | any(contains($idkey))))
+  ((.email|endswith("@stable.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STABLE_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 AoU Staging Conditional
 */}}
 {{- define "workspacemanager.aoustagingconditional" -}}
-  ((.email|endswith("@staging.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STAGING_WHITELIST}" | split(",") | any(contains($idkey))))
+  ((.email|endswith("@staging.fake-research-aou.org")) and (.audience | split(".")[0] as $idkey | "${AOU_STAGING_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element))))
 {{- end }}
 {{/*
 Terra ID Whitelist
 */}}
 {{- define "workspacemanager.terraidwhitelist" -}}
-  (.audience | split(".")[0] as $idkey | "${TERRA_ID_WHITELIST}" | split(",") | any(contains($idkey)))
+  (.audience | split(".")[0] as $idkey | "${TERRA_ID_WHITELIST}" | split(",") | map(. as $element | $idkey | startswith($element)))
 {{- end }}
 {{/*
 Terra Conditional


### PR DESCRIPTION
Currently, the WM proxy audience check assumes that the first portion of an audience (split by "." characters) has a format like "12345678901". However, some valid audiences have a first portion format like "998877665544-abcdefghijkl54321blahblahblah". This check is rejecting valid calls from Rawls.

Current services check that audiences **start with** the whitelisted ids. This change makes WM do the same.

(I'd like to test this more before submitting, I'll bring up the new version in my integration env and we can test against that)