### PR TITLE
Mount new Cromwell config file

### DIFF
--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -99,6 +99,10 @@ spec:
           subPath: cromwell.conf
           name: app-ctmpls
           readOnly: true
+        - mountPath: /etc/cromwell_papi_v2_beta_config.conf
+          subPath: cromwell_papi_v2_beta_config.conf
+          name: app-ctmpls
+          readOnly: true
         - mountPath: /etc/cromwell-account.json
           subPath: cromwell-account.json
           name: app-ctmpls


### PR DESCRIPTION
Mount the new config file `cromwell_papi_v2_beta_config.conf` inside the Cromwell pod.

Added here: https://github.com/broadinstitute/firecloud-develop/pull/2556

We're working on making this workflow better, thanks for your patience!