### PR TITLE
DUOS-1124 Move admin endpoints to private port

### DIFF
--- a/charts/consent/Chart.yaml
+++ b/charts/consent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consent
-version: 0.10.0
+version: 0.10.1
 type: application
 description: A Helm chart for DUOS Consent
 keywords:

--- a/charts/consent/templates/_consent.yaml.tpl
+++ b/charts/consent/templates/_consent.yaml.tpl
@@ -3,9 +3,12 @@ server:
   type: simple
   applicationContextPath: /
   adminContextPath: /admin
-  connector:
-    type: http
-    port: 8080
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
   requestLog:
     appenders:
       - type: console

--- a/charts/consent/templates/_consent.yaml.tpl
+++ b/charts/consent/templates/_consent.yaml.tpl
@@ -1,6 +1,5 @@
 {{- define "consent.config.yaml" -}}
 server:
-  type: simple
   applicationContextPath: /
   adminContextPath: /admin
   applicationConnectors:

--- a/charts/consent/templates/deployment.yaml
+++ b/charts/consent/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+            - name: admin
+              containerPort: 8081
+              protocol: TCP
             - name: metrics
               containerPort: 9090
               protocol: TCP

--- a/charts/ontology/Chart.yaml
+++ b/charts/ontology/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ontology
-version: 0.9.0
+version: 0.9.1
 type: application
 description: A Helm chart for DUOS Ontology, the DUOS Algorithmic Matching System
 keywords:

--- a/charts/ontology/templates/_ontology.yaml.tpl
+++ b/charts/ontology/templates/_ontology.yaml.tpl
@@ -3,9 +3,12 @@ server:
   type: simple
   applicationContextPath: /
   adminContextPath: /admin
-  connector:
-    type: http
-    port: 8080
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
   requestLog:
     appenders:
       - type: console

--- a/charts/ontology/templates/_ontology.yaml.tpl
+++ b/charts/ontology/templates/_ontology.yaml.tpl
@@ -1,6 +1,5 @@
 {{- define "ontology.config.yaml" -}}
 server:
-  type: simple
   applicationContextPath: /
   adminContextPath: /admin
   applicationConnectors:

--- a/charts/ontology/templates/deployment.yaml
+++ b/charts/ontology/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+            - name: admin
+              containerPort: 8081
+              protocol: TCP
             - name: metrics
               containerPort: 9090
               protocol: TCP
@@ -54,10 +57,10 @@ spec:
           - -Dsentry.stacktrace.app.packages=org.broadinstitute
           - -Dsentry.dsn=$(SENTRY_DSN)
           - $(PROMETHEUS_ARGS)
-          - -jar 
-          - /opt/consent-ontology.jar 
-          - server 
-          - /etc/ontology-cm/ontology.yaml 
+          - -jar
+          - /opt/consent-ontology.jar
+          - server
+          - /etc/ontology-cm/ontology.yaml
           volumeMounts:
             - name: configs
               mountPath: /etc/ontology-cm


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1124

Move the exposed admin endpoint to a different port, `8081`.

TODO: ~Ensure that the new port is not exposed outside the cluster.~ Done.