### PR TITLE
[PF-457] Re-add buffer enabled flag to WSM app config

### DIFF
--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -165,6 +165,8 @@ spec:
           value: "{{ .Values.spendProfileId }}"
         - name: WORKSPACE_SPEND_SPENDPROFILES_0_BILLINGACCOUNTID
           value: "{{ .Values.spendBillingAccountId }}"
+        - name: WORKSPACE_BUFFER_ENABLED
+          value: "{{.Values.buffer.enabled }}"
         {{- if .Values.buffer.enabled }}
         - name: WORKSPACE_BUFFER_INSTANCE_URL
           value: "{{ .Values.buffer.instanceUrl }}"


### PR DESCRIPTION
The workspace.buffer.enabled flag was re-added in #290, but was not exposed to the WSM app. However, WSM also needs this value to handle status dependencies properly (see [PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/227))