### PR TITLE
No Ticket Ensure ES backup can use Curl

### DIFF
--- a/charts/elasticsearch/templates/backup/cronjob.yaml
+++ b/charts/elasticsearch/templates/backup/cronjob.yaml
@@ -26,6 +26,7 @@ spec:
             command: ['sh', '-c']
             args:
             - |-
+              apk --no-cacher add curl && \
               TIMESTAMP=$( date +'%Y%m%d.%H%M%S' ) && \
               curl -X PUT "${ELASTICSEARCH_HOSTNAME}:9200/_snapshot/${SNAPSHOT_REPOSITORY}/es-snapshot-${TIMESTAMP}?wait_for_completion=true"
             env: 

--- a/charts/elasticsearch/templates/backup/cronjob.yaml
+++ b/charts/elasticsearch/templates/backup/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             command: ['sh', '-c']
             args:
             - |-
-              apk --no-cacher add curl && \
+              apk --no-cache add curl && \
               TIMESTAMP=$( date +'%Y%m%d.%H%M%S' ) && \
               curl -X PUT "${ELASTICSEARCH_HOSTNAME}:9200/_snapshot/${SNAPSHOT_REPOSITORY}/es-snapshot-${TIMESTAMP}?wait_for_completion=true"
             env: 


### PR DESCRIPTION
I realized that the ES backup cron was failing because curl is not included in the base alpine image. This is a quick fix to that issue. I had trouble finding a minimal base image that actually has `curl` Happy to take other recommendations if any one has them.