### PR TITLE
DDO-939 Leo tweaks

### DIFF
--- a/charts/leonardo/templates/deployments/_deployment.tpl
+++ b/charts/leonardo/templates/deployments/_deployment.tpl
@@ -71,10 +71,10 @@ spec:
         resources: # Mimic existing GCE vm requirements
           requests:
             cpu: 4
-            memory: 8Gi
+            memory: 9Gi
           limits:
             cpu: 4
-            memory: 8Gi
+            memory: 9Gi
         envFrom:
         - secretRef:
             name: {{ $legacyResourcePrefix }}-app-env
@@ -147,7 +147,9 @@ spec:
           successThreshold: 1
         livenessProbe:
           httpGet:
-            path: /status
+            # poll /version instead of /status to avoid auto-restarting Leo
+            # when an upstream dependency, like Sam, goes down
+            path: /version
             port: 8080
           timeoutSeconds: 5
           initialDelaySeconds: 15


### PR DESCRIPTION
* Bump Leo's app container requests from 8GiB to 9GiB, to more closely match existing vms.
* Use /version for liveness instead of /status, so Leo isn't restarted automatically when Sam goes down