### PR TITLE
DDO-1261 Remove applicationVersion override for OpenDJ

### DIFF
--- a/charts/opendj/templates/service.yaml
+++ b/charts/opendj/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "opendj.labels" . | nindent 4 }}
 spec:
   type: LoadBalancer
-  loadBalancerIP: {{ required "A valid serviceIP value is required!" .Values.service.staticIp }}
+  loadBalancerIP: {{ required "A valid .service.staticIp value is required!" .Values.service.staticIp }}
   {{- if .Values.service.firewallEnabled }}
   loadBalancerSourceRanges:
   {{- template "opendj.firewall" . }}

--- a/charts/opendj/templates/statefulset.yaml
+++ b/charts/opendj/templates/statefulset.yaml
@@ -1,4 +1,3 @@
-{{- $imageTag := .Values.imageConfig.tag | default .Values.global.applicationVersion -}}
 {{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Chart.Name -}}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -31,7 +30,7 @@ spec:
           defaultMode: 0744
       containers:
       - name: {{ .Values.name }}
-        image: {{ .Values.imageConfig.repository }}:{{ $imageTag }}
+        image: {{ .Values.imageConfig.repository }}:{{  .Values.imageConfig.tag }}
         imagePullPolicy: {{ .Values.imageConfig.pullPolicy }}
         envFrom:
         - secretRef:

--- a/charts/opendj/values.yaml
+++ b/charts/opendj/values.yaml
@@ -1,6 +1,4 @@
 global:
-  # global.applicationVersion -- What version of the application to deploy
-  applicationVersion: opendj_3
   # global.trustedAddresses -- A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }`
   trustedAddresses: {}
 
@@ -11,8 +9,7 @@ imageConfig:
   # imageConfig.repository -- Image repository
   repository: broadinstitute/openam
   # imageConfig.tag -- (string) Image tag.
-  # @default -- global.applicationVersion
-  tag:
+  tag: opendj_3
   imagePullPolicy: Always
 
 # replicas -- Number of replicas for the deployment


### PR DESCRIPTION
This way:
* We have a single location where OpenDJ's container image version is set
* We can match the pattern followed by the other stateful services