### PR TITLE
DDO-832 Add optional nodeSelector, toleration values to Cromwell chart

### DIFF
--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.8.0
+version: 0.8.1
 type: application
 description: A Helm chart for Cromwell, the Terra Workflow Management System
 keywords:

--- a/charts/cromwell/README.md
+++ b/charts/cromwell/README.md
@@ -17,11 +17,12 @@ Current chart version is `0.8.0`
 | deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @defautl global.applicationVersion |
 | deploymentDefaults.legacyResourcePrefix | string | `nil` | What prefix to use to refer to secrets rendered from firecloud-develop @default deploymentDefaults.name |
 | deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resuorce definitions. Example: `"cromwell1-reader"` |
-| deploymentDefaults.nodeSelector | string | `nil` | Optional nodeSelector |
+| deploymentDefaults.nodeSelector | string | `nil` | Optional nodeSelector map |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deploymentDefaults.serviceAllowedAddresses | object | `{}` | What source IPs to whitelist for access to the service |
 | deploymentDefaults.serviceIP | string | `nil` | Static IP to use for the Service. If set, service will be of type LoadBalancer |
 | deploymentDefaults.serviceName | string | `nil` | What to call the Service |
+| deploymentDefaults.tolerations | string | `nil` | Optional array of tolerations |
 | deployments.standalone.expose | bool | `true` | Whether to expose the default standalone Cromwell deployment as a service |
 | deployments.standalone.name | string | `"cromwell"` | Name to use for the default standalone Cromwell deployment |
 | deployments.standalone.replicas | int | `1` | Number of replicas in the default standalone Cromwell deployment |

--- a/charts/cromwell/README.md
+++ b/charts/cromwell/README.md
@@ -2,7 +2,7 @@ cromwell
 ========
 A Helm chart for Cromwell, the Terra Workflow Management System
 
-Current chart version is `0.7.0`
+Current chart version is `0.8.0`
 
 
 
@@ -17,6 +17,7 @@ Current chart version is `0.7.0`
 | deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @defautl global.applicationVersion |
 | deploymentDefaults.legacyResourcePrefix | string | `nil` | What prefix to use to refer to secrets rendered from firecloud-develop @default deploymentDefaults.name |
 | deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resuorce definitions. Example: `"cromwell1-reader"` |
+| deploymentDefaults.nodeSelector | string | `nil` | Optional nodeSelector |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deploymentDefaults.serviceAllowedAddresses | object | `{}` | What source IPs to whitelist for access to the service |
 | deploymentDefaults.serviceIP | string | `nil` | Static IP to use for the Service. If set, service will be of type LoadBalancer |

--- a/charts/cromwell/README.md
+++ b/charts/cromwell/README.md
@@ -1,10 +1,7 @@
 cromwell
 ========
+
 A Helm chart for Cromwell, the Terra Workflow Management System
-
-Current chart version is `0.8.0`
-
-
 
 
 
@@ -16,13 +13,13 @@ Current chart version is `0.8.0`
 | deploymentDefaults.expose | bool | `false` | Whether to create a Service for this deployment |
 | deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @defautl global.applicationVersion |
 | deploymentDefaults.legacyResourcePrefix | string | `nil` | What prefix to use to refer to secrets rendered from firecloud-develop @default deploymentDefaults.name |
-| deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resuorce definitions. Example: `"cromwell1-reader"` |
-| deploymentDefaults.nodeSelector | string | `nil` | Optional nodeSelector map |
+| deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resource definitions. Example: `"cromwell1-reader"` |
+| deploymentDefaults.nodeSelector | object | `nil` | Optional nodeSelector map |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deploymentDefaults.serviceAllowedAddresses | object | `{}` | What source IPs to whitelist for access to the service |
 | deploymentDefaults.serviceIP | string | `nil` | Static IP to use for the Service. If set, service will be of type LoadBalancer |
 | deploymentDefaults.serviceName | string | `nil` | What to call the Service |
