### PR TITLE
[No Ticket] Filebeat shouldn't export buffer logs to logit

### DIFF
--- a/charts/filebeat/templates/inputConfig.yaml
+++ b/charts/filebeat/templates/inputConfig.yaml
@@ -31,4 +31,4 @@ data:
               - regexp:
                   kubernetes.pod.name: "^.*-cronjob-.*$"
               - regexp:
-                  kubernetes.pod.name: "^terra-bufer.*"
+                  kubernetes.pod.name: "^buffer.*"


### PR DESCRIPTION
The naming convention for buffer pods was changed somewhat recently. This caused buffer logs to sneak back into kibana, contributing to quota overages. This makes sure buffer logs are not going to kibana﻿
