### PR TITLE
[IA-2746] Add calhoun chart

### DIFF
--- a/charts/calhoun/Chart.yaml
+++ b/charts/calhoun/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: calhoun
+version: 0.1.0
+type: application
+description: A Helm chart for Calhoun, Terra's Jupyter notebook preview service
+keywords:
+  - dsp
+  - broadinstitute
+  - terra
+  - calhoun
+sources:
+  - https://github.com/broadinstitute/terra-helm/
+  - https://github.com/DataBiosphere/calhoun

--- a/charts/calhoun/README.md
+++ b/charts/calhoun/README.md
@@ -6,10 +6,11 @@ A Helm chart for Calhoun, Terra's Jupyter notebook preview service
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| calhoun | string | `nil` |  |
+| calhoun.samRoot | string | `nil` |  |
+| calhoun.swaggerClientId | string | `nil` |  |
+| calhoun.swaggerRealm | string | `nil` |  |
 | global.applicationVersion | string | `"latest"` | What version of the application to deploy |
 | global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
-| image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/broad-dsp-gcr-public/calhoun"` | Image repository |
 | imageConfig.tag | string | global.applicationVersion | Image tag. |
@@ -25,28 +26,38 @@ A Helm chart for Calhoun, Terra's Jupyter notebook preview service
 | ingress.cert.vault.enabled | bool | `true` | Enable syncing certificate secret from Vault. Requires [secrets-manager](https://github.com/tuenti/secrets-manager) |
 | ingress.cert.vault.key.path | string | `nil` | Path to secret containing .key |
 | ingress.cert.vault.key.secretKey | string | `nil` | Key in secret containing .key |
+| ingress.domain.hostname | string | `"calhoun"` |  |
+| ingress.domain.namespaceEnv | bool | `true` |  |
+| ingress.domain.suffix | string | `"dsde-dev.broadinstitute.org"` |  |
 | ingress.enabled | bool | `true` | Whether to create Ingress, Service and associated config resources |
 | ingress.securityPolicy | string | `nil` | Name of a GCP Cloud Armor security policy |
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
 | name | string | `"calhoun"` | A name for the deployment that will be substituted into resource definitions |
-| probes.liveness.enabled | bool | `true` |  |
+| probes.liveness.enabled | bool | `true` | Whether to configure a liveness probe |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/status"` |  |
-| probes.liveness.spec.httpGet.port | int | `8000` |  |
+| probes.liveness.spec.httpGet.port | int | `8080` |  |
 | probes.liveness.spec.initialDelaySeconds | int | `15` |  |
 | probes.liveness.spec.periodSeconds | int | `10` |  |
 | probes.liveness.spec.successThreshold | int | `1` |  |
 | probes.liveness.spec.timeoutSeconds | int | `5` |  |
-| probes.readiness.enabled | bool | `true` |  |
+| probes.readiness.enabled | bool | `true` | Whether to configure a readiness probe |
 | probes.readiness.spec.failureThreshold | int | `6` |  |
 | probes.readiness.spec.httpGet.path | string | `"/status"` |  |
-| probes.readiness.spec.httpGet.port | int | `8000` |  |
+| probes.readiness.spec.httpGet.port | int | `8080` |  |
 | probes.readiness.spec.initialDelaySeconds | int | `20` |  |
 | probes.readiness.spec.periodSeconds | int | `10` |  |
 | probes.readiness.spec.successThreshold | int | `1` |  |
 | probes.readiness.spec.timeoutSeconds | int | `5` |  |
+| probes.startup.enabled | bool | `true` | Whether to configure a startup probe |
+| probes.startup.spec.failureThreshold | int | `6` |  |
+| probes.startup.spec.httpGet.path | string | `"/status"` |  |
+| probes.startup.spec.httpGet.port | int | `8080` |  |
+| probes.startup.spec.periodSeconds | int | `10` |  |
+| probes.startup.spec.successThreshold | int | `1` |  |
+| probes.startup.spec.timeoutSeconds | int | `5` |  |
 | proxy.enabled | bool | `true` |  |
 | proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Proxy image repository |
 | proxy.image.version | string | `"tcell_3_1_0"` | Proxy image tag |
@@ -56,7 +67,7 @@ A Helm chart for Calhoun, Terra's Jupyter notebook preview service
 | proxy.tcell.hostIdentifier | string | `nil` | Identifier used for logging to TCell. Required if proxy.tcell.enabled is true |
 | proxy.tcell.vaultPrefix | string | `nil` | Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true. |
 | proxy.whitelist.email | string | `nil` | Required if whitelisting is enabled. Email of buffer client Google service account |
-| proxy.whitelist.enabled | bool | `true` | Enables proxy client email whitelisting |
+| proxy.whitelist.enabled | bool | `false` | Enables proxy client email whitelisting |
 | replicas | int | `3` | Number of replicas for the deployment |
 | resources.limits.cpu | int | `2` | Number of CPU units to limit the deployment to |
 | resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |

--- a/charts/calhoun/README.md
+++ b/charts/calhoun/README.md
@@ -1,0 +1,66 @@
+# calhoun
+
+A Helm chart for Calhoun, Terra's Jupyter notebook preview service
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| calhoun | string | `nil` |  |
+| global.applicationVersion | string | `"latest"` | What version of the application to deploy |
+| global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
+| image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
+| imageConfig.imagePullPolicy | string | `"Always"` |  |
+| imageConfig.repository | string | `"gcr.io/broad-dsp-gcr-public/calhoun"` | Image repository |
+| imageConfig.tag | string | global.applicationVersion | Image tag. |
+| ingress.cert.certManager.enabled | bool | `false` | Enable creating certificate secret with cert-manager |
+| ingress.cert.certManager.issuerKind | string | `"ClusterIssuer"` |  |
+| ingress.cert.certManager.issuerName | string | `"cert-manager-letsencrypt-prod"` |  |
+| ingress.cert.certManager.renewBefore | string | `"720h0m0s"` | When to renew the cert. Defaults to 30 days before expiry. |
+| ingress.cert.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |
+| ingress.cert.vault.cert.path | string | `nil` | Path to secret containing .crt |
+| ingress.cert.vault.cert.secretKey | string | `nil` | Key in secret containing .crt |
+| ingress.cert.vault.chain.path | string | `nil` | Path to secret containing intermediate .crt |
+| ingress.cert.vault.chain.secretKey | string | `nil` | Key in secret containing intermediate .crt |
+| ingress.cert.vault.enabled | bool | `true` | Enable syncing certificate secret from Vault. Requires [secrets-manager](https://github.com/tuenti/secrets-manager) |
+| ingress.cert.vault.key.path | string | `nil` | Path to secret containing .key |
+| ingress.cert.vault.key.secretKey | string | `nil` | Key in secret containing .key |
+| ingress.enabled | bool | `true` | Whether to create Ingress, Service and associated config resources |
+| ingress.securityPolicy | string | `nil` | Name of a GCP Cloud Armor security policy |
+| ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
+| ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
+| ingress.timeoutSec | int | `120` |  |
+| name | string | `"calhoun"` | A name for the deployment that will be substituted into resource definitions |
+| probes.liveness.enabled | bool | `true` |  |
+| probes.liveness.spec.failureThreshold | int | `30` |  |
+| probes.liveness.spec.httpGet.path | string | `"/status"` |  |
+| probes.liveness.spec.httpGet.port | int | `8000` |  |
+| probes.liveness.spec.initialDelaySeconds | int | `15` |  |
+| probes.liveness.spec.periodSeconds | int | `10` |  |
+| probes.liveness.spec.successThreshold | int | `1` |  |
+| probes.liveness.spec.timeoutSeconds | int | `5` |  |
+| probes.readiness.enabled | bool | `true` |  |
+| probes.readiness.spec.failureThreshold | int | `6` |  |
+| probes.readiness.spec.httpGet.path | string | `"/status"` |  |
+| probes.readiness.spec.httpGet.port | int | `8000` |  |
+| probes.readiness.spec.initialDelaySeconds | int | `20` |  |
+| probes.readiness.spec.periodSeconds | int | `10` |  |
+| probes.readiness.spec.successThreshold | int | `1` |  |
+| probes.readiness.spec.timeoutSeconds | int | `5` |  |
+| proxy.enabled | bool | `true` |  |
+| proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Proxy image repository |
+| proxy.image.version | string | `"tcell_3_1_0"` | Proxy image tag |
+| proxy.logLevel | string | `"debug"` | Proxy log level |
+| proxy.reloadOnCertUpdate | bool | `false` | Whether to reload the deployment when the cert is updated. Requires stakater/Reloader service to be running in the cluster. |
+| proxy.tcell.enabled | bool | `true` | Enables TCell |
+| proxy.tcell.hostIdentifier | string | `nil` | Identifier used for logging to TCell. Required if proxy.tcell.enabled is true |
+| proxy.tcell.vaultPrefix | string | `nil` | Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true. |
+| proxy.whitelist.email | string | `nil` | Required if whitelisting is enabled. Email of buffer client Google service account |
+| proxy.whitelist.enabled | bool | `true` | Enables proxy client email whitelisting |
+| replicas | int | `3` | Number of replicas for the deployment |
+| resources.limits.cpu | int | `2` | Number of CPU units to limit the deployment to |
+| resources.limits.memory | string | `"4Gi"` | Memory to limit the deployment to |
+| resources.requests.cpu | int | `2` | Number of CPU units to request for the deployment |
+| resources.requests.memory | string | `"4Gi"` | Memory to request for the deployment |
+| vault.enabled | bool | `true` | When enabled, syncs required secrets from Vault |
+| vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |

--- a/charts/calhoun/README.md.gotmpl
+++ b/charts/calhoun/README.md.gotmpl
@@ -1,0 +1,7 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/calhoun/templates/_helpers.tpl
+++ b/charts/calhoun/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{/*
+Common labels
+*/}}
+{{- define "calhoun.labels" -}}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/component: calhoun
+app.kubernetes.io/part-of: terra
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "calhoun.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Values.name | quote }}
+{{- end }}
+
+{{/*
+FQDN template
+*/}}
+{{- define "calhoun.fqdn" -}}
+    {{ .Values.ingress.domain.hostname -}}
+    {{ if .Values.ingress.domain.namespaceEnv -}}
+    	.{{.Values.global.terraEnv -}}
+    {{ end -}}
+    .{{ .Values.ingress.domain.suffix }}
+{{- end }}

--- a/charts/calhoun/templates/configmaps/proxy-apache-httpd-configmap.yaml
+++ b/charts/calhoun/templates/configmaps/proxy-apache-httpd-configmap.yaml
@@ -4,11 +4,11 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}-proxy-configmap
   labels:
