### PR TITLE
DDO-1125 Match GCE Elasticsearch Clustername

### DIFF
--- a/charts/elasticsearch/templates/backup/cronjob.yaml
+++ b/charts/elasticsearch/templates/backup/cronjob.yaml
@@ -26,6 +26,7 @@ spec:
             command: ['sh', '-c']
             args:
             - |-
+              apk --no-cacher add curl && \
               TIMESTAMP=$( date +'%Y%m%d.%H%M%S' ) && \
               curl -X PUT "${ELASTICSEARCH_HOSTNAME}:9200/_snapshot/${SNAPSHOT_REPOSITORY}/es-snapshot-${TIMESTAMP}?wait_for_completion=true"
             env: 

--- a/charts/elasticsearch/templates/backup/cronjob.yaml
+++ b/charts/elasticsearch/templates/backup/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             command: ['sh', '-c']
             args:
             - |-
-              apk --no-cacher add curl && \
+              apk --no-cache add curl && \
               TIMESTAMP=$( date +'%Y%m%d.%H%M%S' ) && \
               curl -X PUT "${ELASTICSEARCH_HOSTNAME}:9200/_snapshot/${SNAPSHOT_REPOSITORY}/es-snapshot-${TIMESTAMP}?wait_for_completion=true"
             env: 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -34,6 +34,8 @@ vault:
 # Documentation on these values can be found at https://github.com/elastic/helm-charts/tree/master/elasticsearch
 elasticsearch:
 
+  clusterName: elasticsearch5a # Use the same name as GCE terra elasticsearch
+
   image: "docker.io/broadinstitute/elasticsearch"
   imageTag: 5.4.0_6
 


### PR DESCRIPTION
Orchestration expects the elasticsearch cluster to be named elasticsearch5a.
Currently it is just elasticsearch. This pr fixes that

- ensure backup cron can use curl
- fix typo
- use same cluster name as GCE elasticsearch
