### PR TITLE
DUOS-1273[risk=no]Dataset Metrics View - add metrics api url to config

### DIFF
--- a/charts/duos/README.md
+++ b/charts/duos/README.md
@@ -13,6 +13,7 @@ Current chart version is `0.6.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiUrl | string | `nil` | The Consent API url |
+| metricsApiUrl | string | `nil` | The Consent Metrics API url |
 | devDeploy | bool | `false` |  |
 | environment | string | `nil` | The environment of the service. Required |
 | errorApiKey | string | `nil` | The StackDriver API client id |

--- a/charts/duos/README.md
+++ b/charts/duos/README.md
@@ -13,7 +13,7 @@ Current chart version is `0.6.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiUrl | string | `nil` | The Consent API url |
-| metricsApiUrl | string | `nil` | The Consent Metrics API url |
+| metricApiUrl | string | `nil` | The Consent Metrics API url |
 | devDeploy | bool | `false` |  |
 | environment | string | `nil` | The environment of the service. Required |
 | errorApiKey | string | `nil` | The StackDriver API client id |

--- a/charts/duos/templates/_config.json.tpl
+++ b/charts/duos/templates/_config.json.tpl
@@ -4,6 +4,7 @@
   "hash": "{{ .Values.global.applicationVersion }}",
   "tag": "{{ .Values.global.applicationVersion }}",
   "apiUrl": "{{ .Values.apiUrl }}",
+  "metricsApiUrl": "{{ .Values.metricsApiUrl }}",
   "ontologyApiUrl": "{{ .Values.ontologyApiUrl }}",
   "clientId": "{{ .Values.googleClientId }}",
   "errorApiKey": "{{ .Values.errorApiKey }}",

--- a/charts/duos/templates/_config.json.tpl
+++ b/charts/duos/templates/_config.json.tpl
@@ -4,7 +4,7 @@
   "hash": "{{ .Values.global.applicationVersion }}",
   "tag": "{{ .Values.global.applicationVersion }}",
   "apiUrl": "{{ .Values.apiUrl }}",
-  "metricsApiUrl": "{{ .Values.metricsApiUrl }}",
+  "metricApiUrl": "{{ .Values.metricApiUrl }}",
   "ontologyApiUrl": "{{ .Values.ontologyApiUrl }}",
   "clientId": "{{ .Values.googleClientId }}",
   "errorApiKey": "{{ .Values.errorApiKey }}",

--- a/charts/duos/values.yaml
+++ b/charts/duos/values.yaml
@@ -11,6 +11,9 @@ environment:
 # apiUrl -- (string) The Consent API url
 apiUrl:
 
+# metricsApiUrl -- (string) The Consent Metrics API url
+metricsApiUrl:
+
 # ontologyApiUrl -- (string) The Ontology API url
 ontologyApiUrl:
 

--- a/charts/duos/values.yaml
+++ b/charts/duos/values.yaml
@@ -11,8 +11,8 @@ environment:
 # apiUrl -- (string) The Consent API url
 apiUrl:
 
-# metricsApiUrl -- (string) The Consent Metrics API url
-metricsApiUrl:
+# metricApiUrl -- (string) The Consent Metrics API url
+metricApiUrl:
 
 # ontologyApiUrl -- (string) The Ontology API url
 ontologyApiUrl:


### PR DESCRIPTION
SCOPE:
Add the metrics api url to the env config and readme
ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1273