### PR TITLE
DDO-904 rawls ingress health checks

### DIFF
--- a/charts/rawls/templates/_service.tpl
+++ b/charts/rawls/templates/_service.tpl
@@ -8,6 +8,7 @@ metadata:
   annotations:
     cloud.google.com/app-protocols: '{"https":"HTTPS"}'
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "{{ .Chart.Name }}-ingress-backendconfig"}'
   labels:
 {{ include "rawls.labels" . | indent 4 }}
 spec:

--- a/charts/rawls/templates/ingress.yaml
+++ b/charts/rawls/templates/ingress.yaml
@@ -21,5 +21,24 @@ apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
   name: {{ .Chart.Name }}-frontend-config
+  labels:
+{{ include "rawls.labels" . | indent 4 }}
 spec:
   sslPolicy: {{ .Values.sslPolicy }}
+--- 
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ .Chart.Name }}-ingress-backendconfig
+  labels:
+{{ include "rawls.labels" . | indent 4 }}
+spec:
+  timeoutSec: {{ .Values.ingressTimeout }}
+  healthCheck:
+    checkIntervalSec: 5
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    type: HTTPS
+    port: 443
+    requestPath: /status

--- a/charts/rawls/templates/ingress.yaml
+++ b/charts/rawls/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "rawls.labels" . | indent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: {{ .Chart.Name }}-frontend-config
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Chart.Name }}-ingress-frontendconfig
     kubernetes.io/ingress.global-static-ip-name: {{ required "a valid gcp resource name for the ingress ip is required" .Values.ingressIpName }}
     kubernetes.io/ingress.allow-http: "false"
 spec:
@@ -20,7 +20,7 @@ spec:
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Chart.Name }}-frontend-config
+  name: {{ .Chart.Name }}-ingress-frontendconfig
   labels:
 {{ include "rawls.labels" . | indent 4 }}
 spec:

--- a/charts/rawls/values.yaml
+++ b/charts/rawls/values.yaml
@@ -34,6 +34,9 @@ ingressIpName:
 # ingressServiceName -- (string) Name of the rawls service to associate with GKE ingress.
 ingressServiceName: rawls-frontend
 
+# ingressTimeout -- Number of seconds to timeout on requests to the ingress
+ingressTimeout: 120
+
 # sslPolicy -- (string) Name of an existing google ssl policy to associate with an ingress frontend-config
 sslPolicy: tls12-ssl-policy 
 


### PR DESCRIPTION
This pr sets up a backend config for the rawls ingress so that the ingress
health check is configured correctly on pods with multiple containers﻿
