### PR TITLE
DDO-1105 Helm chart for Job Manager

### DIFF
--- a/charts/jobmanager/Chart.yaml
+++ b/charts/jobmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: jobmanager
-version: 0.1.0
+version: 0.2.0
 description: Chart for Job Manager service in Terra
 type: application
 keywords:

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -5,4 +5,40 @@ Chart for Job Manager service in Terra
 
 
 
+## Chart Values
 
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| api.imageConfig.imagePullPolicy | string | `"Always"` |  |
+| api.imageConfig.repository | string | `"databiosphere/job-manager-api-cromwell"` | Image repository |
+| api.imageConfig.tag | string | global.applicationVersion | Image tag. |
+| api.probes.liveness.enabled | bool | `true` |  |
+| api.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
+| api.probes.readiness.enabled | bool | `true` |  |
+| api.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
+| api.resources.limits.cpu | int | `2` | Number of CPU units to limit the deployment to |
+| api.resources.limits.memory | string | `"2Gi"` | Memory to limit the deployment to |
+| api.resources.requests.cpu | int | `2` | Number of CPU units to request for the deployment |
+| api.resources.requests.memory | string | `"2Gi"` | Memory to request for the deployment |
+| global.applicationVersion | string | `"latest"` | What version of the jobmanager application to deploy |
+| ingress.enabled | bool | `true` | Whether to create Ingress and associated Service, FrontendConfig and BackendConfig |
+| ingress.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |
+| ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
+| ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
+| ingress.timeoutSec | int | `120` | Load balancer backend timeout |
+| name | string | `"jobmanager"` | Name for this deployment |
+| proxy.imageConfig.imagePullPolicy | string | `"Always"` |  |
+| proxy.imageConfig.repository | string | `"broadinstitute/openidc-proxy"` | Image repository |
+| proxy.imageConfig.tag | string | `"modsecurity_2_9_2"` | (string) Image tag. |
+| replicas | int | `3` | Number of API replicas to spin up in the deployment |
+| ui.imageConfig.imagePullPolicy | string | `"Always"` |  |
+| ui.imageConfig.repository | string | `"databiosphere/job-manager-ui"` | Image repository |
+| ui.imageConfig.tag | string | global.applicationVersion | Image tag. |
+| ui.probes.liveness.enabled | bool | `true` |  |
+| ui.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/health","port":443},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
+| ui.probes.readiness.enabled | bool | `true` |  |
+| ui.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/health","port":443},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
+| ui.resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
+| ui.resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |
+| ui.resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
+| ui.resources.requests.memory | string | `"4Gi"` | Memory to request for the deployment |

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -15,10 +15,10 @@ Chart for Job Manager service in Terra
 | api.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
 | api.probes.readiness.enabled | bool | `true` |  |
 | api.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
-| api.resources.limits.cpu | int | `2` | Number of CPU units to limit the deployment to |
-| api.resources.limits.memory | string | `"2Gi"` | Memory to limit the deployment to |
-| api.resources.requests.cpu | int | `2` | Number of CPU units to request for the deployment |
-| api.resources.requests.memory | string | `"2Gi"` | Memory to request for the deployment |
+| api.resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
+| api.resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |
+| api.resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
+| api.resources.requests.memory | string | `"4Gi"` | Memory to request for the deployment |
 | global.applicationVersion | string | `"latest"` | What version of the jobmanager application to deploy |
 | ingress.enabled | bool | `true` | Whether to create Ingress and associated Service, FrontendConfig and BackendConfig |
 | ingress.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -9,9 +9,8 @@ Chart for Job Manager service in Terra
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| api.imageConfig.imagePullPolicy | string | `"Always"` |  |
-| api.imageConfig.repository | string | `"databiosphere/job-manager-api-cromwell"` | Image repository |
-| api.imageConfig.tag | string | global.applicationVersion | Image tag. |
+| api.image.repository | string | `"databiosphere/job-manager-api-cromwell"` |  |
+| api.image.tag | string | `nil` |  |
 | api.probes.liveness.enabled | bool | `true` |  |
 | api.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
 | api.probes.readiness.enabled | bool | `true` |  |
