### PR TITLE
DDO-911 Cromwell chart fix: set requests == limits

### DIFF
--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -79,7 +79,8 @@ spec:
             cpu: 7
             memory: 40Gi
           limits:
-            memory: 50Gi
+            cpu: 7
+            memory: 40Gi
         envFrom:
         - secretRef:
             name: {{ $legacyResourcePrefix }}-app-env


### PR DESCRIPTION
This PR sets Cromwell's [CPU and memory limits](https://learnk8s.io/setting-cpu-memory-limits-requests) equal to its requests.

Previously, Cromwell had no CPU limit and could expand to use all available CPU on the node where it was running, leading to noisy CPU capacity alerts in #workbench-resilience. This PR will restrict it to using only 7 of the 8 available CPUs on each node.

Similarly, this PR sets Cromwell's memory limit to 40 GiB instead of 50 GiB. This means that Cromwell will only be able to use 40 GiB (43 GB) of the available memory on the node, instead of all of the available memory (Cromwell's nodes have 46.5 GiB / 50 GB total memory).

**Background**

Back when we first tried running Cromwell in GKE, we decided to experiment with having limits that were higher than requests; since then, our team [has decided to set limits equal to requests on all Terra app containers](https://docs.google.com/document/d/1nE87v09Lx1qTpuHxypX2XO6mPh6iQQ31bW-y0nPwI3o/edit#bookmark=id.v8ysbyk7q6fq) so that that each Terra app pod has predictable, fixed-size, guaranteed CPU and memory resources. We'll likely revisit this policy later to improve efficiency, but for now, it keeps things simple.
