### PR TITLE
DDO-849-2 consent ingress health check

### DIFF
--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -22,3 +22,19 @@ metadata:
   name: {{ .Chart.Name }}-frontend-config
 spec:
   sslPolicy: {{ .Values.sslPolicy }}
+---
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ .Chart.Name }}-ingress-backendconfig
+  labels:
+{{ include "consent.labels" . | indent 4 }}
+spec:
+  healthCheck:
+    checkIntervalSec: 5
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    type: HTTPS
+    port: 443
+    requestPath: /status

--- a/charts/consent/templates/service.yaml
+++ b/charts/consent/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     cloud.google.com/app-protocols: '{"https":"HTTPS"}'
     cloud.google.com/neg: '{"ingress": true}' 
+    cloud.google.com/backend-config: '{"default": "{{ .Chart.Name }}-ingress-backendconfig"}'
   labels:
     app: {{ .Chart.Name }}-service
 {{ include "consent.labels" . | indent 4 }}

--- a/release-strategy.json
+++ b/release-strategy.json
@@ -1,4 +1,5 @@
 {
+    "consent":          {"dev_only": false},
     "crljanitor":       {"dev_only": false},
     "cromwell":         {"dev_only": false},
     "leonardo":         {"dev_only": false},


### PR DESCRIPTION
This pr adds a back end config to the consent ingress 
so that the https loadbalancer health check properly uses
the status endpoint﻿
