### PR TITLE
remove unnecessary config

### DIFF
--- a/charts/leonardo/templates/zombieMonitorCron.yaml
+++ b/charts/leonardo/templates/zombieMonitorCron.yaml
@@ -38,8 +38,6 @@ spec:
                   key: password
             - name: LEONARDO_PATH_TO_CREDENTIAL
               value: /secrets/service-account.json
-            - name: REPORT_DESTINATION_BUCKET
-              value: "{{ .Values.commonCronjob.reportDestinationBucket }}"
             volumeMounts:
             - name: leonardo-sa-json-file
               mountPath: /secrets


### PR DESCRIPTION
`REPORT_DESTINATION_BUCKET` exists in application.conf now. Hence we don't need this env variable now