@@ -27,17 +26,15 @@ Chart for Job Manager service in Terra
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` | Load balancer backend timeout |
 | name | string | `"jobmanager"` | Name for this deployment |
-| proxy.imageConfig.imagePullPolicy | string | `"Always"` |  |
-| proxy.imageConfig.repository | string | `"broadinstitute/openidc-proxy"` | Image repository |
-| proxy.imageConfig.tag | string | `"modsecurity_2_9_2"` | (string) Image tag. |
+| proxy.image.repository | string | `"broadinstitute/openidc-proxy"` |  |
+| proxy.image.tag | string | `"modsecurity_2_9_2"` |  |
 | replicas | int | `3` | Number of API replicas to spin up in the deployment |
-| ui.imageConfig.imagePullPolicy | string | `"Always"` |  |
-| ui.imageConfig.repository | string | `"databiosphere/job-manager-ui"` | Image repository |
-| ui.imageConfig.tag | string | global.applicationVersion | Image tag. |
+| ui.image.repository | string | `"databiosphere/job-manager-ui"` |  |
+| ui.image.tag | string | `nil` |  |
 | ui.probes.liveness.enabled | bool | `true` |  |
-| ui.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/health","port":443},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
+| ui.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/health","port":8000},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
 | ui.probes.readiness.enabled | bool | `true` |  |
-| ui.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/health","port":443},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
+| ui.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/health","port":8000},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
 | ui.resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
 | ui.resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |
 | ui.resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -9,8 +9,8 @@ Chart for Job Manager service in Terra
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| api.image.repository | string | `"databiosphere/job-manager-api-cromwell"` |  |
-| api.image.tag | string | `nil` |  |
+| api.image.repository | string | `"databiosphere/job-manager-api-cromwell"` | Image repository |
+| api.image.tag | string | global.applicationVersion | Image tag. |
 | api.probes.liveness.enabled | bool | `true` |  |
 | api.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
 | api.probes.readiness.enabled | bool | `true` |  |
@@ -26,11 +26,11 @@ Chart for Job Manager service in Terra
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` | Load balancer backend timeout |
 | name | string | `"jobmanager"` | Name for this deployment |
-| proxy.image.repository | string | `"broadinstitute/openidc-proxy"` |  |
-| proxy.image.tag | string | `"modsecurity_2_9_2"` |  |
+| proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Image repository |
+| proxy.image.tag | string | `"modsecurity_2_9_2"` | (string) Image tag. |
 | replicas | int | `3` | Number of API replicas to spin up in the deployment |
-| ui.image.repository | string | `"databiosphere/job-manager-ui"` |  |
-| ui.image.tag | string | `nil` |  |
+| ui.image.repository | string | `"databiosphere/job-manager-ui"` | Image repository |
+| ui.image.tag | string | global.applicationVersion | Image tag. |
 | ui.probes.liveness.enabled | bool | `true` |  |
 | ui.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/health","port":8000},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for liveness probe |
 | ui.probes.readiness.enabled | bool | `true` |  |

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -16,9 +16,9 @@ Chart for Job Manager service in Terra
 | api.probes.readiness.enabled | bool | `true` |  |
 | api.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/health","port":8190},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
 | api.resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
-| api.resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |
+| api.resources.limits.memory | string | `"3.6Gi"` | Memory to limit the deployment to |
 | api.resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
-| api.resources.requests.memory | string | `"4Gi"` | Memory to request for the deployment |
+| api.resources.requests.memory | string | `"3.6Gi"` | Memory to request for the deployment |
 | global.applicationVersion | string | `"latest"` | What version of the jobmanager application to deploy |
 | ingress.enabled | bool | `true` | Whether to create Ingress and associated Service, FrontendConfig and BackendConfig |
 | ingress.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |
@@ -36,6 +36,6 @@ Chart for Job Manager service in Terra
 | ui.probes.readiness.enabled | bool | `true` |  |
 | ui.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/health","port":8000},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes spec for readiness probe |
 | ui.resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
-| ui.resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |
+| ui.resources.limits.memory | string | `"3.6Gi"` | Memory to limit the deployment to |
 | ui.resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