-    {{- include "buffer.labels" . | nindent 4 }}
+    {{- include "calhoun.labels" . | nindent 4 }}
 data:
   apache-httpd-proxy-config: |-
     ServerAdmin ${SERVER_ADMIN}
-    ServerName {{ template "buffer.fqdn" . }}
+    ServerName {{ template "calhoun.fqdn" . }}
     ServerTokens ProductOnly
     TraceEnable off
 
@@ -35,12 +35,12 @@ data:
     <VirtualHost _default_:${HTTPD_PORT}>
       ErrorLog /dev/stdout
       CustomLog "/dev/stdout" combined
-      Redirect / https://{{ template "buffer.fqdn" . }}/
+      Redirect / https://{{ template "calhoun.fqdn" . }}/
     </VirtualHost>
 
     <VirtualHost _default_:${SSL_HTTPD_PORT}>
         ServerAdmin ${SERVER_ADMIN}
-        ServerName {{ template "buffer.fqdn" . }}
+        ServerName {{ template "calhoun.fqdn" . }}
 
         SSLEngine On
         SSLProxyEngine On

--- a/charts/calhoun/templates/configmaps/proxy-apache-httpd-configmap.yaml
+++ b/charts/calhoun/templates/configmaps/proxy-apache-httpd-configmap.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-proxy-configmap
+  labels:
+    {{- include "buffer.labels" . | nindent 4 }}
+data:
+  apache-httpd-proxy-config: |-
+    ServerAdmin ${SERVER_ADMIN}
+    ServerName {{ template "buffer.fqdn" . }}
+    ServerTokens ProductOnly
+    TraceEnable off
+
+    LogFormat "%h %l %u \"%{OIDC_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%{X-Forwarded-For}i %l %u \"%{OIDC_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+    CustomLog "/dev/stdout" combined env=!forwarded
+    CustomLog "/dev/stdout" proxy env=forwarded
+
+    LogLevel {{ .Values.proxy.logLevel }}
+
+    Header unset X-Frame-Options
+    Header always set X-Frame-Options SAMEORIGIN
+    Header unset X-XSS-Protection
+    Header always set X-XSS-Protection "1; mode=block"
+    Header unset X-Content-Type-Options
+    Header always set X-Content-Type-Options: nosniff
+    Header unset Strict-Transport-Security
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+
+    ProxyTimeout ${PROXY_TIMEOUT}
+    OIDCOAuthTokenIntrospectionInterval 60
+
+    <VirtualHost _default_:${HTTPD_PORT}>
+      ErrorLog /dev/stdout
+      CustomLog "/dev/stdout" combined
+      Redirect / https://{{ template "buffer.fqdn" . }}/
+    </VirtualHost>
+
+    <VirtualHost _default_:${SSL_HTTPD_PORT}>
+        ServerAdmin ${SERVER_ADMIN}
+        ServerName {{ template "buffer.fqdn" . }}
+
+        SSLEngine On
+        SSLProxyEngine On
+        SSLCertificateFile /etc/ssl/certs/server.crt
+        SSLCertificateKeyFile /etc/ssl/private/server.key
+        {{ if .Values.ingress.cert.vault.enabled -}}
+          SSLCertificateChainFile /etc/ssl/certs/ca-bundle.crt
+        {{- end }}
+
+        ErrorLog /dev/stdout
+        CustomLog "/dev/stdout" combined
+
+        <Location ${PROXY_PATH}>
+          RewriteCond %{REQUEST_METHOD} OPTIONS
+          RewriteRule ^(.*)$ $1 [R=204,L]
+
+          <Limit OPTIONS>
+              Require all granted
+          </Limit>
+
+          ${AUTH_TYPE}
+          ${AUTH_REQUIRE}
+
+          ProxyPass http://localhost:8080/
+          ProxyPassReverse http://localhost:8080/
+        </Location>
+
+        <Location ${PROXY_PATH2}>
+          Header unset Access-Control-Allow-Origin
+          Header always set Access-Control-Allow-Origin "*"
+          Header unset Access-Control-Allow-Headers
+          Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin,x-app-id"
+          Header unset Access-Control-Allow-Methods
+          Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+          Header unset Access-Control-Max-Age
+          Header always set Access-Control-Max-Age 1728000
+
+          RewriteEngine On
+          RewriteCond %{REQUEST_METHOD} OPTIONS
+          RewriteRule ^(.*)$ $1 [R=204,L]
+
+          <Limit OPTIONS>
+              Require all granted
+          </Limit>
+
+          ${AUTH_TYPE2}
+
+          <RequireAll>
+            <RequireAll>
+              ${AUTH_REQUIRE2}
+            </RequireAll>
+            {{ if .Values.proxy.whitelist.enabled -}}
+            <RequireAny>
+              Require claims_expr '((.email == "{{ required "Whitelist email is required when whitelisting is enabled" .Values.proxy.whitelist.email }}"))'
+            </RequireAny>
+            {{- end }}
+          </RequireAll>
+
+          ProxyPass http://localhost:8080/api
+          ProxyPassReverse http://localhost:8080/api
+
+          AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript
+        </Location>
+    </VirtualHost>
+{{- end }}

