### PR TITLE
Add a startup probe to Cromwell chart

### DIFF
--- a/charts/cromwell/Chart.yaml
+++ b/charts/cromwell/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cromwell
-version: 0.14.0
+version: 0.15.0
 type: application
 description: A Helm chart for Cromwell, the Terra Workflow Management System
 keywords:

--- a/charts/cromwell/README.md
+++ b/charts/cromwell/README.md
@@ -12,10 +12,12 @@ A Helm chart for Cromwell, the Terra Workflow Management System
 | deploymentDefaults.legacyResourcePrefix | string | `nil` | What prefix to use to refer to secrets rendered from firecloud-develop @default deploymentDefaults.name |
 | deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resource definitions. Example: `"cromwell1-reader"` |
 | deploymentDefaults.nodeSelector | object | `nil` | Optional nodeSelector map |
-| deploymentDefaults.probes.liveness.enabled | bool | `true` |  |
+| deploymentDefaults.probes.liveness.enabled | bool | `true` | Whether to configure a liveness probe |
 | deploymentDefaults.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/engine/latest/version","port":8000},"initialDelaySeconds":20,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the liveness probe to deploy, if enabled |
-| deploymentDefaults.probes.readiness.enabled | bool | `true` |  |
+| deploymentDefaults.probes.readiness.enabled | bool | `true` | Whether to configure a readiness probe |
 | deploymentDefaults.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/engine/latest/version","port":8000},"initialDelaySeconds":20,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the readiness probe to deploy, if enabled |
+| deploymentDefaults.probes.startup.enabled | bool | `true` | Whether to configure a startup probe |
+| deploymentDefaults.probes.startup.spec | object | `{"failureThreshold":1080,"httpGet":{"path":"/engine/latest/version","port":8000},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the startup probe to deploy, if enabled |
 | deploymentDefaults.proxyImage | string | `"broadinstitute/openidc-proxy:tcell-mpm-big"` | Image that the OIDC proxy uses |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deploymentDefaults.serviceAllowedAddresses | object | `{}` | What source IPs to whitelist for access to the service |

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -123,6 +123,10 @@ spec:
         livenessProbe:
           {{- toYaml $settings.probes.liveness.spec | nindent 10 }}
         {{- end }}
+        {{- if $settings.probes.startup.enabled }}
+        startupProbe:
+          {{- toYaml $settings.probes.startup.spec | nindent 10 }}
+        {{- end }}
       - name: {{ $settings.name }}-proxy
         image: {{ $settings.proxyImage }}
         ports:

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -37,7 +37,7 @@ deploymentDefaults:
   proxyImage: broadinstitute/openidc-proxy:tcell-mpm-big
   probes:
     readiness:
-      # deploymentDefaults.probes.readiness.enable -- Whether to configure a readiness probe
+      # deploymentDefaults.probes.readiness.enabled -- Whether to configure a readiness probe
       enabled: true
       # deploymentDefaults.probes.readiness.spec -- k8s spec of the readiness probe to deploy, if enabled
       spec:
@@ -50,7 +50,7 @@ deploymentDefaults:
         failureThreshold: 6
         successThreshold: 1
     liveness:
-      # deploymentDefaults.probes.liveness.enable -- Whether to configure a liveness probe
+      # deploymentDefaults.probes.liveness.enabled -- Whether to configure a liveness probe
       enabled: true
       # deploymentDefaults.probes.liveness.spec -- k8s spec of the liveness probe to deploy, if enabled
       spec:
@@ -62,7 +62,18 @@ deploymentDefaults:
         periodSeconds: 10
         failureThreshold: 30 # 5 minutes before restarted
         successThreshold: 1
-
+    startup:
+      # deploymentDefaults.probes.startup.enabled -- Whether to configure a startup probe
+      enabled: true
+      # deploymentDefaults.probes.startup.spec -- k8s spec of the startup probe to deploy, if enabled
+      spec:
+        httpGet:
+          path: /engine/latest/version
+          port: 8000
+        timeoutSeconds: 5
+        periodSeconds: 10
+        failureThreshold: 1080 # 3 hours before restarted, to prevent liveness probes from interrupting long-running liquibase migrations
+        successThreshold: 1
 # A map of Cromwell deployments. In Terra's production environment,
 # Cromwell is deployed as 4 separate services with different configurations.
 #


### PR DESCRIPTION
Add a 3-hour startup probe to the Cromwell chart, to prevent the 5-minute liveness probe from disrupting liquibase migrations.