-| ui.resources.requests.memory | string | `"4Gi"` | Memory to request for the deployment |
+| ui.resources.requests.memory | string | `"3.6Gi"` | Memory to request for the deployment |

--- a/charts/jobmanager/templates/_labels.tpl
+++ b/charts/jobmanager/templates/_labels.tpl
@@ -1,0 +1,14 @@
+{{- /*
+Create labels to use for resources in this chart
+
+See
+https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+*/ -}}
+{{- define "jobmanager.labels" -}}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/component: {{ .Values.name }}
+app.kubernetes.io/part-of: terra
+{{- end -}}

--- a/charts/jobmanager/templates/configmap.yaml
+++ b/charts/jobmanager/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-cm
+  labels:
+{{ include "jobmanager.labels" . | indent 4 }}
+# No data yet

--- a/charts/jobmanager/templates/configmap.yaml
+++ b/charts/jobmanager/templates/configmap.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.name }}-cm
-  labels:
-{{ include "jobmanager.labels" . | indent 4 }}
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
 # No data yet

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           subPath: ui-config.json
           name: ui-ctmpls
         - mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.json # TODO rename to nginx.conf when templates are moved out of firecloud-develop
+          subPath: nginx.json # TODO rename to nginx.conf when templates are moved out of firecloud-develop?
           name: ui-ctmpls
         # Note: These readiness settings only apply to Kubernetes' internal load
         # balancing mechanism -- there's a separate health check setting for
@@ -148,7 +148,7 @@ spec:
         - mountPath: /etc/apache2/sites-enabled/mod_security_logging.conf
           subPath: mod_security_logging.conf
           name: proxy-ctmpls
