### PR TITLE
DDO-1102 Alert if cronjob does not run in 24 hour period

### DIFF
--- a/charts/terra-prometheus/templates/rules/appRules.yaml
+++ b/charts/terra-prometheus/templates/rules/appRules.yaml
@@ -126,3 +126,11 @@ spec:
       for: 1h
       labels:
         severity: warning
+    - alert: CronJobNotRunning
+      annotations:
+        message: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete.
+        runbook_url: alert-name-kubejobfailed
+      expr: time() - kube_cronjob_status_last_schedule_time{job="kube-state-metrics"} > 86400
+      for: 2h
+      labels:
+        severity: warning


### PR DESCRIPTION
This pr configures an alert which looks at the last time each cronJob was successfully scheduled and compares to the current time. If greater than 24 hours have elapsed since the last successful scheduling, an alert will fire. There is a 2 hour buffer before the alert fires to accommodate for transient timing issues and avoid potential alert spam since most of our cronjobs are daily.﻿
