### PR TITLE
DDO-1209 Bump ArgoCD resources

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -88,3 +88,10 @@ argo-cd:
             key: secretid
       - name: ARGOCD_GIT_MODULES_ENABLED # Required for firecloud-develop clones to succeed
         value: "false"
+    resources:
+      limits:
+        cpu: 1
+        memory: 2Gi
+      requests:
+        cpu: 1
+        memory: 2Gi

--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -70,9 +70,6 @@ argo-cd:
     extraArgs:
     - --repo-server-timeout-seconds=180
     resources:
-      limits:
-        cpu: 4
-        memory: 4Gi
       requests:
         cpu: 4
         memory: 4Gi
@@ -96,9 +93,6 @@ argo-cd:
       - name: ARGOCD_GIT_MODULES_ENABLED # Required for firecloud-develop clones to succeed
         value: "false"
     resources:
-      limits:
-        cpu: 4
-        memory: 4Gi
       requests:
         cpu: 4
         memory: 4Gi

--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -71,7 +71,7 @@ argo-cd:
     - --repo-server-timeout-seconds=180
     resources:
       requests:
-        cpu: 4
+        cpu: 3.2
         memory: 4Gi
   repoServer:
     image:
@@ -94,5 +94,5 @@ argo-cd:
         value: "false"
     resources:
       requests:
-        cpu: 4
+        cpu: 3.2
         memory: 4Gi

--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -69,6 +69,13 @@ argo-cd:
   controller:
     extraArgs:
     - --repo-server-timeout-seconds=180
+    resources:
+      limits:
+        cpu: 4
+        memory: 4Gi
+      requests:
+        cpu: 4
+        memory: 4Gi
   repoServer:
     image:
       repository: us-central1-docker.pkg.dev/dsp-artifact-registry/terra-helmfile-images/argocd-custom-image
@@ -90,8 +97,8 @@ argo-cd:
         value: "false"
     resources:
       limits:
-        cpu: 1
-        memory: 2Gi
+        cpu: 4
+        memory: 4Gi
       requests:
-        cpu: 1
-        memory: 2Gi
+        cpu: 4
+        memory: 4Gi


### PR DESCRIPTION
Follow-up on https://github.com/broadinstitute/terra-helm/pull/366:

Reduce CPU request from 4 to 3.2 so that ArgoCD pods are still schedulable on the dsp-tools cluster's existing node pool.