-        - mountPath: /etc/apache2/sites-enabled/mod_security_ignore.conf
+        - mountPath: /etc/modsecurity/mod_security_ignore.conf
           subPath: mod_security_ignore.conf
           name: proxy-ctmpls
         - mountPath: /etc/apache2/tcell_agent.config

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}-deployment
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: 0
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      deployment: {{ .Values.name }}-deployment
+  template:
+    metadata:
+      labels:
+        deployment: {{ .Values.name }}-deployment
+        {{- include "jobmanager.labels" . | nindent 8 }}
+      annotations:
+        {{- /* Automatically restart deployments on config map change: */}}
+        checksum/{{ .Values.name }}-cm: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Values.name }}-sa
+      # Containers are configured to talk to each other by name
+      # via docker-compose links; make corresponding aliases
+      # to loopback in /etc/hosts
+      hostAliases:
+      - ip: 127.0.0.1
+        hostnames:
+        - ui
+        - api
+      volumes:
+      - name: ui-ctmpls
+        secret:
+          secretName: {{ .Values.name }}-ui-ctmpls
+      - name: api-ctmpls
+        secret:
+          secretName: {{ .Values.name }}-api-ctmpls
+      - name: proxy-ctmpls
+        secret:
+          secretName: {{ .Values.name }}-proxy-ctmpls
+      - name: {{ .Values.name }}-modsecurity-logs
+        emptyDir: {}
+      containers:
+      - name: {{ .Values.name }}-api
+        image: "{{ .Values.api.imageRepository }}:{{ .Values.api.imageTag | default .Values.global.applicationVersion }}"
+        ports:
+        - containerPort: 8190
+        resources: # Mimic existing GCE vm requirements
+          requests:
+            cpu: {{ .Values.api.resources.requests.cpu }}
+            memory: {{ .Values.api.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.api.resources.limits.cpu }}
+            memory: {{ .Values.api.resources.limits.memory }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.name }}-api-env
+        env:
+        # Make node, pod name accessible to app as env vars
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - mountPath: /etc/api-config.json
+          subPath: api-config.json
+          name: api-ctmpls
+        - mountPath: /etc/capabilities-config.json
+          subPath: capabilities-config.json
+          name: api-ctmpls
+        # Note: These readiness settings only apply to Kubernetes' internal load
+        # balancing mechanism -- there's a separate health check setting for
+        # Agora's Ingress / GCP load balancer in the Ingress's backendConfig
+        {{- if .Values.probes.readiness.enabled }}
+        readinessProbe:
+          {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
+        {{- end }}
+        {{- if .Values.probes.liveness.enabled }}
+        livenessProbe:
+          {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
+        {{- end }}
+      - name: {{ .Values.name }}-ui
+        image: "{{ .Values.ui.imageRepository }}:{{ .Values.ui.imageTag | default .Values.global.applicationVersion }}"
+        ports:
+        - containerPort: 443
+        resources: # Mimic existing GCE vm requirements
+          requests:
+            cpu: {{ .Values.ui.resources.requests.cpu }}
+            memory: {{ .Values.ui.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.ui.resources.limits.cpu }}
+            memory: {{ .Values.ui.resources.limits.memory }}
+        env:
+        # Make node, pod name accessible to app as env vars
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - mountPath: /app/ui-config.json:/ui/dist/assets/environments/environment.json
+          subPath: ui-config.json
+          name: ui-ctmpls
+        - mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+          name: ui-ctmpls
+        # Note: These readiness settings only apply to Kubernetes' internal load
+        # balancing mechanism -- there's a separate health check setting for
+        # Agora's Ingress / GCP load balancer in the Ingress's backendConfig
+        {{- if .Values.ui.probes.readiness.enabled }}
+        readinessProbe:
+          {{- toYaml .Values.ui.probes.readiness.spec | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ui.probes.liveness.enabled }}
+        livenessProbe:
+          {{- toYaml .Values.ui.probes.liveness.spec | nindent 10 }}
+        {{- end }}
+      - name: {{ .Values.name }}-proxy
+        image: "{{ .Values.proxy.imageRepository }}:{{ .Values.proxy.imageTag }}"
+        ports:
+          - containerPort: 443
+          - containerPort: 80
+          - containerPort: 8888
+        envFrom:
+        - secretRef:
+            name: {{ .Values.name }}-proxy-env
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/server.crt
+          subPath: server.crt
+          name: proxy-ctmpls
+        - mountPath: /etc/ssl/private/server.key
+          subPath: server.key
+          name: proxy-ctmpls
+        - mountPath: /etc/ssl/certs/ca-bundle.crt
+          subPath: ca-bundle.crt
+          name: proxy-ctmpls
+        - mountPath: /etc/apache2/sites-enabled/mod_security_logging.conf
+          subPath: mod_security_logging.conf
+          name: proxy-ctmpls
+        - mountPath: /etc/apache2/sites-enabled/mod_security_ignore.conf
+          subPath: mod_security_ignore.conf
+          name: proxy-ctmpls
+        - mountPath: /etc/apache2/tcell_agent.config
+          subPath: tcell_agent.config
+          name: proxy-ctmpls
+        - mountPath: /etc/apache2/sites-available/site.conf
+          subPath: site.conf
+          name: proxy-ctmpls
+        - mountPath: /var/log/modsecurity
+          name: {{ .Values.name }}-modsecurity-logs

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         emptyDir: {}
       containers:
       - name: {{ .Values.name }}-api
-        image: "{{ .Values.api.imageRepository }}:{{ .Values.api.imageTag | default .Values.global.applicationVersion }}"
+        image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.global.applicationVersion }}"
         ports:
         - containerPort: 8190
         resources: # Mimic existing GCE vm requirements
@@ -88,7 +88,7 @@ spec:
           {{- toYaml .Values.api.probes.liveness.spec | nindent 10 }}
         {{- end }}
       - name: {{ .Values.name }}-ui
-        image: "{{ .Values.ui.imageRepository }}:{{ .Values.ui.imageTag | default .Values.global.applicationVersion }}"
+        image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.global.applicationVersion }}"
         ports:
         - containerPort: 443
         resources: # Mimic existing GCE vm requirements

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -79,13 +79,13 @@ spec:
         # Note: These readiness settings only apply to Kubernetes' internal load
         # balancing mechanism -- there's a separate health check setting for
         # the Ingress / GCP load balancer in the Ingress's backendConfig
-        {{- if .Values.probes.readiness.enabled }}
+        {{- if .Values.api.probes.readiness.enabled }}
         readinessProbe:
