### PR TITLE
DDO-963 Update default cert renewal interval

### DIFF
--- a/charts/buffer/README.md
+++ b/charts/buffer/README.md
@@ -1,15 +1,14 @@
-# buffer
-
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-
+buffer
+======
 Chart for Resource Buffering Service
 
-## Source Code
+Current chart version is `0.11.0`
 
-* <https://github.com/broadinstitute/terra-helm/tree/master/charts>
-* <https://github.com/DataBiosphere/terra-resource-buffer>
 
-## Values
+
+
+
+## Chart Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -19,7 +18,7 @@ Chart for Resource Buffering Service
 | certManager.enabled | bool | `false` | Enable to create certificate secret with cert-manager |
 | certManager.issuerKind | string | `"ClusterIssuer"` |  |
 | certManager.issuerName | string | `"cert-manager-letsencrypt-prod"` |  |
-| certManager.renewBefore | string | `"360h0m0s"` | When to renew the cert. Defaults to 15 days before expiry. |
+| certManager.renewBefore | string | `"720h0m0s"` | When to renew the cert. Defaults to 30 days before expiry. |
 | cleanupAfterHandout | bool | `false` | Whether to publish message to Janitor after resource is handed out. |
 | domain.hostname | string | `"buffer"` | Hostname of this deployment |
 | domain.namespaceEnv | bool | `true` | If true, an extra level of namespacing (`global.terraEnv`) will be added between the hostname and suffix |
@@ -28,12 +27,17 @@ Chart for Resource Buffering Service
 | global.trustedAddresses | object | `{}` | A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
-| imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/terra-buffer"` | Image repository |
+| imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/terra-resource-buffer"` | Image repository |
 | imageConfig.tag | string | The chart's appVersion value will be used | Image tag. |
 | proxy.enabled | bool | `true` |  |
 | proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Proxy image repository |
 | proxy.image.version | string | `"bernick_tcell"` | Proxy image tag |
 | proxy.logLevel | string | `"debug"` | Proxy log level |
+| proxy.tcell.enabled | bool | `true` | Enables TCell |
+| proxy.tcell.hostIdentifier | string | `nil` | Identifier used for logging to TCell. Required if proxy.tcell.enabled is true |
+| proxy.tcell.vaultPrefix | string | `nil` | Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true. |
+| proxy.whitelist.email | string | `nil` | Required if whitelisting is enabled. Email of buffer client Google service account |
+| proxy.whitelist.enabled | bool | `true` | Enables proxy client email whitelisting |
 | replicas | int | `1` |  |
 | serviceAllowedAddresses | object | `{}` | A map of addresses in the form `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | serviceFirewallEnabled | bool | `false` | Whether to restrict access to the service to the IPs supplied via serviceAllowedAddresses |

--- a/charts/buffer/values.yaml
+++ b/charts/buffer/values.yaml
@@ -59,8 +59,8 @@ certManager:
   enabled: false
   # certManager.duration -- Certificate duration. Defaults to 3 months.
   duration: 2160h0m0s
-  # certManager.renewBefore -- When to renew the cert. Defaults to 15 days before expiry.
-  renewBefore: 360h0m0s
+  # certManager.renewBefore -- When to renew the cert. Defaults to 30 days before expiry.
+  renewBefore: 720h0m0s
   issuerName: cert-manager-letsencrypt-prod
   issuerKind: ClusterIssuer
 vaultCert:

--- a/charts/crljanitor/README.md
+++ b/charts/crljanitor/README.md
@@ -2,7 +2,7 @@ crljanitor
 ==========
 Chart for Cloud Resource Manager Janitor
 
-Current chart version is `0.1.1`
+Current chart version is `0.1.11`
 
 
 
@@ -17,7 +17,8 @@ Current chart version is `0.1.1`
 | certManager.enabled | bool | `false` | Enable to create certificate secret with cert-manager |
 | certManager.issuerKind | string | `"ClusterIssuer"` |  |
 | certManager.issuerName | string | `"cert-manager-letsencrypt-prod"` |  |
-| certManager.renewBefore | string | `"360h0m0s"` | When to renew the cert. Defaults to 15 days before expiry. |
+| certManager.renewBefore | string | `"720h0m0s"` | When to renew the cert. Defaults to 30 days before expiry. |
+| configBasedAuthzEnabled | bool | `true` | Whether to use static file with admin users email for authorization. TODO(PF-81): Switch to use SAM instead of config file for user authZ. |
 | domain.hostname | string | `"crljanitor"` | Hostname of this deployment |
 | domain.namespaceEnv | bool | `true` | If true, an extra level of namespacing (`global.terraEnv`) will be added between the hostname and suffix |
 | domain.suffix | string | `"integ.envs.broadinstitute.org"` | Domain suffix |
@@ -25,7 +26,7 @@ Current chart version is `0.1.1`
 | global.trustedAddresses | object | `{}` | A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
-| imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/crl-janitor"` | Image repository |
+| imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/terra-resource-janitor"` | Image repository |
 | imageConfig.tag | string | The chart's appVersion value will be used | Image tag. |
 | proxy.enabled | bool | `true` |  |
 | proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Proxy image repository |
