### PR TITLE
[No Ticket] Fix to failed volume mount when orch probe is disabled

### DIFF
--- a/charts/firecloudorch/templates/deployment.yaml
+++ b/charts/firecloudorch/templates/deployment.yaml
@@ -52,10 +52,12 @@ spec:
         emptyDir: {}
       - name: {{ .Values.name }}-es-probe-tools
         emptyDir: {}
+      {{- if .Values.elasticsearch.transportProbe.enabled }}
       - name: {{ .Values.name }}-es-probe-cm
         configMap:
           name: {{ .Values.name }}-es-probe-cm
           defaultMode: 0555
+      {{- end }}
       containers:
       - name: {{ .Values.name }}-app
         image: "{{ .Values.imageConfig.repository }}:{{ $imageTag }}"

--- a/charts/firecloudorch/templates/deployment.yaml
+++ b/charts/firecloudorch/templates/deployment.yaml
@@ -50,9 +50,9 @@ spec:
         emptyDir: {}
       - name: {{ .Values.name }}-prometheusjmx-jar
         emptyDir: {}
+      {{- if .Values.elasticsearch.transportProbe.enabled }}  
       - name: {{ .Values.name }}-es-probe-tools
         emptyDir: {}
-      {{- if .Values.elasticsearch.transportProbe.enabled }}
       - name: {{ .Values.name }}-es-probe-cm
         configMap:
           name: {{ .Values.name }}-es-probe-cm


### PR DESCRIPTION
A mistake in conditional logic caused the new probe helm chart update for orch to fail due to unable to mount a nonexistent volume when the probe was disabled. This fixes that mistake.