-          {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
+          {{- toYaml .Values.api.probes.readiness.spec | nindent 10 }}
         {{- end }}
-        {{- if .Values.probes.liveness.enabled }}
+        {{- if .Values.api.probes.liveness.enabled }}
         livenessProbe:
-          {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
+          {{- toYaml .Values.api.probes.liveness.spec | nindent 10 }}
         {{- end }}
       - name: {{ .Values.name }}-ui
         image: "{{ .Values.ui.imageRepository }}:{{ .Values.ui.imageTag | default .Values.global.applicationVersion }}"

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -127,7 +127,7 @@ spec:
           {{- toYaml .Values.ui.probes.liveness.spec | nindent 10 }}
         {{- end }}
       - name: {{ .Values.name }}-proxy
-        image: "{{ .Values.proxy.imageRepository }}:{{ .Values.proxy.imageTag }}"
+        image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
         ports:
           - containerPort: 443
           - containerPort: 80

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         volumeMounts:
-        - mountPath: /app/ui-config.json:/ui/dist/assets/environments/environment.json
+        - mountPath: /ui/dist/assets/environments/environment.json
           subPath: ui-config.json
           name: ui-ctmpls
         - mountPath: /etc/nginx/nginx.conf

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
       containers:
       - name: {{ .Values.name }}-api
         image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.global.applicationVersion }}"
+        args: ["-b", ":8190", "-t", "60"]
         ports:
         - containerPort: 8190
         resources: # Mimic existing GCE vm requirements
@@ -90,7 +91,7 @@ spec:
       - name: {{ .Values.name }}-ui
         image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.global.applicationVersion }}"
         ports:
-        - containerPort: 443
+        - containerPort: 8000
         resources: # Mimic existing GCE vm requirements
           requests:
             cpu: {{ .Values.ui.resources.requests.cpu }}

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           name: api-ctmpls
         # Note: These readiness settings only apply to Kubernetes' internal load
         # balancing mechanism -- there's a separate health check setting for
-        # Agora's Ingress / GCP load balancer in the Ingress's backendConfig
+        # the Ingress / GCP load balancer in the Ingress's backendConfig
         {{- if .Values.probes.readiness.enabled }}
         readinessProbe:
           {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
@@ -117,7 +117,7 @@ spec:
           name: ui-ctmpls
         # Note: These readiness settings only apply to Kubernetes' internal load
         # balancing mechanism -- there's a separate health check setting for
-        # Agora's Ingress / GCP load balancer in the Ingress's backendConfig
+        # the Ingress / GCP load balancer in the Ingress's backendConfig
         {{- if .Values.ui.probes.readiness.enabled }}
         readinessProbe:
           {{- toYaml .Values.ui.probes.readiness.spec | nindent 10 }}

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           subPath: ui-config.json
           name: ui-ctmpls
         - mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
+          subPath: nginx.json # TODO rename to nginx.conf when templates are moved out of firecloud-develop
           name: ui-ctmpls
         # Note: These readiness settings only apply to Kubernetes' internal load
         # balancing mechanism -- there's a separate health check setting for

--- a/charts/jobmanager/templates/ingress.yaml
+++ b/charts/jobmanager/templates/ingress.yaml
@@ -7,9 +7,9 @@ metadata:
   annotations:
     networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
-{{- if not (empty .Values.ingress.preSharedCerts) }}
+    {{- if not (empty .Values.ingress.preSharedCerts) }}
     ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.preSharedCerts | join "," | quote }}
-{{- end }}
+    {{- end }}
     kubernetes.io/ingress.allow-http: "false"
 spec:
   backend:

--- a/charts/jobmanager/templates/ingress.yaml
+++ b/charts/jobmanager/templates/ingress.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Values.name }}-ingress
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
+  annotations:
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
+{{- if not (empty .Values.ingress.preSharedCerts) }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.preSharedCerts | join "," | quote }}
+{{- end }}
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  backend:
+    serviceName: {{ .Values.name }}-service
+    servicePort: 443
+{{- end }}

