### PR TITLE
DDO-849-3 Set timeout on ingress

### DIFF
--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -30,6 +30,7 @@ metadata:
   labels:
 {{ include "consent.labels" . | indent 4 }}
 spec:
+  timeoutSec: {{ .Values.ingressTimeout }}
   healthCheck:
     checkIntervalSec: 5
     timeoutSec: 5

--- a/charts/consent/values.yaml
+++ b/charts/consent/values.yaml
@@ -53,6 +53,8 @@ ingressCert:
 
 # Resource name for the global static ip in google to be used for the ingress
 ingressIpName:
+# ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
+ingressTimeout: 120
 
 proxyLogLevel:
 proxyImageRepository:


### PR DESCRIPTION
This pr ensures that the timeout on requests to consents ingress
are configured the same as the gce loadbalancer which is set to 120 seconds﻿
