### PR TITLE
DUOS-1296[risk=no]Update api url in configs

### DIFF
--- a/charts/duos/README.md
+++ b/charts/duos/README.md
@@ -13,7 +13,6 @@ Current chart version is `0.6.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiUrl | string | `nil` | The Consent API url |
-| metricApiUrl | string | `nil` | The Consent Metrics API url |
 | devDeploy | bool | `false` |  |
 | environment | string | `nil` | The environment of the service. Required |
 | errorApiKey | string | `nil` | The StackDriver API client id |

--- a/charts/duos/templates/_config.json.tpl
+++ b/charts/duos/templates/_config.json.tpl
@@ -4,7 +4,6 @@
   "hash": "{{ .Values.global.applicationVersion }}",
   "tag": "{{ .Values.global.applicationVersion }}",
   "apiUrl": "{{ .Values.apiUrl }}",
-  "metricApiUrl": "{{ .Values.metricApiUrl }}",
   "ontologyApiUrl": "{{ .Values.ontologyApiUrl }}",
   "clientId": "{{ .Values.googleClientId }}",
   "errorApiKey": "{{ .Values.errorApiKey }}",

--- a/charts/duos/values.yaml
+++ b/charts/duos/values.yaml
@@ -11,9 +11,6 @@ environment:
 # apiUrl -- (string) The Consent API url
 apiUrl:
 
-# metricApiUrl -- (string) The Consent Metrics API url
-metricApiUrl:
-
 # ontologyApiUrl -- (string) The Ontology API url
 ontologyApiUrl:
 


### PR DESCRIPTION
SCOPE: this PR reverts changes from DUOS-1273 because now the api url value is updated to the old value of the metric api url so we no longer need the metric api url
ADDRESSES: https://broadworkbench.atlassian.net/browse/DUOS-1296