--- a/charts/jobmanager/templates/ingress/backendconfig.yaml
+++ b/charts/jobmanager/templates/ingress/backendconfig.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ .Values.name }}-ingress-backendconfig
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
+spec:
+  timeoutSec: {{ .Values.ingress.timeoutSec }}
+  healthCheck:
+    checkIntervalSec: 5
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    type: HTTPS
+    port: 443
+    requestPath: /health
+{{- end }}

--- a/charts/jobmanager/templates/ingress/frontendconfig.yaml
+++ b/charts/jobmanager/templates/ingress/frontendconfig.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ .Values.name }}-ingress-frontendconfig
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
+{{- if .Values.ingress.sslPolicy }}
+spec:
+  sslPolicy: {{ .Values.ingress.sslPolicy }}
+{{- end }}
+{{- end }}

--- a/charts/jobmanager/templates/ingress/service.yaml
+++ b/charts/jobmanager/templates/ingress/service.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-service
+  labels: {{- include "agora.labels" . | nindent 4 }}
+  annotations:
+    # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
+    cloud.google.com/backend-config: '{"default": "agora-ingress-backendconfig"}'
+    # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
+    cloud.google.com/neg: '{"ingress": true}'
+    # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb
+    cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+spec:
+  type: ClusterIP
+  selector:
+    deployment: {{ .Values.name }}-deployment
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443
+{{- end }}

--- a/charts/jobmanager/templates/ingress/service.yaml
+++ b/charts/jobmanager/templates/ingress/service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.name }}-service
-  labels: {{- include "agora.labels" . | nindent 4 }}
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
   annotations:
     # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
-    cloud.google.com/backend-config: '{"default": "agora-ingress-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
     # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
     cloud.google.com/neg: '{"ingress": true}'
     # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb

--- a/charts/jobmanager/templates/role.yaml
+++ b/charts/jobmanager/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.name }}-role
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - terra-default-psp

--- a/charts/jobmanager/templates/rolebinding.yaml
+++ b/charts/jobmanager/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.name }}-sa-binding
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}-sa
+roleRef:
+  kind: Role
+  name: {{ .Values.name }}-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/jobmanager/templates/serviceaccount.yaml
+++ b/charts/jobmanager/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}-sa
+  labels: {{- include "jobmanager.labels" . | nindent 4 }}

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -50,7 +50,7 @@ ui:
       spec:
         httpGet:
           path: /health
-          port: 443
+          port: 8000
         timeoutSeconds: 5
         periodSeconds: 10
         failureThreshold: 6
@@ -62,7 +62,7 @@ ui:
       spec:
         httpGet:
           path: /health
-          port: 443
+          port: 8000
         timeoutSeconds: 5
         periodSeconds: 10
         failureThreshold: 30

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -114,9 +114,8 @@ api:
         successThreshold: 1
 
 proxy:
-  imageConfig:
+  image:
     # proxy.imageConfig.repository -- Image repository
     repository: broadinstitute/openidc-proxy
     # proxy.imageConfig.tag -- (string) Image tag.
     tag: modsecurity_2_9_2
-    imagePullPolicy: Always

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -36,12 +36,12 @@ ui:
       # ui.resources.requests.cpu -- Number of CPU units to request for the deployment
       cpu: 4
       # ui.resources.requests.memory -- Memory to request for the deployment
-      memory: 4Gi
+      memory: 3.6Gi
     limits:
       # ui.resources.limits.cpu -- Number of CPU units to limit the deployment to
       cpu: 4
       # ui.resources.limits.memory -- Memory to limit the deployment to
-      memory: 4Gi
+      memory: 3.6Gi
   probes:
     readiness:
       # ui.probes.readiness.enable -- Whether to configure a readiness probe
@@ -81,12 +81,12 @@ api:
       # api.resources.requests.cpu -- Number of CPU units to request for the deployment
       cpu: 4
       # api.resources.requests.memory -- Memory to request for the deployment
-      memory: 4Gi
+      memory: 3.6Gi
     limits:
       # api.resources.limits.cpu -- Number of CPU units to limit the deployment to
       cpu: 4
       # api.resources.limits.memory -- Memory to limit the deployment to