-| deploymentDefaults.tolerations | string | `nil` | Optional array of tolerations |
+| deploymentDefaults.tolerations | array | `nil` | Optional array of tolerations |
 | deployments.standalone.expose | bool | `true` | Whether to expose the default standalone Cromwell deployment as a service |
 | deployments.standalone.name | string | `"cromwell"` | Name to use for the default standalone Cromwell deployment |
 | deployments.standalone.replicas | int | `1` | Number of replicas in the default standalone Cromwell deployment |

--- a/charts/cromwell/README.md.gotmpl
+++ b/charts/cromwell/README.md.gotmpl
@@ -1,0 +1,7 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -179,4 +179,8 @@ spec:
         volumeMounts:
         - mountPath: /cromwell-prometheusjmx-jar
           name: cromwell-prometheusjmx-jar
+      {{- if $settings.nodeSelector }}
+      nodeSelector:
+        {{ $settings.nodeSelector | toYaml | indent 8 | trim }}
+      {{- end -}}
 {{- end -}}

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -183,4 +183,8 @@ spec:
       nodeSelector:
         {{ $settings.nodeSelector | toYaml | indent 8 | trim }}
       {{- end -}}
+      {{- if $settings.tolerations }}
+      tolerations:
+        {{ $settings.tolerations | toYaml | indent 8 | trim }}
+      {{- end -}}
 {{- end -}}

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -29,6 +29,8 @@ deploymentDefaults:
   # deploymentDefaults.legacyResourcePrefix -- What prefix to use to refer to secrets rendered from firecloud-develop
   # @default deploymentDefaults.name
   legacyResourcePrefix: null
+  # deploymentDefaults.nodeSelector -- Optional nodeSelector
+  nodeSelector: null
 
 # A map of Cromwell deployments. In Terra's production environment,
 # Cromwell is deployed as 4 separate services with different configurations.

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -10,7 +10,7 @@ global:
 deploymentDefaults:
   # deploymentDefaults.enabled -- Whether a declared deployment is enabled. If false, no resources will be created
   enabled: true
-  # deploymentDefaults.name -- A name for the deployment that will be substituted into resuorce definitions.
+  # deploymentDefaults.name -- A name for the deployment that will be substituted into resource definitions.
   # Example: `"cromwell1-reader"`
   name: null
   # deploymentDefaults.imageTag -- Image tag to be used when deploying Pods
@@ -29,9 +29,9 @@ deploymentDefaults:
   # deploymentDefaults.legacyResourcePrefix -- What prefix to use to refer to secrets rendered from firecloud-develop
   # @default deploymentDefaults.name
   legacyResourcePrefix: null
-  # deploymentDefaults.nodeSelector -- Optional nodeSelector map
+  # deploymentDefaults.nodeSelector -- (object) Optional nodeSelector map
   nodeSelector: null
-  # deploymentDefaults.tolerations -- Optional array of tolerations
+  # deploymentDefaults.tolerations -- (array) Optional array of tolerations
   tolerations: null
 
 # A map of Cromwell deployments. In Terra's production environment,

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -29,8 +29,10 @@ deploymentDefaults:
   # deploymentDefaults.legacyResourcePrefix -- What prefix to use to refer to secrets rendered from firecloud-develop
   # @default deploymentDefaults.name
   legacyResourcePrefix: null
-  # deploymentDefaults.nodeSelector -- Optional nodeSelector
+  # deploymentDefaults.nodeSelector -- Optional nodeSelector map
   nodeSelector: null
+  # deploymentDefaults.tolerations -- Optional array of tolerations
+  tolerations: null
 
 # A map of Cromwell deployments. In Terra's production environment,
 # Cromwell is deployed as 4 separate services with different configurations.


### PR DESCRIPTION
Add optional `nodeSelector` and `toleration` values to the Cromwell chart so that we can start scheduling Cromwell on its new dedicated node pool.

See https://github.com/broadinstitute/terraform-ap-deployments/pull/140 for background.