### PR TITLE
[no ticket] fix hash bump

### DIFF
--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -96,13 +96,13 @@ cronjob:
   # deployments.standalone.name -- Name to use for the default standalone Leonardo deployment
   name: leonardo-resource-validator-cronjob
   imageRepository: us.gcr.io/broad-dsp-gcr-public/resource-validator
-  imageTag: 5186276
+  imageTag: "5186276"
   googleProject:
 zombieMonitorCron:
   # deployments.standalone.name -- Name to use for the default standalone Leonardo deployment
   name: leonardo-zombie-monitor-cronjob
   imageRepository: us.gcr.io/broad-dsp-gcr-public/zombie-monitor
-  imageTag: 5186276
+  imageTag: "5186276"
 vault:
   # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
   pathPrefix:


### PR DESCRIPTION
https://github.com/broadinstitute/terra-helm/pull/359 worked as intended. But somehow argo parsed the hash as `              image: 'us.gcr.io/broad-dsp-gcr-public/zombie-monitor:5.186276e+06'`. Adding double quote and see if this fixes things