### PR TITLE
DDO-1132 Fix Tcell config for Buffer

### DIFF
--- a/charts/buffer/templates/configmaps/proxy-tcell-configmap.yaml
+++ b/charts/buffer/templates/configmaps/proxy-tcell-configmap.yaml
@@ -11,8 +11,6 @@ data:
       "version": 1,
       "applications": [
         {
-          "app_id": "$(TCELL_APP_ID)",
-          "api_key": "$(TCELL_API_KEY)",
           "tcell_api_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
           "tcell_input_url": "https://us.input.tcell.insight.rapid7.com/api/v1",
           "js_agent_api_base_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",

--- a/charts/buffer/templates/configmaps/proxy-tcell-configmap.yaml
+++ b/charts/buffer/templates/configmaps/proxy-tcell-configmap.yaml
@@ -11,6 +11,8 @@ data:
       "version": 1,
       "applications": [
         {
+          "app_id": "$(TCELL_APP_ID)",
+          "api_key": "$(TCELL_API_KEY)",
           "tcell_api_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
           "tcell_input_url": "https://us.input.tcell.insight.rapid7.com/api/v1",
           "js_agent_api_base_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",

--- a/charts/buffer/templates/deployment.yaml
+++ b/charts/buffer/templates/deployment.yaml
@@ -188,12 +188,12 @@ spec:
         - name: REMOTE_USER_CLAIM
           value: sub
         {{- if .Values.proxy.tcell.enabled }}
-        - name: TCELL_APP_ID
+        - name: TCELL_AGENT_APP_ID
           valueFrom:
             secretKeyRef:
               name: {{ .Values.name }}-proxy-tcell-secrets
               key: app-id
-        - name: TCELL_API_KEY
+        - name: TCELL_AGENT_API_KEY
           valueFrom:
             secretKeyRef:
               name: {{ .Values.name }}-proxy-tcell-secrets

--- a/charts/buffer/values.yaml
+++ b/charts/buffer/values.yaml
@@ -132,7 +132,7 @@ proxy:
     # proxy.image.repository -- Proxy image repository
     repository: broadinstitute/openidc-proxy
     # proxy.image.version -- Proxy image tag
-    version: bernick_tcell
+    version: tcell_3_1_0 
   tcell:
     # proxy.tcell.enabled -- Enables TCell
     enabled: true


### PR DESCRIPTION
This pr includes fixes so that buffer's apache proxy is able to be properly monitored by tcell, one of the blockers for RBS going to prod.
Changes:
1. Update buffer's proxy to use the latest image `broadinstitute/openidc-proxy:tcell_3_1_0`. This is identical to the previous proxy image other than that it is using the latest version of tcell.
2. Rename the environment variables containing the tcell api key and app id. The latest version of tcell can read these values directly from the environment rather than trying to inject them into the config file as bash variables, which doesn't actually work. [more info](https://docs.tcell.io/docs/server-agent-options#section-environment-variables-and-config-file-properties)