### PR TITLE
don't send worspace manager logs to kibana to avoid quota issues

### DIFF
--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -16,9 +16,9 @@ data:
             in_cluster: true
         - drop_event:
             when:
-              and:
+              or:
               - not:
                   equals:
                     kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
               - regexp:
-                  kubernetes.pod.name: "^workspacemanage.*"
+                  kubernetes.pod.name: "^workspacemanager.*"

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -20,5 +20,5 @@ data:
               - not:
                   equals:
                     kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
-              - equals:
-                  kubernetes.pod.name: *workspacemanager*
+              - regexp:
+                  kubernetes.pod.name: "^workspacemanager.*"

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -20,5 +20,5 @@ data:
               - not:
                   equals:
                     kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
-              - equals:
+              - regexp:
                   kubernetes.pod.name: *workspacemanager*

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -20,5 +20,5 @@ data:
               - not:
                   equals:
                     kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
-              - regexp:
-                  kubernetes.pod.name: "^workspacemanager.*"
+              - equals:
+                  kubernetes.pod.name: *workspacemanager*

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -21,4 +21,4 @@ data:
                   equals:
                     kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
               - regexp:
-                  kubernetes.pod.name: *workspacemanager*
+                  kubernetes.pod.name: "^workspacemanage.*"

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -17,8 +17,8 @@ data:
         - drop_event:
             when:
               and:
-                - not:
-                    equals:
-                      kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
-                - equals:
-                    kubernetes.pod.name: *workspacemanager*
+              - not:
+                  equals:
+                    kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
+              - equals:
+                  kubernetes.pod.name: *workspacemanager*

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -16,6 +16,9 @@ data:
             in_cluster: true
         - drop_event:
             when:
-              not:
-                equals:
-                  kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
+              and:
+                - not:
+                    equals:
+                      kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
+                - equals:
+                    kubernetes.pod.name: *workspacemanager*


### PR DESCRIPTION
This is my quick hack to  stop hammering our non prod logit stack. The workspace manager proxy has been sending a ton of logs. As a quick fix I set filebeat to not forward workspace manager logs to kibana. 

Will make a DDO ticket to come up with a better longterm solution. Perhaps a flag so that only legacy(former GCE) apps deployed on k8s forward to kibana