### PR TITLE
DDO-1268 Define azure credentials for atlantis declaratively

### DIFF
--- a/charts/dsp-atlantis/Chart.yaml
+++ b/charts/dsp-atlantis/Chart.yaml
@@ -16,4 +16,4 @@ sources:
 dependencies:
 - name: atlantis
   version: 3.12.2
-  repository: https://runatlantis.github.io/helm-charts
+  repository: https://runatlantis.github.io/helm-charts/

--- a/charts/dsp-atlantis/Chart.yaml
+++ b/charts/dsp-atlantis/Chart.yaml
@@ -15,5 +15,5 @@ sources:
 
 dependencies:
 - name: atlantis
-  version: 3.12.2
-  repository: https://runatlantis.github.io/helm-charts/
+  version: 3.12.4
+  repository: https://runatlantis.github.io/helm-charts

--- a/charts/dsp-atlantis/Chart.yaml
+++ b/charts/dsp-atlantis/Chart.yaml
@@ -16,4 +16,4 @@ sources:
 dependencies:
 - name: atlantis
   version: 3.12.2
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://runatlantis.github.io/helm-charts

--- a/charts/dsp-atlantis/templates/azureCredentials.yaml
+++ b/charts/dsp-atlantis/templates/azureCredentials.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.azure.enabled -}}
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: {{ .Values.name }}-azure-creds-secretdefinition
+  labels:
+    {{- template "dsp-atlantis.labels" }}
+spec:
+  name: azure-cert
+  keysMap:
+    {{ .Values.azure.certificateFile }}:
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/certificate
+      encoding: base64
+      key: {{ .Values.azure.certificateFile }}.b64
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: {{ .Values.name }}-azure-env-secretdefinition
+  labels:
+    {{- template "dsp-atlantis.labels" }}
+spec:
+  name: azure-env
+  keysMap:
+    ARM_CLIENT_CERTIFICATE_PASSWORD:
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/env
+      key: ARM_CLIENT_CERTIFICATE_PASSWORD
+    ARM_CLIENT_ID:
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/env
+      key: ARM_CLIENT_ID
+    ARM_TENANT_ID:
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/env
+      key: ARM_TENANT_ID
+{{- end -}}

--- a/charts/dsp-atlantis/values.yaml
+++ b/charts/dsp-atlantis/values.yaml
@@ -1,3 +1,4 @@
+name: atlantis
 serviceAccount: atlantis
 cert:
   secretName: atlantis-cert
@@ -12,3 +13,9 @@ atlantis:
   fullnameOverride: atlantis
   serviceAccount:
     name: atlantis
+azure:
+  enabled: true
+  certificateFile: atlantis-test-sp.pfx
+vault:
+  azure:
+    pathPrefix: secret/devops/terraform/azure

--- a/charts/dsp-atlantis/values.yaml
+++ b/charts/dsp-atlantis/values.yaml
@@ -14,8 +14,8 @@ atlantis:
   serviceAccount:
     name: atlantis
 azure:
-  enabled: true
-  certificateFile: atlantis-test-sp.pfx
+  enabled: false
+  certificateFile: "azure-cert.pfx"
 vault:
   azure:
-    pathPrefix: secret/devops/terraform/azure
+    pathPrefix: /path/to/azure/secrets


### PR DESCRIPTION
This pr adds support for defining secrets holding credentials declaratively via secrets-manager rather than creating them manually. This pr adds support just for managing azure credentials but could easily be extended to support gcp credentials as well. 

Additionally we were previously using an atlantis chart from the now deprecated `helm-stable` chart repo which was deprecated  back in November. I switched the atlantis dependency over to the new atlantis chart repo so that we can actually build new versions of this chart.