--- a/charts/calhoun/templates/configmaps/proxy-tcell-configmap.yaml
+++ b/charts/calhoun/templates/configmaps/proxy-tcell-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.proxy.tcell.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-tcell-configmap
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+data:
+  tcell-config: |-
+    {
+      "version": 1,
+      "applications": [
+        {
+          "tcell_api_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
+          "tcell_input_url": "https://us.input.tcell.insight.rapid7.com/api/v1",
+          "js_agent_api_base_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
+          "host_identifier":"{{ .Values.proxy.tcell.hostIdentifier }}",
+          "logging_options":{"enabled":true,"level":"INFO","filename":"mytcell.log"}
+        }
+      ]
+    }
+{{- end}}

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -32,9 +32,6 @@ spec:
     spec:
       serviceAccountName: {{ .Values.name }}-service-sa
       volumes:
-      - name: cloudsql-sa-creds
-        secret:
-          secretName: {{ .Values.name }}-cloudsql-sa
       - name: app-sa-creds
         secret:
           secretName: {{ .Values.name }}-app-sa
@@ -72,7 +69,7 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:
-        - name: SAM_URL_ROOT
+        - name: SAM_ROOT
           value: {{ .Values.calhoun.samUrlRoot }}
         - name: SWAGGER_CLIENT_ID
           valueFrom:

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     reloader.stakater.com/auto: "true"
   {{- end }}
 spec:
