### PR TITLE
DDO-849 consent-gke-ingress

### DIFF
--- a/charts/consent/README.md
+++ b/charts/consent/README.md
@@ -31,6 +31,7 @@ Current chart version is `0.1.0`
 | image | string | `nil` |  |
 | imageRepository | string | `nil` |  |
 | imageTag | string | `nil` |  |
+| ingressIpName | string | `nil` | Global static ip for ingress. Required. | 
 | proxyImageRepository | string | `nil` |  |
 | proxyImageVersion | string | `nil` |  |
 | proxyLogLevel | string | `nil` |  |

--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}-ingress
+  labels:
+{{ include "consent.labels" . | indent 4 }}
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: {{ required "a valid gcp resource name for the ingress ip is required" .Values.ingressIpName }}
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: {{ .Chart.Name }}-cert
+  rules:
+  - http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: {{ .Values.ingressServiceName }}
+          servicePort: 443 

--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -10,10 +10,6 @@ metadata:
 spec:
   tls:
   - secretName: {{ .Chart.Name }}-cert
-  rules:
-  - http:
-      paths:
-      - path: /*
-        backend:
-          serviceName: {{ .Chart.Name }}
-          servicePort: 443 
+  backend:
+    serviceName: {{ .Chart.Name }}
+    servicePort: 443 

--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -15,5 +15,5 @@ spec:
       paths:
       - path: /*
         backend:
-          serviceName: {{ .Values.ingressServiceName }}
+          serviceName: {{ .Chart.Name }}
           servicePort: 443 

--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ include "consent.labels" . | indent 4 }}
   annotations:
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Chart.Name }}-frontend-config
     kubernetes.io/ingress.global-static-ip-name: {{ required "a valid gcp resource name for the ingress ip is required" .Values.ingressIpName }}
     kubernetes.io/ingress.allow-http: "false"
 spec:

--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -12,4 +13,11 @@ spec:
   - secretName: {{ .Chart.Name }}-cert
   backend:
     serviceName: {{ .Chart.Name }}
-    servicePort: 443 
+    servicePort: 443
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ .Chart.Name }}-frontend-config
+spec:
+  sslPolicy: {{ .Values.sslPolicy }}

--- a/charts/consent/templates/ingressCert.yaml
+++ b/charts/consent/templates/ingressCert.yaml
@@ -1,0 +1,15 @@
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-{{ .Chart.Name }}-ingress-cert
+  labels:
+{{ include "consent.labels" . | indent 4 }}
+spec:
+  name: {{ .Chart.Name }}-cert
+  keysMap:
+    tls.crt:
+      path: {{ required "A valid ingressCert.cert.path value is required when ingressCert is enabled" .Values.ingressCert.cert.path }}
+      key: {{ required "A valid ingressCert.cert.secretKey value is required when ingressCert is enabled" .Values.ingressCert.cert.secretKey }}
+    tls.key:
+      path: {{ required "A valid ingressCert.key.path value is required when ingressCert is enabled" .Values.ingressCert.key.path }}
+      key: {{ required "A valid ingressCert.key.secretKey value is required when ingressCert is enabled" .Values.ingressCert.key.secretKey }}

--- a/charts/consent/templates/service.yaml
+++ b/charts/consent/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Chart.Name }}
   annotations:
     cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+    cloud.google.com/neg: '{"ingress": true}' 
   labels:
     app: {{ .Chart.Name }}-service
 {{ include "consent.labels" . | indent 4 }}
@@ -13,6 +14,6 @@ spec:
       protocol: TCP
       port: 443
       targetPort: 443
-  type: NodePort
+  type: ClusterIP
   selector:
     app: {{ .Chart.Name }}

--- a/charts/consent/templates/service.yaml
+++ b/charts/consent/templates/service.yaml
@@ -2,15 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Chart.Name }}
+  annotations:
+    cloud.google.com/app-protocols: '{"https":"HTTPS"}'
   labels:
     app: {{ .Chart.Name }}-service
 {{ include "consent.labels" . | indent 4 }}
 spec:
-  loadBalancerIP: {{ required "A valid serviceIP value is required!" .Values.serviceIP }}
   ports:
     - name: https
       protocol: TCP
       port: 443
-  type: LoadBalancer
+      targetPort: 443
+  type: NodePort
   selector:
     app: {{ .Chart.Name }}

--- a/charts/consent/values.yaml
+++ b/charts/consent/values.yaml
@@ -68,6 +68,8 @@ sentryDsnKey:
 servicesLocalUrl:
 servicesOntologyUrl:
 
+sslPolicy:  tls12-ssl-policy
+
 vaultEnabled: true
 
 vaultCertPath:

--- a/charts/consent/values.yaml
+++ b/charts/consent/values.yaml
@@ -37,6 +37,23 @@ image:
 imageRepository:
 imageTag:
 
+# GKE ingress requires certificate in a slightly different format from the apache proxy
+# This is used to set tls for the GKE ingress
+ingressCert:
+  cert:
+    # ingressCert.cert.path -- (string) Path to secret containing .crt
+    path:
+    # ingressCert.cert.secretKey -- (string) Key in secret containing .crt
+    secretKey:
+  key:
+    # ingressCert.key.path -- (string) Path to secret containing .key
+    path:
+    # ingressCert.key.secretKey -- (string) Key in secret containing .key
+    secretKey:
+
+# Resource name for the global static ip in google to be used for the ingress
+ingressIpName:
+
 proxyLogLevel:
 proxyImageRepository:
 proxyImageVersion:
@@ -47,9 +64,6 @@ sendgridApiKey:
 
 sentryDsnPath:
 sentryDsnKey:
-
-# serviceIP -- (string) External IP of the service. Required.
-serviceIP:
 
 servicesLocalUrl:
 servicesOntologyUrl:


### PR DESCRIPTION
This pr will convert consent from using a kubernetes internal loadbalancer for access to the application
to use GKE ingress as an external https loadbalancer﻿