-      memory: 4Gi
+      memory: 3.6Gi
   probes:
     readiness:
       # api.probes.readiness.enable -- Whether to configure a readiness probe

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -25,13 +25,12 @@ ingress:
 #        To minimize changes during the migration, this chart deploys both containers as part of the same pod. Eventually we should think about breaking them into separate deployments with separate ingresses.
 # Settings for the UI container
 ui:
-  imageConfig:
+  image:
     # ui.imageConfig.repository -- Image repository
     repository: databiosphere/job-manager-ui
     # ui.imageConfig.tag -- (string) Image tag.
     # @default -- global.applicationVersion
     tag:
-    imagePullPolicy: Always
   resources:
     requests:
       # ui.resources.requests.cpu -- Number of CPU units to request for the deployment
@@ -71,13 +70,12 @@ ui:
 
 # Settings for the API container
 api:
-  imageConfig:
+  image:
     # api.imageConfig.repository -- Image repository
     repository: databiosphere/job-manager-api-cromwell
     # api.imageConfig.tag -- (string) Image tag.
     # @default -- global.applicationVersion
     tag:
-    imagePullPolicy: Always
   resources:
     requests:
       # api.resources.requests.cpu -- Number of CPU units to request for the deployment

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -26,9 +26,9 @@ ingress:
 # Settings for the UI container
 ui:
   image:
-    # ui.imageConfig.repository -- Image repository
+    # ui.image.repository -- Image repository
     repository: databiosphere/job-manager-ui
-    # ui.imageConfig.tag -- (string) Image tag.
+    # ui.image.tag -- (string) Image tag.
     # @default -- global.applicationVersion
     tag:
   resources:
@@ -71,9 +71,9 @@ ui:
 # Settings for the API container
 api:
   image:
-    # api.imageConfig.repository -- Image repository
+    # api.image.repository -- Image repository
     repository: databiosphere/job-manager-api-cromwell
-    # api.imageConfig.tag -- (string) Image tag.
+    # api.image.tag -- (string) Image tag.
     # @default -- global.applicationVersion
     tag:
   resources:
@@ -115,7 +115,7 @@ api:
 
 proxy:
   image:
-    # proxy.imageConfig.repository -- Image repository
+    # proxy.image.repository -- Image repository
     repository: broadinstitute/openidc-proxy