-  revisionHistoryLimit: 1
+  revisionHistoryLimit: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -85,7 +85,7 @@ spec:
           {{- toYaml .Values.probes.startup.spec | nindent 10 }}
         {{- end }}
       {{- if .Values.proxy.enabled }}
-      - name: {{ .Values.name }}-oidc-proxy
+      - name: {{ .Values.name }}-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
         ports:
         - containerPort: 443

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -1,0 +1,146 @@
+{{- $imageTag := .Values.imageConfig.tag | default .Values.global.applicationVersion -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}-deployment
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+  {{- if and .Values.proxy.enabled .Values.proxy.reloadOnCertUpdate }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
+spec:
+  revisionHistoryLimit: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "calhoun.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      name: {{ .Values.name }}-service
+      labels:
+        {{- include "calhoun.labels" . | nindent 8 }}
+      annotations:
+        {{- /* Automatically restart deployments on config map changes: */}}
+        checksum/{{ .Values.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-tcell-configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Values.name }}-service-sa
+      volumes:
+      - name: cloudsql-sa-creds
+        secret:
+          secretName: {{ .Values.name }}-cloudsql-sa
+      - name: app-sa-creds
+        secret:
+          secretName: {{ .Values.name }}-app-sa
+      {{- if .Values.proxy.enabled }}
+      - name: apache-httpd-proxy-config
+        configMap:
+          name: {{ .Values.name }}-proxy-configmap
+          items:
+          - key: apache-httpd-proxy-config
+            path: {{ .Values.name }}-proxy.conf
+      - name: cert
+        secret:
+          secretName: {{ .Chart.Name }}-cert
+      {{- if .Values.proxy.tcell.enabled }}
+      - name: tcell-config
+        configMap:
+          name: {{ .Values.name }}-tcell-configmap
+          items:
+          - key: tcell-config
+            path: tcell-config.conf
+      {{- end }}
+      {{- end }}
+      containers:
+      - name: {{ .Values.name }}
+        image: "{{- if .Values.image -}}
+            {{ .Values.image }}
+          {{- else -}}
+            {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
+          {{- end }}"
+        imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
+        ports:
+        - name: status
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        env:
+        - name: SAM_URL_ROOT
+          value: {{ .Values.calhoun.samUrlRoot }}
+        - name: SWAGGER_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-swagger-client
+              key: id
+        - name: SWAGGER_REALM
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-swagger-client
+              key: realm
+      {{- if .Values.proxy.enabled }}
+      - name: {{ .Values.name }}-oidc-proxy
+        image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
+        ports:
+        - containerPort: 443
+        - containerPort: 80
+        env:
+        - name: REMOTE_USER_CLAIM
+          value: sub
+        {{- if .Values.proxy.tcell.enabled }}
+        - name: TCELL_AGENT_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-proxy-tcell-secrets
+              key: app-id
+        - name: TCELL_AGENT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-proxy-tcell-secrets
+              key: api-key
+        - name: ENABLE_TCELL
+          value: 'yes'
+        {{- end }}
+        volumeMounts:
+        - mountPath: /etc/apache2/sites-available/site.conf
+          name: apache-httpd-proxy-config
+          subPath: {{ .Values.name }}-proxy.conf
+        - mountPath: /etc/ssl/certs/server.crt
+          subPath: tls.crt
+          name: cert
+          readOnly: true
+        - mountPath: /etc/ssl/private/server.key
+          subPath: tls.key
+          name: cert
+          readOnly: true
+        {{- if .Values.ingress.cert.vault.enabled}}
+        - mountPath: /etc/ssl/certs/ca-bundle.crt
+          subPath: ca-bundle.crt
+          name: cert
+          readOnly: true
+        {{- end }}
+        {{- if .Values.proxy.tcell.enabled }}
+        - mountPath: /etc/apache2/tcell_agent.config
+          name: tcell-config
+          subPath: tcell-config.conf
+        {{- end }}
+        {{- if .Values.probes.readiness.enabled }}
+        readinessProbe:
+          {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
+        {{- end }}
+        {{- if .Values.probes.liveness.enabled }}
+        livenessProbe:
+          {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
+        {{- end }}
+        {{- if .Values.probes.startup.enabled }}
+        startupProbe:
+          {{- toYaml .Values.probes.startup.spec | nindent 10 }}
+        {{- end }}
+
+      {{- end }}

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -81,6 +81,18 @@ spec:
             secretKeyRef:
               name: {{ .Values.name }}-swagger-client
               key: realm
+        {{- if .Values.probes.readiness.enabled }}
+        readinessProbe:
+          {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
+        {{- end }}
+        {{- if .Values.probes.liveness.enabled }}
+        livenessProbe:
+          {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
+        {{- end }}
+        {{- if .Values.probes.startup.enabled }}
+        startupProbe:
+          {{- toYaml .Values.probes.startup.spec | nindent 10 }}
+        {{- end }}
       {{- if .Values.proxy.enabled }}
       - name: {{ .Values.name }}-oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
@@ -126,18 +138,6 @@ spec:
         - mountPath: /etc/apache2/tcell_agent.config
           name: tcell-config
           subPath: tcell-config.conf
-        {{- end }}
-        {{- if .Values.probes.readiness.enabled }}
-        readinessProbe:
-          {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
-        {{- end }}
-        {{- if .Values.probes.liveness.enabled }}
-        livenessProbe:
-          {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
-        {{- end }}
-        {{- if .Values.probes.startup.enabled }}
-        startupProbe:
-          {{- toYaml .Values.probes.startup.spec | nindent 10 }}
         {{- end }}
 
       {{- end }}

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ .Values.name }}-swagger-client
-              key: id
+              key: client-id
         - name: SWAGGER_REALM
           valueFrom:
             secretKeyRef:

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
         env:
         - name: SAM_ROOT
           value: {{ .Values.calhoun.samUrlRoot }}
+        - name: SWAGGER_CLIENT_ID
+          value: {{ .Values.calhoun.swaggerClientId }}
+        - name: SWAGGER_REALM
+          value: {{ .Values.calhoun.swaggerRealm }}
         {{- if .Values.probes.readiness.enabled }}
         readinessProbe:
           {{- toYaml .Values.probes.readiness.spec | nindent 10 }}

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -32,9 +32,6 @@ spec:
     spec:
       serviceAccountName: {{ .Values.name }}-service-sa
       volumes:
-      - name: app-sa-creds
-        secret:
-          secretName: {{ .Values.name }}-app-sa
       {{- if .Values.proxy.enabled }}
       - name: apache-httpd-proxy-config
         configMap:
@@ -71,16 +68,6 @@ spec:
         env:
         - name: SAM_ROOT
           value: {{ .Values.calhoun.samUrlRoot }}
-        - name: SWAGGER_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.name }}-swagger-client
-              key: client-id
-        - name: SWAGGER_REALM
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.name }}-swagger-client
-              key: realm
         {{- if .Values.probes.readiness.enabled }}
         readinessProbe:
           {{- toYaml .Values.probes.readiness.spec | nindent 10 }}

--- a/charts/calhoun/templates/deployment.yaml
+++ b/charts/calhoun/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
-            {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
+            {{ .Values.imageConfig.repository }}:{{ default .Values.global.applicationVersion .Values.imageConfig.tag }}
           {{- end }}"
         imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
         ports:

--- a/charts/calhoun/templates/ingress/backendconfig.yaml
+++ b/charts/calhoun/templates/ingress/backendconfig.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ .Values.name }}-ingress-backendconfig
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+spec:
+  timeoutSec: {{ .Values.ingress.timeoutSec }}
+  healthCheck:
+    checkIntervalSec: 10
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    type: HTTPS
+    port: 443
+    requestPath: /status
+  {{- if .Values.ingress.securityPolicy }}
+  securityPolicy:
+    name: {{ .Values.ingress.securityPolicy }}
+  {{- end }}
+{{- end }}

--- a/charts/calhoun/templates/ingress/cert.yaml
+++ b/charts/calhoun/templates/ingress/cert.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.cert.certManager.enabled }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ .Values.name }}-cert
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.name }}-cert
+  renewBefore: {{ .Values.ingress.cert.certManager.renewBefore }}
+  dnsNames:
+  - {{ template "calhoun.fqdn" . }}
+  issuerRef:
+    name: {{ .Values.ingress.cert.certManager.issuerName }}
+    kind: {{ .Values.ingress.cert.certManager.issuerKind }}
+{{ else if .Values.ingress.cert.vault.enabled -}}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-{{ .Values.name }}-cert
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+spec:
+  name: {{ .Values.name }}-cert
+  keysMap:
+    tls.crt:
+      path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}
+      key: {{ required "A valid ingress.cert.vault.cert.secretKey value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.secretKey }}
+    tls.key:
+      path: {{ required "A valid ingress.cert.vault.key.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.key.path }}
+      key: {{ required "A valid ingress.cert.vault.key.secretKey value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.key.secretKey }}
+    ca-bundle.crt:
+      path: {{ required "A valid ingress.cert.vault.chain.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.chain.path }}
+      key: {{ required "A valid ingress.cert.vault.chain.secretKey value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.chain.secretKey }}
+{{ end -}}

--- a/charts/calhoun/templates/ingress/frontendconfig.yaml
+++ b/charts/calhoun/templates/ingress/frontendconfig.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ .Values.name }}-ingress-frontendconfig
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+{{- if .Values.ingress.sslPolicy }}
+spec:
+  sslPolicy: {{ .Values.ingress.sslPolicy }}
+{{- end }}
+{{- end }}

--- a/charts/calhoun/templates/ingress/ingress.yaml
+++ b/charts/calhoun/templates/ingress/ingress.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Values.name }}-ingress
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+  annotations:
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
+    kubernetes.io/ingress.allow-http: "false"
+{{- if not (empty .Values.ingress.cert.preSharedCerts) }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.cert.preSharedCerts | join "," | quote }}
+{{- end }}
+spec:
+{{- if empty .Values.ingress.cert.preSharedCerts }}
+  tls:
+  - secretName: {{ .Values.name }}-cert
+{{- end }}
+  backend:
+    serviceName: {{ .Values.name }}-service
+    servicePort: 443
+{{- end }}

--- a/charts/calhoun/templates/ingress/service.yaml
+++ b/charts/calhoun/templates/ingress/service.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.ingress.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-service
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+  annotations:
+    # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
+    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
+    # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
+    cloud.google.com/neg: '{"ingress": true}'
+    # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb
+    cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "calhoun.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443
+{{- end }}

--- a/charts/calhoun/templates/role.yaml
+++ b/charts/calhoun/templates/role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.name }}-service-role
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - terra-default-psp
+- apiGroups: ['']
+  resources: ['secrets']
+  verbs: ['get', 'create']
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]

--- a/charts/calhoun/templates/role.yaml
+++ b/charts/calhoun/templates/role.yaml
@@ -10,12 +10,3 @@ rules:
   verbs:     ['use']
   resourceNames:
   - terra-default-psp
-- apiGroups: ['']
-  resources: ['secrets']
-  verbs: ['get', 'create']
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions", "apps"]
-  resources: ["deployments"]
-  verbs: ["get", "list", "watch"]

--- a/charts/calhoun/templates/rolebinding.yaml
+++ b/charts/calhoun/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.name }}-service-role-binding
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ .Values.name }}-service-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: {{ .Values.name }}-service-sa

