### PR TITLE
DDO-1073 Enable toggle of security policy on ingress

### DIFF
--- a/charts/workspacemanager/templates/ingress/backendconfig.yaml
+++ b/charts/workspacemanager/templates/ingress/backendconfig.yaml
@@ -16,5 +16,5 @@ spec:
     port: 443
     requestPath: /status
   securityPolicy:
-    name: {{ .Values.ingress.securityPolicy }}
+    name: {{ quote .Values.ingress.securityPolicy }}
 {{- end }}

--- a/charts/workspacemanager/templates/ingress/backendconfig.yaml
+++ b/charts/workspacemanager/templates/ingress/backendconfig.yaml
@@ -15,8 +15,6 @@ spec:
     type: HTTPS
     port: 443
     requestPath: /status
-  {{- if .Values.ingress.securityPolicy }}
   securityPolicy:
     name: {{ .Values.ingress.securityPolicy }}
-  {{- end }}
 {{- end }}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -50,7 +50,7 @@ ingress:
   # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
   sslPolicy: null
   # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
-  securityPolicy: null
+  securityPolicy: ""
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -50,7 +50,7 @@ ingress:
   # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
   sslPolicy: null
   # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
-  securityPolicy: """"
+  securityPolicy: "\"\""
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -50,7 +50,7 @@ ingress:
   # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
   sslPolicy: null
   # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
-  securityPolicy: '""'
+  securityPolicy: ''
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -50,7 +50,7 @@ ingress:
   # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
   sslPolicy: null
   # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
-  securityPolicy: "\"\""
+  securityPolicy: ""
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -50,7 +50,7 @@ ingress:
   # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
   sslPolicy: null
   # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
-  securityPolicy: ""
+  securityPolicy: '""'
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -50,7 +50,7 @@ ingress:
   # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
   sslPolicy: null
   # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
-  securityPolicy: ''
+  securityPolicy: """"
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 


### PR DESCRIPTION
In order to make the security policy a toggle, it must always be specified in the backend 
config manifest and set to "" when a security policy is not desired. Other wise the cloud armor
policy will not be updated properly if the securityPolicy field is removed entirely

See [here](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#removing_the_configuration_specified_in_a_frontendconfig_or_backendconfig) for more info﻿
