### PR TITLE
DDO-1125 Fix Cluster name for GKE Elasticsearch

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -34,6 +34,8 @@ vault:
 # Documentation on these values can be found at https://github.com/elastic/helm-charts/tree/master/elasticsearch
 elasticsearch:
 
+  clusterName: elasticsearch5a
+
   image: "docker.io/broadinstitute/elasticsearch"
   imageTag: 5.4.0_6
 


### PR DESCRIPTION
Orchestration expects the name of the elasticsearch it connects to to be `elasticsearch5a`
currently this chart uses the default of `elasticsearch`
﻿