--- a/charts/calhoun/templates/secrets.yaml
+++ b/charts/calhoun/templates/secrets.yaml
@@ -1,0 +1,49 @@
+{{ if .Values.vault.enabled }}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: {{ .Values.name }}-swagger-client
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+spec:
+  name: {{ .Values.name }}-swagger-client
+  keysMap:
+    id:
+      path: {{ .Values.vault.pathPrefix }}/calhoun/swagger-client
+      key: id
+    realm:
+      path: {{ .Values.vault.pathPrefix }}/calhoun/swagger-client
+      key: realm
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: {{ .Values.name }}-app-sa
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+spec:
+  name: {{ .Values.name }}-app-sa
+  keysMap:
+    service-account.json:
+      path: {{ .Values.vault.pathPrefix }}/calhoun/app-sa
+      encoding: base64
+      key: key
+{{- if .Values.proxy.tcell.enabled }}
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: {{ .Values.name }}-proxy-tcell-secrets
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}
+spec:
+  name: {{ .Values.name }}-proxy-tcell-secrets
+  keysMap:
+    app-id:
+      path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_app_id
+      key: tcell_app_id
+    api-key:
+      path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_api_key
+      key: tcell_api_key
+{{- end }}
+{{ end }}

--- a/charts/calhoun/templates/secrets.yaml
+++ b/charts/calhoun/templates/secrets.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   name: {{ .Values.name }}-swagger-client
   keysMap:
