### PR TITLE
DDO-1147 Add 3-hour startupProbe to Leo

### DIFF
--- a/charts/leonardo/README.md
+++ b/charts/leonardo/README.md
@@ -12,16 +12,18 @@ A Helm chart for Leonardo, Terra's Jupyter notebook integration service
 | commonCronjob.reportDestinationBucket | string | `nil` |  |
 | cronjob.googleProject | string | `nil` |  |
 | cronjob.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/resource-validator"` |  |
-| cronjob.imageTag | string | `"ed126d1"` |  |
+| cronjob.imageTag | string | `"59b370b"` |  |
 | cronjob.name | string | `"leonardo-resource-validator-cronjob"` |  |
 | deploymentDefaults.enabled | bool | `true` | Whether a declared deployment is enabled. If false, no resources will be created |
 | deploymentDefaults.imageRepository | string | `"gcr.io/broad-dsp-gcr-public/leonardo"` | Image repo to pull Leonardo images from |
 | deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @default global.applicationVersion |
 | deploymentDefaults.name | Required | `nil` | A name for the deployment that will be substituted into resource definitions. Example: `"leonardo-backend"`. The deployment name will be substituted into Deployment and ConfigMap names.   Eg. "leonardo-frontend" -> "leonardo-frontend-deployment", "leonardo-frontend-cm" |
-| deploymentDefaults.probes.liveness.enabled | bool | `false` |  |
+| deploymentDefaults.probes.liveness.enabled | bool | `true` |  |
 | deploymentDefaults.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/version","port":8080},"initialDelaySeconds":15,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the liveness probe to deploy, if enabled |
 | deploymentDefaults.probes.readiness.enabled | bool | `true` |  |
 | deploymentDefaults.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/status","port":8080},"initialDelaySeconds":15,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the readiness probe to deploy, if enabled |
+| deploymentDefaults.probes.startup.enabled | bool | `true` |  |
+| deploymentDefaults.probes.startup.spec | object | `{"failureThreshold":1080,"httpGet":{"path":"/version","port":8080},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the liveness probe to deploy, if enabled |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deployments.standalone.name | string | `"leonardo"` | Name to use for the default standalone Leonardo deployment |
 | deployments.standalone.replicas | int | `1` | Number of replicas in the default standalone Leonardo deployment |
@@ -35,5 +37,5 @@ A Helm chart for Leonardo, Terra's Jupyter notebook integration service
 | monitoring.enabled | bool | `true` | Whether to enable Prometheus monitoring for Leonardo pods |
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |
 | zombieMonitorCron.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/zombie-monitor"` |  |
-| zombieMonitorCron.imageTag | string | `"5188eb3"` |  |
+| zombieMonitorCron.imageTag | string | `"59b370b"` |  |
 | zombieMonitorCron.name | string | `"leonardo-zombie-monitor-cronjob"` |  |

--- a/charts/leonardo/templates/deployments/_deployment.tpl
+++ b/charts/leonardo/templates/deployments/_deployment.tpl
@@ -103,7 +103,7 @@ spec:
         - mountPath: /etc/jupyter-server.crt
           subPath: jupyter-server.crt
           readOnly: true
-          name: app-ctmpls        
+          name: app-ctmpls
         - mountPath: /leonardo/terra-app-setup/tls.crt
           subPath: jupyter-server.crt
           readOnly: true
@@ -111,7 +111,7 @@ spec:
         - mountPath: /etc/jupyter-server.key
           subPath: jupyter-server.key
           readOnly: true
-          name: app-ctmpls        
+          name: app-ctmpls
         - mountPath: /leonardo/terra-app-setup/tls.key
           subPath: jupyter-server.key
           readOnly: true
@@ -127,7 +127,7 @@ spec:
         - mountPath: /etc/rootCA.pem
           subPath: rootCA.pem
           readOnly: true
-          name: app-ctmpls       
+          name: app-ctmpls
         - mountPath: /leonardo/terra-app-setup/ca.crt
           subPath: rootCA.pem
           readOnly: true
@@ -155,6 +155,10 @@ spec:
         {{- if $settings.probes.liveness.enabled }}
         livenessProbe:
           {{- toYaml $settings.probes.liveness.spec | nindent 10 }}
+        {{- end }}
+        {{- if $settings.probes.startup.enabled }}
+        startupProbe:
+          {{- toYaml $settings.probes.startup.spec | nindent 10 }}
         {{- end }}
       - name: {{ $settings.name }}-proxy
         image: broadinstitute/openidc-proxy:tcell-mpm-big

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -48,7 +48,7 @@ deploymentDefaults:
     startup:
       # deploymentDefaults.probes.startup.enable -- Whether to configure a startup probe
       enabled: true
-      # deploymentDefaults.probes.startup.spec -- k8s spec of the liveness probe to deploy, if enabled
+      # deploymentDefaults.probes.startup.spec -- k8s spec of the startup probe to deploy, if enabled
       spec:
         httpGet:
           path: /version

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -45,6 +45,18 @@ deploymentDefaults:
         periodSeconds: 10
         failureThreshold: 30 # 5 minutes before restarted
         successThreshold: 1
+    startup:
+      # deploymentDefaults.probes.startup.enable -- Whether to configure a startup probe
+      enabled: true
+      # deploymentDefaults.probes.startup.spec -- k8s spec of the liveness probe to deploy, if enabled
+      spec:
+        httpGet:
+          path: /version
+          port: 8080
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 1080 # 3 hours before restarted, to prevent liveness probes from interrupting long-running liquibase migrations
+        successThreshold: 1
 # A map of Leonardo deployments. In Terra's production environment,
 # Leonardo is deployed as two services (backend and frontend)
 # with different configurations.


### PR DESCRIPTION
Currently, we've configured Leo with a 5-minute liveness probe. This means that if Leo's `/version` endpoint ever stops responding, after 5 minutes Kubernetes will restart the pod, saving the on-call engineer from being paged and having to restart the pod manually.

This is useful, but poses a problem for Liquibase migrations. Leo's `/version` endpoint does not start returning 200s until Liquibase migrations have finished; in the event a migration takes longer than 5 minutes, Kubernetes will kill the pod and potentially leave the database in a half-migrated state. (See [this thread](https://broadinstitute.slack.com/archives/C01E2DDTGQG/p1615304704000800) from a few weeks ago where the first statement of a migration was executed, but not the second, and I had to manually fix up the database to get Leo to start up.)

This PR adds a 3-hour [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/), also on the /version endpoint. This way:
* we still get auto-restart behavior from Kubernetes liveness probes
* database migrations will only be interrupted if they exceed 3 hours

Props to @gmalkov for the elegant probe config pattern!