### PR TITLE
PF-568 Deprecate the serviceGoogleProject WM  helm value

### DIFF
--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -88,7 +88,7 @@ Chart for Terra Workspace Manager
 | resources.requests.memory | string | `"8Gi"` | Memory to request for the deployment |
 | samAddress | string | `"https://sam.dsde-dev.broadinstitute.org/"` | Address of SAM instance this deploy will talk to |
 | samplingProbability | float | `1` | the frequency with which calls should be traced. |
-| serviceGoogleProject | string | `"broad-dsde-dev"` | the id of the google project which the instance is associated with |
+| serviceGoogleProject | string | `"deprecated"` | Deprecated. TODO(PF-568) remove me when safe. |
 | spendBillingAccountId | string | `nil` | the Google Billing account Id for WSM to use for workspace projects. |
 | spendProfileId | string | `nil` | the Spend Profile Id to associate with the billing account. |
 | terraDataRepoUrl | string | `"https://jade.datarepo-dev.broadinstitute.org"` | corresponding data repo instance for the environment |

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -149,8 +149,6 @@ spec:
         {{- end }}
         - name: SAM_ADDRESS
           value: {{ .Values.samAddress }}
-        - name: SERVICE_GOOGLE_PROJECT
-          value: {{ .Values.serviceGoogleProject }}
         - name: SAMPLING_PROBABILITY
           value: "{{ .Values.samplingProbability }}"
         - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -200,8 +200,8 @@ initDB: false
 # samAddress -- Address of SAM instance this deploy will talk to
 samAddress: https://sam.dsde-dev.broadinstitute.org/
 
-# serviceGoogleProject -- the id of the google project which the instance is associated with
-serviceGoogleProject: broad-dsde-dev
+# serviceGoogleProject -- Deprecated. TODO(PF-568) remove me when safe.
+serviceGoogleProject: deprecated
 
 # samplingProbability -- the frequency with which calls should be traced.
 samplingProbability: 1.0


### PR DESCRIPTION
No longer used in WM as of https://github.com/DataBiosphere/terra-workspace-manager/pull/248