### PR TITLE
[PF-197] Remove WM references to cloud trace SA

### DIFF
--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -43,9 +43,6 @@ spec:
         secret:
           secretName: workspace-sqlproxy-sa
       {{- end }}
-      - name: cloud-trace-sa-creds
-        secret:
-          secretName: workspace-cloud-trace-sa
       - name: app-sa-creds
         secret:
           secretName: workspace-app-sa
@@ -158,8 +155,6 @@ spec:
           value: "{{ .Values.samplingProbability }}"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/app/service-account.json
-        - name: CLOUD_TRACE_SA_PATH
-          value: /secrets/cloudtrace/service-account.json
         - name: CLOUD_TRACE_ENABLED
           value: "{{ .Values.cloudTraceEnabled }}"
         - name: TERRA_DATAREPO_URL
@@ -173,9 +168,6 @@ spec:
         volumeMounts:
         - name: app-sa-creds
           mountPath: /secrets/app
-          readOnly: true
-        - name: cloud-trace-sa-creds
-          mountPath: /secrets/cloudtrace
           readOnly: true
         {{- if .Values.prometheus.enabled }}
         - name: {{ .Values.name }}-prometheusjmx-config

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -151,19 +151,4 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/workspace/app-sa
       encoding: base64
       key: key
----
-# TODO(wchamber): Remove cloudtrace SA once we're migrated to app SA.
-apiVersion: secrets-manager.tuenti.io/v1alpha1
-kind: SecretDefinition
-metadata:
-  name: secretdefinition-workspace-cloud-trace-sa
-  labels:
-{{ include "workspacemanager.labels" . | indent 4 }}
-spec:
-  name: workspace-cloud-trace-sa
-  keysMap:
-    service-account.json:
-      path: {{ .Values.vault.pathPrefix }}/workspace/cloud-trace-sa
-      encoding: base64
-      key: key
 {{ end }}


### PR DESCRIPTION
Workspace Manager stopped using a separate service account for cloud tracing in https://github.com/DataBiosphere/terra-workspace-manager/pull/121, but the existing SA credentials were left in for backwards compatibility. 

All environments are now on a version past this change (see https://github.com/broadinstitute/terra-helmfile/pull/789), so it's now safe to remove this from the Helm chart. I'll make a terraform change to remove this SA once this chart change is deployed to all environments.

No helmfile change is necessary as there is no cloudtrace SA specific value, and we continue to use `Values.cloudTraceEnabled`.