### PR TITLE
Fix multiline stack trace handling

### DIFF
--- a/charts/filebeat/templates/config.yaml
+++ b/charts/filebeat/templates/config.yaml
@@ -17,6 +17,12 @@ data:
         # Reload module configs as they change:
         reload.enabled: false
 
+    # Handle JVM stackstraces
+    multiline.type: pattern
+    multiline.pattern: '^[[:space:]]+(at|\.{3})[[:space:]]+\b|^Caused by:'
+    multiline.negate: false
+    multiline.match: after
+
     processors:
       - add_cloud_metadata:
 


### PR DESCRIPTION
Multiline stack traces from k8s deployments were being split by line in kibana. This attempts to fix that﻿
