### PR TITLE
[DUOS-1029][risk=no] Remove sentry from consent/ontology deployments

### DIFF
--- a/charts/consent/templates/_consent.yaml.tpl
+++ b/charts/consent/templates/_consent.yaml.tpl
@@ -19,10 +19,6 @@ logging:
       target: stdout
       layout:
         type: json
-    - type: sentry
-      dsn: https://foo:bar@sentry.io/baz {{/* Override on the command line */}}
-      threshold: ERROR
-      environment: {{ .Values.environment }}
   loggers:
     "org.reflections.Reflections": ERROR
     "org.apache.pdfbox": ERROR

--- a/charts/consent/templates/deployment.yaml
+++ b/charts/consent/templates/deployment.yaml
@@ -43,11 +43,6 @@ spec:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false
           env:
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Chart.Name }}-secrets
-                  key: dsn
             - name: PROMETHEUS_ARGS
               value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/consent-cm/prometheusJmx.yaml"
             - name: BASIC_AUTH_USER
@@ -77,8 +72,6 @@ spec:
                   key: sendgridApiKey
           command: ["java"]
           args:
-          - -Dsentry.stacktrace.app.packages=org.broadinstitute
-          - -Dsentry.dsn=$(SENTRY_DSN)
           - -Ddw.basicAuthentication.users[0].user=$(BASIC_AUTH_USER)
           - -Ddw.basicAuthentication.users[0].password=$(BASIC_AUTH_USER_PASSWORD)
           - -Ddw.database.user=$(DB_USER)

--- a/charts/ontology/templates/_ontology.yaml.tpl
+++ b/charts/ontology/templates/_ontology.yaml.tpl
@@ -19,10 +19,6 @@ logging:
       target: stdout
       layout:
         type: json
-    - type: sentry
-      dsn: https://foo:bar@sentry.io/baz {{/* Override on the command line */}}
-      threshold: ERROR
-      environment: {{ .Values.environment }}
   loggers:
     "org.semanticweb": ERROR
 elasticSearch:

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -42,22 +42,15 @@ spec:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false
           env:
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Chart.Name }}-secrets
-                  key: dsn
             - name: PROMETHEUS_ARGS
               value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/ontology-cm/prometheusJmx.yaml"
           command: ["java"]
           args:
-          - -Dsentry.stacktrace.app.packages=org.broadinstitute
-          - -Dsentry.dsn=$(SENTRY_DSN)
           - $(PROMETHEUS_ARGS)
-          - -jar 
-          - /opt/consent-ontology.jar 
-          - server 
-          - /etc/ontology-cm/ontology.yaml 
+          - -jar
+          - /opt/consent-ontology.jar
+          - server
+          - /etc/ontology-cm/ontology.yaml
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1029

Removes all sentry configs from consent/ontology. All logging should go straight to GCP.
This will require follow-on PRs to remove the sentry values from the helmfile and finally, removing the sentry logging checks from the consent and ontology apps.