### PR TITLE
DDO-915 Automatically reset all Terra ArgoCD Apps back to master branch of terra-helmfile every night

### DIFF
--- a/charts/dsp-argocd/templates/apps/terra-app-generator.yaml
+++ b/charts/dsp-argocd/templates/apps/terra-app-generator.yaml
@@ -9,6 +9,11 @@ spec:
     server: https://kubernetes.default.svc # And in the same cluster
   sourceRepos:
   - '*'
+  syncWindows:
+  - kind: allow
+    schedule: '0 22 * * *' # Schedule a 10-minute window during which the terra-app-generator job will automatically sync
+    duration: 10m
+    manualSync: true # Allow manual syncs outside window
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -24,4 +29,6 @@ spec:
     plugin:
       name: terra-helmfile-argocd
     repoURL: https://github.com/broadinstitute/terra-helmfile
-  syncPolicy: {}
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/charts/terra-argocd-app/Chart.yaml
+++ b/charts/terra-argocd-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terra-argocd-app
 description: A Helm chart for generating ArgoCD resources for a Terra app in an environment
 type: application
-version: 0.2.0
+version: 0.3.0
 dependencies:
   - name: terra-argocd-templates
     version: 0.0.4

--- a/charts/terra-argocd-app/templates/app.yaml
+++ b/charts/terra-argocd-app/templates/app.yaml
@@ -21,6 +21,9 @@ spec:
     server: {{ quote .clusterAddress }}
   source:
     repoURL: {{ quote .helmfileRepo }}
+{{- if .helmfileRepoRevision }}
+    targetRevision: {{ quote .helmfileRepoRevision }}
+{{- end }}
     path: .
     plugin:
       name: helmfile

--- a/charts/terra-argocd-app/values.yaml
+++ b/charts/terra-argocd-app/values.yaml
@@ -28,6 +28,12 @@ purgeDeployedResourcesOnDelete: false
 # helmfileRepo -- Terra's helmfile repo
 helmfileRepo: https://github.com/broadinstitute/terra-helmfile
 
+# helmfileRepoRevision -- Target revision of terra-helmfile to deploy.
+# We follow GitOps, so HEAD/master branch of terra-helmfile is "the desired
+# state of the world", but occasionally it is useful to deploy off a terra-helmfile
+# PR branch
+helmfileRepoRevision: HEAD
+
 # legacyConfigsEnabled -- Whether to create a separate application to sync values from firecloud-develop
 legacyConfigsEnabled: false
 


### PR DESCRIPTION
* Configure ArgoCD apps to deploy HEAD revision of terra-helmfile by default (previously this was not specified)
* Add a sync window + automated sync policy to terra-app-generator to automatically sync during a 10-minute window every night at 10pm (the nightly perf deploy kicks off at 