@@ -35,7 +36,9 @@ Current chart version is `0.1.1`
 | serviceAllowedAddresses | object | `{}` | A map of addresses in the form `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | serviceFirewallEnabled | bool | `false` | Whether to restrict access to the service to the IPs supplied via serviceAllowedAddresses |
 | serviceIP | string | `nil` | External IP of the service. Required. |
-| trackResourcePubsubEnabled | bool | `trus` | Enable pubsub to track resource. |
+| trackResourcePubsubEnabled | bool | `true` | Whether to enable using pubsub to receive new tracked resources. |
+| vault.adminUserFilePath | string | `"config/terra/crl-janitor/common/iam"` | (string) Vault path prefix for admin user list. Required if vault.enabled. Use the same users as admin for all env by default. Override if needed in helmfile repo. |
+| vault.configPathPrefix | string | `nil` | Vault path prefix for configs. Required if vault.enabled. |
 | vault.enabled | bool | `true` | When enabled, syncs required secrets from Vault |
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |
 | vaultCert.cert.path | string | `nil` | Path to secret containing .crt |

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -61,8 +61,8 @@ certManager:
   enabled: false
   # certManager.duration -- Certificate duration. Defaults to 3 months.
   duration: 2160h0m0s
-  # certManager.renewBefore -- When to renew the cert. Defaults to 15 days before expiry.
-  renewBefore: 360h0m0s
+  # certManager.renewBefore -- When to renew the cert. Defaults to 30 days before expiry.
+  renewBefore: 720h0m0s
   issuerName: cert-manager-letsencrypt-prod
   issuerKind: ClusterIssuer
 vaultCert:

--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -25,7 +25,7 @@ Chart for Terra Workspace Manager
 | ingress.cert.certManager.enabled | bool | `false` | Enable creating certificate secret with cert-manager |
 | ingress.cert.certManager.issuerKind | string | `"ClusterIssuer"` |  |
 | ingress.cert.certManager.issuerName | string | `"cert-manager-letsencrypt-prod"` |  |
-| ingress.cert.certManager.renewBefore | string | `"360h0m0s"` | When to renew the cert. Defaults to 15 days before expiry. |
+| ingress.cert.certManager.renewBefore | string | `"720h0m0s"` | When to renew the cert. Defaults to 30 days before expiry. |
 | ingress.cert.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |
 | ingress.cert.vault.cert.path | string | `nil` | Path to secret containing .crt |
 | ingress.cert.vault.cert.secretKey | string | `nil` | Key in secret containing .crt |
@@ -38,6 +38,7 @@ Chart for Terra Workspace Manager
 | ingress.domain.namespaceEnv | bool | `true` |  |
 | ingress.domain.suffix | string | `"integ.envs.broadinstitute.org"` |  |
 | ingress.enabled | bool | `true` | Whether to create Ingress, Service and associated config resources |
+| ingress.securityPolicy | string | `nil` | Name of a GCP Cloud Armor security policy |
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -101,8 +101,8 @@ ingress:
       enabled: false
       # ingress.cert.certManager.duration -- Certificate duration. Defaults to 3 months.
       duration: 2160h0m0s
-      # ingress.cert.certManager.renewBefore -- When to renew the cert. Defaults to 15 days before expiry.
-      renewBefore: 360h0m0s
+      # ingress.cert.certManager.renewBefore -- When to renew the cert. Defaults to 30 days before expiry.
+      renewBefore: 720h0m0s
       issuerName: cert-manager-letsencrypt-prod
       issuerKind: ClusterIssuer
 


### PR DESCRIPTION
Letsencrypt sends out warning emails 20 days before expiry, and our cert-manager certs for these charts are currently set to auto-renew 15 days before expiry. Changing that to 30 days to avoid the email spam.