### PR TITLE
Add locking to release workflows

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -6,6 +6,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up GCS Google Service Account
+        run: echo '${{ secrets.GCS_SA }}' > service_account.json
+
+      - name: Lock
+        uses: databiosphere/github-actions/actions/locker@locker-0.8.0
+        with:
+          operation: lock
+          lock_name: terra-helm-release
+          bucket: broad-dsp-locker-action
+          lock_timeout_ms: '120000'
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -22,3 +33,15 @@ jobs:
         uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
+
+      - name: Set up GCS Google Service Account
+        if: ${{ always() }}
+        run: echo '${{ secrets.GCS_SA }}' > service_account.json
+
+      - name: Unlock
+        uses: databiosphere/github-actions/actions/locker@locker-0.8.0
+        if: ${{ always() }}
+        with:
+          operation: unlock
+          lock_name: terra-helm-release
+          bucket: broad-dsp-locker-action

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,17 +40,6 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
 
-      - name: Notify Slack on failure
-        if: failure()
-        uses: broadinstitute/action-slack@v2.7.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          username: "Chart Releaser Action"
-          text: "terra-helm chart release failed!"
-
       - name: Set up GCS Google Service Account
         if: ${{ always() }}
         run: echo '${{ secrets.GCS_SA }}' > service_account.json
@@ -62,3 +51,14 @@ jobs:
           operation: unlock
           lock_name: terra-helm-release
           bucket: broad-dsp-locker-action
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: broadinstitute/action-slack@v2.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          username: "Chart Releaser Action"
+          text: "terra-helm chart release failed!"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up GCS Google Service Account
+        run: echo '${{ secrets.GCS_SA }}' > service_account.json
+
+      - name: Lock
+        uses: databiosphere/github-actions/actions/locker@locker-0.8.0
+        with:
+          operation: lock
+          lock_name: terra-helm-release
+          bucket: broad-dsp-locker-action
+          lock_timeout_ms: '120000'
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -39,3 +50,15 @@ jobs:
           status: ${{ job.status }}
           username: "Chart Releaser Action"
           text: "terra-helm chart release failed!"
+
+      - name: Set up GCS Google Service Account
+        if: ${{ always() }}
+        run: echo '${{ secrets.GCS_SA }}' > service_account.json
+
+      - name: Unlock
+        uses: databiosphere/github-actions/actions/locker@locker-0.8.0
+        if: ${{ always() }}
+        with:
+          operation: unlock
+          lock_name: terra-helm-release
+          bucket: broad-dsp-locker-action


### PR DESCRIPTION
This avoids race conditions when writing to index.yaml while releasing charts