### PR TITLE
Switch OpenDJ back to the default rolling update strategy

### DIFF
--- a/charts/opendj/templates/statefulset.yaml
+++ b/charts/opendj/templates/statefulset.yaml
@@ -12,8 +12,6 @@ spec:
   selector:
     matchLabels:
       {{- include "opendj.selectorLabels" . | nindent 6 }}
-  updateStrategy:
-    type: OnDelete
   template:
     metadata:
       labels:


### PR DESCRIPTION
The OnDelete strategy means that someone has to manually delete the OpenDJ pod to trigger a restart. This can lead to unfortunate suprises, for example when I synced OpenDJ in alpha yesterday but the pod didn't actually update. (Props to @mflinn-broad for setting up Prometheus alerts that caught this).

I'm guessing the OnDelete strategy was originally added as a layer of "protection" to prevent automatic OpenDJ restarts; but we already require manual ArgoCD syncs for stateful services, so IMO this layer of protection is unnecessary.