-    id:
+    client-id:
       path: {{ .Values.vault.pathPrefix }}/calhoun/swagger-client
-      key: id
+      key: client-id
     realm:
       path: {{ .Values.vault.pathPrefix }}/calhoun/swagger-client
       key: realm

--- a/charts/calhoun/templates/secrets.yaml
+++ b/charts/calhoun/templates/secrets.yaml
@@ -1,35 +1,5 @@
 {{ if .Values.vault.enabled }}
-apiVersion: secrets-manager.tuenti.io/v1alpha1
-kind: SecretDefinition
-metadata:
-  name: {{ .Values.name }}-swagger-client
-  labels:
-    {{- include "calhoun.labels" . | nindent 4 }}
-spec:
-  name: {{ .Values.name }}-swagger-client
-  keysMap:
-    client-id:
-      path: {{ .Values.vault.pathPrefix }}/calhoun/swagger-client
-      key: client-id
-    realm:
-      path: {{ .Values.vault.pathPrefix }}/calhoun/swagger-client
-      key: realm
----
-apiVersion: secrets-manager.tuenti.io/v1alpha1
-kind: SecretDefinition
-metadata:
-  name: {{ .Values.name }}-app-sa
-  labels:
-    {{- include "calhoun.labels" . | nindent 4 }}
-spec:
-  name: {{ .Values.name }}-app-sa
-  keysMap:
-    service-account.json:
-      path: {{ .Values.vault.pathPrefix }}/calhoun/app-sa
-      encoding: base64
-      key: key
 {{- if .Values.proxy.tcell.enabled }}
----
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:

--- a/charts/calhoun/templates/service-account.yaml
+++ b/charts/calhoun/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}-service-sa
+  labels:
+    {{- include "calhoun.labels" . | nindent 4 }}

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -164,3 +164,5 @@ proxy:
 
 calhoun:
   samRoot:
+  swaggerClientId:
+  swaggerRealm:

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -156,7 +156,7 @@ proxy:
     hostIdentifier:
   whitelist:
     # proxy.whitelist.enabled -- Enables proxy client email whitelisting
-    enabled: true
+    enabled: false
     # proxy.whitelist.email -- (string) Required if whitelisting is enabled. Email of buffer client Google service account
     email: null
   # proxy.reloadOnCertUpdate -- Whether to reload the deployment when the cert is updated. Requires stakater/Reloader service to be running in the cluster.

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -127,6 +127,15 @@ ingress:
         path:
         # ingress.cert.vault.chain.secretKey -- (string) Key in secret containing intermediate .crt
         secretKey:
+    
+    # If cert.certManager is enabled, it is used to configure the certificate and populate the k8s secret. Requires [cert-manager](https://github.com/jetstack/cert-manager)
+    certManager:
+      # ingress.cert.certManager.enabled -- Enable creating certificate secret with cert-manager
+      enabled: false
+      # ingress.cert.certManager.renewBefore -- When to renew the cert. Defaults to 30 days before expiry.
+      renewBefore: 720h0m0s
+      issuerName: cert-manager-letsencrypt-prod
+      issuerKind: ClusterIssuer
 
 proxy:
   # proxy.enable -- Enables OIDC proxy sidecar, used for TLS and TCell. Either `certManager` or `vaultCert` must be enabled if the proxy is enabled.

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -9,10 +9,6 @@ global:
 # name -- A name for the deployment that will be substituted into resource definitions
 name: calhoun
 
-# image -- (string) Used for local Skaffold deploys
-# @default -- Is set by Skaffold on local deploys
-image:
-
 imageConfig:
   # imageConfig.repository -- Image repository
   repository: gcr.io/broad-dsp-gcr-public/calhoun
