### PR TITLE
Add back buffer.enabled flag. 

### DIFF
--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -1,22 +1,24 @@
-workspacemanager
-================
+# workspacemanager
 
 Chart for Terra Workspace Manager
 
-## Chart Requirements
+## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
 | https://broadinstitute.jfrog.io/broadinstitute/terra-helm-proxy | postgres | 0.1.0 |
 
-## Chart Values
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| buffer.clientCredentialPath | string | `nil` | the credentials to use for talking to buffer service. Required if enabled is true. |
+| buffer.enabled | bool | `false` | When enabled, use Buffer service to create projects. |
+| buffer.instanceUrl | string | `nil` | the Buffer Service instance to use in a given environment. |
+| buffer.poolId | string | `nil` | pool in Buffer Service to use. Must include version information and match a poolId in the buffer service config in the environment given above. |
 | cloudTraceEnabled | bool | `true` | Whether to enable gcp cloud trace |
 | global.applicationVersion | string | `"latest"` | What version of the application to deploy |
 | global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
-| googleFolderId | string | `nil` | the id of the Google Folder to create projects for workspaces within. |
 | image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/terra-kernel-k8s/terra-workspace-manager"` | Image repository |

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -165,12 +165,14 @@ spec:
           value: "{{ .Values.spendProfileId }}"
         - name: WORKSPACE_SPEND_SPENDPROFILES_0_BILLINGACCOUNTID
           value: "{{ .Values.spendBillingAccountId }}"
+        {{- if .Values.buffer.enabled }}
         - name: WORKSPACE_BUFFER_INSTANCE_URL
           value: "{{ .Values.buffer.instanceUrl }}"
         - name: WORKSPACE_BUFFER_POOL_ID
           value: "{{ .Values.buffer.poolId }}"
         - name: WORKSPACE_BUFFER_CLIENT_CREDENTIAL_FILE_PATH
           value: /secrets/app/buffer-client-sa.json
+        {{- end }}
         volumeMounts:
         - name: app-sa-creds
           mountPath: /secrets/app

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -151,8 +151,10 @@ spec:
       path: {{ .Values.vault.pathPrefix }}/workspace/app-sa
       encoding: base64
       key: key
+    {{- if .Values.buffer.enabled }}
     buffer-client-sa.json:
       path: {{required "Must have clientCredentialPath if buffer is enabled" .Values.buffer.clientCredentialPath }}
       encoding: base64
       key: key
+    {{ end }}
 {{ end }}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -41,9 +41,6 @@ vault:
   enabled: true
   # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
   pathPrefix:
-  # bufferClientCredentialPath - the credentials to use for talking to buffer service. Required once
-  # Workspace Manager always uses Buffer Service.
-  bufferClientCredentialPath:
 
 ingress:
   # ingress.enabled -- Whether to create Ingress, Service and associated config resources
@@ -154,11 +151,13 @@ prometheus:
   jmxJarVersion: '0.13.0'
 
 buffer:
-  # clientCredentialPath - the credentials to use for talking to buffer service. Required if enabled is true.
+  # buffer.enabled -- When enabled, use Buffer service to create projects.
+  enabled: false
+  # buffer.clientCredentialPath -- the credentials to use for talking to buffer service. Required if enabled is true.
   clientCredentialPath:
-  # instanceUrl - the Buffer Service instance to use in a given environment.
+  # buffer.instanceUrl -- the Buffer Service instance to use in a given environment.
   instanceUrl:
-  # poolId - pool in Buffer Service to use. Must include version information and match
+  # buffer.poolId -- pool in Buffer Service to use. Must include version information and match
   # a poolId in the buffer service config in the environment given above.
   poolId:
 
@@ -188,10 +187,3 @@ terraDataRepoUrl: https://jade.datarepo-dev.broadinstitute.org
 spendBillingAccountId:
 # spendProfileId -- the Spend Profile Id to associate with the billing account.
 spendProfileId:
-
-# bufferInstanceUrl - the Buffer Service instance to use in a given environment.
-bufferInstanceUrl: https://buffer.dsde-dev.broadinstitute.org
-
-# bufferPoolId - pool in Buffer Service to use. Must include version information and match
-# a poolId in the buffer service config in the environment given above.
-bufferPoolId: workspace_manager_v1


### PR DESCRIPTION
This is used to ensure we only sync secrets if they exist for buffer in the given environment. Not passed to the WSM Service.