### PR TITLE
[No ticket] More Logit Quota management

### DIFF
--- a/charts/filebeat/templates/daemonset.yaml
+++ b/charts/filebeat/templates/daemonset.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
 {{ include "filebeat.labels" . | indent 4 }}
 spec:
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -24,3 +24,5 @@ data:
                   kubernetes.pod.name: "^workspacemanager.*"
               - regexp:
                   kubernetes.pod.name: "^.*-cronjob-.*$"
+              - regexp:
+                  kubernetes.pod.name: "^terra-bufer.*"

--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -22,3 +22,5 @@ data:
                     kubernetes.namespace: terra-{{ required "a valid environment name is required ie: dev, perf, etc..." .Values.environmentName }}
               - regexp:
                   kubernetes.pod.name: "^workspacemanager.*"
+              - regexp:
+                  kubernetes.pod.name: "^.*-cronjob-.*$"


### PR DESCRIPTION
Even after disabling debug logging for cromiam, the main source of trouble for the logit quota 
since enabaling k8s log forward, we were still getting worryingly close to the quota each day.
After isolating a few causes of this namely the workspace manager proxy being set to debug 
and the leo cron jobs, it is best to just not forward to logit from anything that isn't a part
of gce terra.﻿