@@ -80,6 +76,14 @@ ingress:
   # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
   timeoutSec: 120
 
+  domain:
+    # domain.hostname -- Hostname of this deployment
+    hostname: calhoun
+    # domain.namespaceEnv -- If true, an extra level of namespacing (`global.terraEnv`) will be added between the hostname and suffix
+    namespaceEnv: true
+    # domain.suffix -- Domain suffix
+    suffix: integ.envs.broadinstitute.org
+
   cert:
     # A TLS certificate is used for the GKE ingress and the OIDC proxy sidecar.
     # If preSharedCerts is not empty, its contents are used for the GKE ingress. Otherwise a secret with the cert is expected.
@@ -113,15 +117,6 @@ ingress:
         # ingress.cert.vault.chain.secretKey -- (string) Key in secret containing intermediate .crt
         secretKey:
 
-    # If cert.certManager is enabled, it is used to configure the certificate and populate the k8s secret. Requires [cert-manager](https://github.com/jetstack/cert-manager)
-    certManager:
-      # ingress.cert.certManager.enabled -- Enable creating certificate secret with cert-manager
-      enabled: false
-      # ingress.cert.certManager.renewBefore -- When to renew the cert. Defaults to 30 days before expiry.
-      renewBefore: 720h0m0s
-      issuerName: cert-manager-letsencrypt-prod
-      issuerKind: ClusterIssuer
-
 proxy:
   # proxy.enable -- Enables OIDC proxy sidecar, used for TLS and TCell. Either `certManager` or `vaultCert` must be enabled if the proxy is enabled.
   enabled: true
@@ -148,3 +143,4 @@ proxy:
   reloadOnCertUpdate: false
 
 calhoun:
+  samUrlRoot:

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -59,7 +59,7 @@ probes:
       successThreshold: 1
   startup:
     # probes.startup.enabled -- Whether to configure a startup probe
-    enabled: true
+    enabled: false
     spec:
       httpGet:
         path: /status
@@ -111,7 +111,7 @@ ingress:
     #   certificate from Vault to a k8s secret.
     vault:
       # ingress.cert.vault.enabled -- Enable syncing certificate secret from Vault. Requires [secrets-manager](https://github.com/tuenti/secrets-manager)
-      enabled: true
+      enabled: false
       cert:
         # ingress.cert.vault.cert.path -- (string) Path to secret containing .crt
         path: null

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -1,0 +1,150 @@
+# Global values used by this chart
+global:
+  # global.applicationVersion -- What version of the application to deploy
+  applicationVersion: latest
+  # global.terraEnv -- (string) Terget Terra environment name. Required.
+  # @default -- Is set by Helmfile on deploy
+  terraEnv: null
+
+# name -- A name for the deployment that will be substituted into resource definitions
+name: calhoun
+
+# image -- (string) Used for local Skaffold deploys
+# @default -- Is set by Skaffold on local deploys
+image:
+
+imageConfig:
+  # imageConfig.repository -- Image repository
+  repository: gcr.io/broad-dsp-gcr-public/calhoun
+  # imageConfig.tag -- (string) Image tag.
+  # @default -- global.applicationVersion
+  tag: null
+  imagePullPolicy: Always
+
+# replicas -- Number of replicas for the deployment
+replicas: 3
+
+resources:
+  requests:
+    # resources.requests.cpu -- Number of CPU units to request for the deployment
+    cpu: 2
+    # resources.requests.memory -- Memory to request for the deployment
+    memory: 4Gi
+  limits:
+    # resources.limits.cpu -- Number of CPU units to limit the deployment to
+    cpu: 2
+    # resources.limits.memory -- Memory to limit the deployment to
+    memory: 4Gi
+
+probes:
+  readiness:
+    # probes.readiness.enable -- Whether to configure a readiness probe
+    enabled: true
+    spec:
+      httpGet:
+        path: /status
+        port: 8000
+      timeoutSeconds: 5
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6
+      successThreshold: 1
+  liveness:
+    # probes.liveness.enable -- Whether to configure a liveness probe
+    enabled: true
+    spec:
+      httpGet:
+        path: /status
+        port: 8000
+      timeoutSeconds: 5
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      failureThreshold: 30 # 5 minutes before restarted
+      successThreshold: 1
+
+vault:
+  # vault.enabled -- When enabled, syncs required secrets from Vault
+  enabled: true
+  # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
+  pathPrefix:
+
+ingress:
+  # ingress.enabled -- Whether to create Ingress, Service and associated config resources
+  enabled: true
+  # ingress.staticIpName -- (string) Required. Name of the static IP, allocated in GCP, to associate with the Ingress
+  staticIpName: null
+  # ingress.sslPolicy -- (string) Name of a GCP SSL policy to associate with the Ingress
+  sslPolicy: null
+  # ingress.securityPolicy -- (string) Name of a GCP Cloud Armor security policy
+  securityPolicy: null
+  # ingressTimeout -- (number) number of seconds requests on the https loadbalancer will time out after
+  timeoutSec: 120
+
+  cert:
+    # A TLS certificate is used for the GKE ingress and the OIDC proxy sidecar.
+    # If preSharedCerts is not empty, its contents are used for the GKE ingress. Otherwise a secret with the cert is expected.
+    # The cert secret is required if the OIDC proxy is enabled.
+    # This secret can be
+    #   - synced from Vault
+    #   - created/managed with cert-manager
+    #   - created manually before the chart is applied
+
+    # ingress.cert.preSharedCerts -- Array of pre-shared GCP SSL certificate names to associate with the Ingress
+    preSharedCerts: []
+
+    # If cert.vault is enabled, a secrets-manager SecretDefinition resource is created to sync the
+    #   certificate from Vault to a k8s secret.
+    vault:
+      # ingress.cert.vault.enabled -- Enable syncing certificate secret from Vault. Requires [secrets-manager](https://github.com/tuenti/secrets-manager)
+      enabled: true
+      cert:
+        # ingress.cert.vault.cert.path -- (string) Path to secret containing .crt
+        path: null
+        # ingress.cert.vault.cert.secretKey -- (string) Key in secret containing .crt
+        secretKey: null
+      key:
+        # ingress.cert.vault.key.path -- (string) Path to secret containing .key
+        path: null
+        # ingress.cert.vault.key.secretKey -- (string) Key in secret containing .key
+        secretKey: null
+      chain:
+        # ingress.cert.vault.chain.path -- (string) Path to secret containing intermediate .crt
+        path:
+        # ingress.cert.vault.chain.secretKey -- (string) Key in secret containing intermediate .crt
+        secretKey:
+
+    # If cert.certManager is enabled, it is used to configure the certificate and populate the k8s secret. Requires [cert-manager](https://github.com/jetstack/cert-manager)
+    certManager:
+      # ingress.cert.certManager.enabled -- Enable creating certificate secret with cert-manager
+      enabled: false
+      # ingress.cert.certManager.renewBefore -- When to renew the cert. Defaults to 30 days before expiry.
+      renewBefore: 720h0m0s
+      issuerName: cert-manager-letsencrypt-prod
+      issuerKind: ClusterIssuer
+
+proxy:
+  # proxy.enable -- Enables OIDC proxy sidecar, used for TLS and TCell. Either `certManager` or `vaultCert` must be enabled if the proxy is enabled.
+  enabled: true
+  # proxy.logLevel -- Proxy log level
+  logLevel: debug
+  image:
+    # proxy.image.repository -- Proxy image repository
+    repository: broadinstitute/openidc-proxy
+    # proxy.image.version -- Proxy image tag
+    version: tcell_3_1_0
+  tcell:
+    # proxy.tcell.enabled -- Enables TCell
+    enabled: true
+    # proxy.tcell.vaultPrefix -- Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true.
+    vaultPrefix:
+    # proxy.tcell.hostIdentifier -- Identifier used for logging to TCell. Required if proxy.tcell.enabled is true
+    hostIdentifier:
+  whitelist:
+    # proxy.whitelist.enabled -- Enables proxy client email whitelisting
+    enabled: true
+    # proxy.whitelist.email -- (string) Required if whitelisting is enabled. Email of buffer client Google service account
+    email: null
+  # proxy.reloadOnCertUpdate -- Whether to reload the deployment when the cert is updated. Requires stakater/Reloader service to be running in the cluster.
+  reloadOnCertUpdate: false
+
+calhoun:

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -93,7 +93,7 @@ ingress:
     # domain.namespaceEnv -- If true, an extra level of namespacing (`global.terraEnv`) will be added between the hostname and suffix
     namespaceEnv: true
     # domain.suffix -- Domain suffix
