### PR TITLE
(No Ticket) Adjustments to duos helm chart container naming

### DIFF
--- a/charts/consent/templates/deployment.yaml
+++ b/charts/consent/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - app
             - sqlproxy
       containers:
-        - name: {{ .Chart.Name }}-service
+        - name: {{ .Chart.Name }}-app
           image: "{{- if .Values.image -}}
           {{ .Values.image }}
           {{- else -}}
@@ -120,7 +120,7 @@ spec:
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false
-        - name: oidc-proxy
+        - name: {{ Chart.Name }}-proxy
           image: "{{ .Values.proxyImageRepository }}:{{ .Values.proxyImageVersion }}"
           ports:
             - containerPort: 443

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           hostnames:
             - app
       containers:
-        - name: {{ .Chart.Name }}-service
+        - name: {{ .Chart.Name }}-app
           image: "{{- if .Values.image -}}
           {{ .Values.image }}
           {{- else -}}
@@ -86,7 +86,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             failureThreshold: 30 # Restart container after 5 minutes
-        - name: oidc-proxy
+        - name: {{ Chart.Name }}-proxy
           image: "{{ .Values.proxyImageRepository }}:{{ .Values.proxyImageVersion }}"
           ports:
             - containerPort: 443


### PR DESCRIPTION
This pr adjusts the names of k8s containers from the DUOS services so that it is easily identifiable which service 
service the container is associated with in metadata﻿
