### PR TITLE
[No Ticket] Create a Service Account for Elasticsearch backup Cronjob

### DIFF
--- a/charts/elasticsearch/templates/backup/role.yaml
+++ b/charts/elasticsearch/templates/backup/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Values.name }}-backup-role
-  labels: {{ include "elasticsearch.labels". | nindent 4 }}
+  labels: {{ include "elasticsearch.labels" . | nindent 4 }}
 rules: 
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/charts/elasticsearch/templates/backup/role.yaml
+++ b/charts/elasticsearch/templates/backup/role.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.backup.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.name }}-backup-role
+  labels: {{ include "elasticsearch.labels". | nindent 4 }}
+rules: 
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - terra-default-psp
+{{ end -}}

--- a/charts/elasticsearch/templates/backup/roleBinding.yaml
+++ b/charts/elasticsearch/templates/backup/roleBinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.backup.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.name }}-backup-sa-binding
+  labels: {{ include "elasticsearch.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}-backup-sa
+roleRef:
+  kind: Role
+  name: {{ .Values.name }}-backup-role
+  apiGroup: rbac.authorization.k8s.io
+{{ end -}}

--- a/charts/elasticsearch/templates/backup/serviceAccount.yaml
+++ b/charts/elasticsearch/templates/backup/serviceAccount.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}-backup-sa
-  lables: {{ include "elasticsearch.labels" . | nindent 4 }}
+  labels: {{ include "elasticsearch.labels" . | nindent 4 }}
 {{ end -}}

--- a/charts/elasticsearch/templates/backup/serviceAccount.yaml
+++ b/charts/elasticsearch/templates/backup/serviceAccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}-backup-sa
+  lables: {{ include "elasticsearch.labels" . | nindent 4 }}
+{{ end -}}


### PR DESCRIPTION
Last night 3/2/21 The elastic search backup cronjob failed to schedule. I realized I forgot to make a service account for it.
This pr creates a service account for the backup cron to use.﻿
