### PR TITLE
DDO-1324 Set API version to `cloud.google.com/v1` in all BackendConfig manifests

### DIFF
--- a/charts/agora/templates/ingress/backendconfig.yaml
+++ b/charts/agora/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Chart.Name }}-ingress-backendconfig

--- a/charts/buffer/templates/ingress/backendconfig.yaml
+++ b/charts/buffer/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/consent/templates/ingress.yaml
+++ b/charts/consent/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   sslPolicy: {{ .Values.sslPolicy }}
 ---
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Chart.Name }}-ingress-backendconfig

--- a/charts/duos/templates/ingress/backendConfig.yaml
+++ b/charts/duos/templates/ingress/backendConfig.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Chart.Name }}-ingress-backendconfig

--- a/charts/externalcreds/templates/ingress/backendconfig.yaml
+++ b/charts/externalcreds/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/firecloudorch/templates/ingress/backendConfig.yaml
+++ b/charts/firecloudorch/templates/ingress/backendConfig.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/firecloudui/templates/ingress/backendconfig.yaml
+++ b/charts/firecloudui/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/jobmanager/templates/ingress/backendconfig.yaml
+++ b/charts/jobmanager/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/leonardo/templates/ingress/backendconfig.yaml
+++ b/charts/leonardo/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Chart.Name }}-ingress-backendconfig

--- a/charts/rawls/templates/ingress.yaml
+++ b/charts/rawls/templates/ingress.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   sslPolicy: {{ .Values.ingress.sslPolicy }}
 --- 
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Chart.Name }}-ingress-backendconfig

--- a/charts/sam/templates/ingress/backendconfig.yaml
+++ b/charts/sam/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/thurloe/templates/ingress/backendconfig.yaml
+++ b/charts/thurloe/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/charts/workspacemanager/templates/ingress/backendconfig.yaml
+++ b/charts/workspacemanager/templates/ingress/backendconfig.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: cloud.google.com/v1beta1
+apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Values.name }}-ingress-backendconfig

--- a/release-strategy.json
+++ b/release-strategy.json
@@ -1,15 +1,1 @@
-{
-    "consent":          {"dev_only": false},
-    "crljanitor":       {"dev_only": false},
-    "cromwell":         {"dev_only": false},
-    "externalcreds":    {"dev_only": false},
-    "firecloudorch":    {"dev_only": false},
-    "leonardo":         {"dev_only": false},
-    "ontology":         {"dev_only": false},
-    "poc":              {"dev_only": false},
-    "rawls":            {"dev_only": false},
-    "sam":              {"dev_only": false},
-    "opendj":           {"dev_only": false},
-    "buffer":           {"dev_only": false},
-    "workspacemanager": {"dev_only": false}
-}
+{}


### PR DESCRIPTION
I am probably going to disable the chart autoreleaser before merging and then re-enable it with a commit directly to master... Just to avoid all the noise from failed automerges.