### PR TITLE
DDO-1214 Use image with curl baked in to avoid GCP security alerts

### DIFF
--- a/charts/elasticsearch/templates/backup/cronjob.yaml
+++ b/charts/elasticsearch/templates/backup/cronjob.yaml
@@ -27,7 +27,6 @@ spec:
             command: ['sh', '-c']
             args:
             - |-
-              apk --no-cache add curl && \
               TIMESTAMP=$( date +'%Y%m%d.%H%M%S' ) && \
               curl -X PUT "${ELASTICSEARCH_HOSTNAME}:9200/_snapshot/${SNAPSHOT_REPOSITORY}/es-snapshot-${TIMESTAMP}?wait_for_completion=true"
             env: 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -17,9 +17,9 @@ backup:
   # backup.timeoutSeconds -- amount of time after which job automatically fails
   timeoutSeconds: 7200 # 2 hrs
   # backup.imageRepo -- specify an image repository for the backup job
-  imageRepo: alpine
+  imageRepo: us-central1-docker.pkg.dev/dsp-artifact-registry/elasticsearch-backup/elasticsearch-backup
   # backup.imageTag -- specify a tag for the image running the backup job
-  imageTag: "3.13"
+  imageTag: "1.0.0"
   # backup.hostname -- hostname of the elasticsearch server the backup job will snapshot
   hostname: null
   #backup.snapshotRepository -- name of the snapshot repo backed by a GCS bucket to create snapshot in


### PR DESCRIPTION
Installing curl after the image starts was setting off security alarm bells in GCP that were very noisy. Using an image with curl pre-installed﻿