-    # proxy.imageConfig.tag -- (string) Image tag.
+    # proxy.image.tag -- (string) Image tag.
     tag: modsecurity_2_9_2

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -1,1 +1,124 @@
-# No values yet!
+global:
+  # global.applicationVersion -- What version of the jobmanager application to deploy
+  applicationVersion: latest
+
+# replicas -- Number of API replicas to spin up in the deployment
+replicas: 3
+
+# name -- Name for this deployment
+name: jobmanager
+
+# Settings for Job Manager's Ingress & Service
+ingress:
+  # ingress.enabled -- Whether to create Ingress and associated Service, FrontendConfig and BackendConfig
+  enabled: true
+  # ingress.staticIpName -- (string) Required. Name of the static IP, allocated in GCP, to associate with the Ingress
+  staticIpName: null
+  # ingress.preSharedCerts -- Array of pre-shared GCP SSL certificate names to associate with the Ingress
+  preSharedCerts: []
+  # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
+  sslPolicy: null
+  # ingress.timeoutSec -- Load balancer backend timeout
+  timeoutSec: 120
+
+# TODO - At the time we migrated from VMs to GKE, Job Manager's API and UI containers were deployed to the same VM, with the UI acting as a frontend for the API.
+#        To minimize changes during the migration, this chart deploys both containers as part of the same pod. Eventually we should think about breaking them into separate deployments with separate ingresses.
+# Settings for the UI container
+ui:
+  imageConfig:
+    # ui.imageConfig.repository -- Image repository
+    repository: databiosphere/job-manager-ui
+    # ui.imageConfig.tag -- (string) Image tag.
+    # @default -- global.applicationVersion
+    tag:
+    imagePullPolicy: Always
+  resources:
+    requests:
+      # ui.resources.requests.cpu -- Number of CPU units to request for the deployment
+      cpu: 4
+      # ui.resources.requests.memory -- Memory to request for the deployment
+      memory: 4Gi
+    limits:
+      # ui.resources.limits.cpu -- Number of CPU units to limit the deployment to
+      cpu: 4
+      # ui.resources.limits.memory -- Memory to limit the deployment to
+      memory: 4Gi
+  probes:
+    readiness:
+      # ui.probes.readiness.enable -- Whether to configure a readiness probe
+      enabled: true
+      # ui.probes.readiness.spec -- Kubernetes spec for readiness probe
+      spec:
+        httpGet:
+          path: /health
+          port: 443
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 6
+        successThreshold: 1
+    liveness:
+      # ui.probes.liveness.enable -- Whether to configure a liveness probe
+      enabled: true
+      # ui.probes.liveness.spec -- Kubernetes spec for liveness probe
+      spec:
+        httpGet:
+          path: /health
+          port: 443
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 30
+        successThreshold: 1
+
+# Settings for the API container
+api:
+  imageConfig:
+    # api.imageConfig.repository -- Image repository
+    repository: databiosphere/job-manager-api-cromwell
+    # api.imageConfig.tag -- (string) Image tag.
+    # @default -- global.applicationVersion
+    tag:
+    imagePullPolicy: Always
+  resources:
+    requests:
+      # api.resources.requests.cpu -- Number of CPU units to request for the deployment
+      cpu: 2
+      # api.resources.requests.memory -- Memory to request for the deployment
+      memory: 2Gi
+    limits:
+      # api.resources.limits.cpu -- Number of CPU units to limit the deployment to
+      cpu: 2
+      # api.resources.limits.memory -- Memory to limit the deployment to
+      memory: 2Gi
+  probes:
+    readiness:
+      # api.probes.readiness.enable -- Whether to configure a readiness probe
+      enabled: true
+      # api.probes.readiness.spec -- Kubernetes spec for readiness probe
+      spec:
+        httpGet:
+          path: /api/v1/health
+          port: 8190
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 6
+        successThreshold: 1
+    liveness:
+      # api.probes.liveness.enable -- Whether to configure a liveness probe
+      enabled: true
+      # api.probes.liveness.spec -- Kubernetes spec for liveness probe
+      spec:
+        httpGet:
+          path: /api/v1/health
+          port: 8190
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 30 # 5 minutes before restarted
+        successThreshold: 1
+
+proxy:
+  imageConfig:
+    # proxy.imageConfig.repository -- Image repository
+    repository: broadinstitute/openidc-proxy
+    # proxy.imageConfig.tag -- (string) Image tag.
+    tag: modsecurity_2_9_2
+    imagePullPolicy: Always

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -79,14 +79,14 @@ api:
   resources:
     requests:
       # api.resources.requests.cpu -- Number of CPU units to request for the deployment
-      cpu: 2
+      cpu: 4
       # api.resources.requests.memory -- Memory to request for the deployment
-      memory: 2Gi
+      memory: 4Gi
     limits:
       # api.resources.limits.cpu -- Number of CPU units to limit the deployment to
-      cpu: 2
+      cpu: 4
       # api.resources.limits.memory -- Memory to limit the deployment to
-      memory: 2Gi
+      memory: 4Gi
   probes:
     readiness:
       # api.probes.readiness.enable -- Whether to configure a readiness probe


### PR DESCRIPTION
This is an initial Helm chart implementation for Job Manager, based on its existing docker-compose configs.

Note that:
* Instead of a primary `app` container, Job Manager has two containers: `ui`, and `api`. The `ui` and `api` containers are deployed inside the same pod, because they were deployed on the same VM under docker-compose and we would like to minimize the delta associated with the GKE transition
* The Job Manager vms have 4 CPUs/3.5 GiB of RAM; I have separately given the UI container and API container each 4 CPUs/3.5 GiB of RAM, because it's hard to say which container uses more resources with the data available for GCE vms. Once the containers are running in GKE, Prometheus should give us enough information to allocate resources more efficiently.
* Job Manager has no database and therefore no `sqlproxy` container
* Job Manager API is a Python app and the UI is static files served by Nginx, so there is no Prometheus exporter configuration in this chart