### PR TITLE
Make legacy configs app generator work for apps that don't have any instance types

### DIFF
--- a/charts/terra-argocd-app/Chart.yaml
+++ b/charts/terra-argocd-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terra-argocd-app
 description: A Helm chart for generating ArgoCD resources for a Terra app in an environment
 type: application
-version: 0.1.2
+version: 0.1.3
 dependencies:
 - name: terra-argocd-templates
   version: 0.0.4

--- a/charts/terra-argocd-app/templates/legacy-configs-app.yaml
+++ b/charts/terra-argocd-app/templates/legacy-configs-app.yaml
@@ -21,7 +21,7 @@ spec:
     server: {{ quote .clusterAddress }}
   source:
     repoURL: {{ quote .legacyConfigsRepo }}
-    targetRevision: {{ .legacyConfigsRepoRef }}
+    targetRevision: {{ quote .legacyConfigsRepoRef }}
     path: .
     plugin:
       name: legacy-configs

--- a/charts/terra-argocd-app/templates/legacy-configs-app.yaml
+++ b/charts/terra-argocd-app/templates/legacy-configs-app.yaml
@@ -29,7 +29,7 @@ spec:
       {{- $instanceTypes := .legacyConfigsInstanceTypes | join "," -}}
       {{- $envVars := merge .legacyConfigsEnv (dict "ENV" .environment "APP_NAME" .app "INSTANCE_TYPES" $instanceTypes ) -}}
       {{- range $name, $value := $envVars }}
-      - name: {{ $name }}
-        value: {{ $value }}
+      - name: {{ quote $name }}
+        value: {{ quote $value }}
       {{- end -}}
 {{- end -}}{{- end -}}


### PR DESCRIPTION
Make legacy configs app generator work for Sam