-    suffix: integ.envs.broadinstitute.org
+    suffix: dsde-dev.broadinstitute.org
 
   cert:
     # A TLS certificate is used for the GKE ingress and the OIDC proxy sidecar.

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -39,7 +39,7 @@ probes:
     spec:
       httpGet:
         path: /status
-        port: 8000
+        port: 8080
       timeoutSeconds: 5
       initialDelaySeconds: 20
       periodSeconds: 10
@@ -51,7 +51,7 @@ probes:
     spec:
       httpGet:
         path: /status
-        port: 8000
+        port: 8080
       timeoutSeconds: 5
       initialDelaySeconds: 15
       periodSeconds: 10
@@ -63,7 +63,7 @@ probes:
     spec:
       httpGet:
         path: /status
-        port: 8000
+        port: 8080
       timeoutSeconds: 5
       periodSeconds: 10
       failureThreshold: 6

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -34,7 +34,7 @@ resources:
 
 probes:
   readiness:
-    # probes.readiness.enable -- Whether to configure a readiness probe
+    # probes.readiness.enabled -- Whether to configure a readiness probe
     enabled: true
     spec:
       httpGet:
@@ -46,7 +46,7 @@ probes:
       failureThreshold: 6
       successThreshold: 1
   liveness:
-    # probes.liveness.enable -- Whether to configure a liveness probe
+    # probes.liveness.enabled -- Whether to configure a liveness probe
     enabled: true
     spec:
       httpGet:
@@ -56,6 +56,17 @@ probes:
       initialDelaySeconds: 15
       periodSeconds: 10
       failureThreshold: 30 # 5 minutes before restarted
+      successThreshold: 1
+  startup:
+    # probes.startup.enabled -- Whether to configure a startup probe
+    enabled: true
+    spec:
+      httpGet:
+        path: /status
+        port: 8000
+      timeoutSeconds: 5
+      periodSeconds: 10
+      failureThreshold: 6
       successThreshold: 1
 
 vault:

--- a/charts/calhoun/values.yaml
+++ b/charts/calhoun/values.yaml
@@ -163,4 +163,4 @@ proxy:
   reloadOnCertUpdate: false
 
 calhoun:
-  samUrlRoot:
+  samRoot:


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-2746

Add a helm chart for the calhoun (notebook preview) service.

Friends with: https://github.com/broadinstitute/terra-helmfile/pull/1383

I generally used some MC Terra (e.g. `buffer`) services as a model. Calhoun doesn't have any pre-existing ctmpls in firecloud-develop so it's more of a "new" service than a migration of an old GCE service.

Manually deployed to dev: https://calhoun.dsde-dev.broadinstitute.org/swagger-ui/