### PR TITLE
DDO-1324 Update Cromiam API version

### DIFF
--- a/charts/cromiam/templates/ingress/backendconfig.yaml
+++ b/charts/cromiam/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Chart.Name }}-ingress-backendconfig


### PR DESCRIPTION
It seems the `cloud.google.com/v1beta1` BackendConfig version stopped working in `1.19.10-gke.1600`. Google support has asked us to switch to `cloud.google.com/v1`.

I want to verify it works with cromiam first, afterwards I will update all the BackendConfigs