### PR TITLE
Move annotations to be top metadata

### DIFF
--- a/charts/cromiam/templates/deployment.yaml
+++ b/charts/cromiam/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Chart.Name }}-deployment
   labels:
 {{ include "cromiam.labels" . | indent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 spec:
   strategy:
     type: RollingUpdate
@@ -23,9 +27,6 @@ spec:
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
         checksum/{{ .Chart.Name }}-cm: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- range $key, $value := .Values.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-sa
       # Containers are configured to talk to each other by name

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -10,6 +10,10 @@ metadata:
   name: {{ $settings.name }}
   labels:
 {{ include "cromwell.labels" . | indent 4 }}
+  annotations:
+    {{- range $key, $value := $settings.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 spec:
   revisionHistoryLimit: 0 # Cromwell is resource-intensive
   strategy:
@@ -28,10 +32,7 @@ spec:
 {{ include "cromwell.labels" . | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }}
-        {{- range $key, $value := $settings.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
+        checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }
     spec:
       serviceAccountName: cromwell-sa
       # Containers are configured to talk to each other by name

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -32,7 +32,7 @@ spec:
 {{ include "cromwell.labels" . | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }
+        checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }}
     spec:
       serviceAccountName: cromwell-sa
       # Containers are configured to talk to each other by name

--- a/charts/leonardo/templates/deployments/_deployment.tpl
+++ b/charts/leonardo/templates/deployments/_deployment.tpl
@@ -10,6 +10,10 @@ metadata:
   name: {{ $settings.name }}-deployment
   labels:
 {{ include "leonardo.labels" . | indent 4 }}
+  annotations:
+    {{- range $key, $value := $settings.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 spec:
   strategy:
     type: RollingUpdate
@@ -29,9 +33,6 @@ spec:
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
         checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }}
-        {{- range $key, $value := $settings.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
     spec:
       serviceAccountName: leonardo-sa
       # Containers are configured to talk to each other by name

--- a/charts/ncbiaccess/templates/deployment.yaml
+++ b/charts/ncbiaccess/templates/deployment.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}-deployment
   labels: {{ include "ncbiaccess.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 spec:
   revisionHistoryLimit: 0
   strategy:
@@ -17,10 +21,6 @@ spec:
   template:
     metadata:
       labels: {{- include "ncbiaccess.labels" . | nindent 8 }}
-      annotations:
-        {{- range $key, $value := .Values.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
     spec:
       serviceAccountName: {{ .Values.name }}-sa
       volumes:

--- a/charts/rawls/templates/_deployment.tpl
+++ b/charts/rawls/templates/_deployment.tpl
@@ -10,6 +10,10 @@ metadata:
   name: {{ $settings.name }}-deployment
   labels:
 {{ include "rawls.labels" . | indent 4 }}
+  annotations:
+    {{- range $key, $value := $settings.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 spec:
   replicas: {{ $settings.replicas }}
   revisionHistoryLimit: 0
@@ -29,9 +33,6 @@ spec:
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
         checksum/{{ $settings.name }}-cm: {{ $outputs.configmapChecksum }}
-        {{- range $key, $value := $settings.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
     spec:
       serviceAccountName: rawls-sa
       hostAliases:

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -5,10 +5,13 @@ metadata:
   name: {{ .Values.name }}-deployment
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
-  {{- if and .Values.proxy.enabled .Values.proxy.reloadOnCertUpdate }}
   annotations:
-    reloader.stakater.com/auto: "true"
-  {{- end }}
+    {{- if and .Values.proxy.enabled .Values.proxy.reloadOnCertUpdate }}
+      reloader.stakater.com/auto: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
 spec:
   revisionHistoryLimit: 0
   strategy:
@@ -34,9 +37,6 @@ spec:
         {{- end }}
         {{- if .Values.prometheus.enabled }}
         checksum/{{ .Values.name }}-prometheus-configmap: {{ include (print $.Template.BasePath "/configmaps/prometheus-configmap.yaml") . | sha256sum }}
-        {{- end }}
-        {{- range $key, $value := .Values.annotations }}
-        {{ $key }}: {{ $value }}
         {{- end }}
     spec:
       serviceAccountName: {{ .Values.name }}-service-sa


### PR DESCRIPTION
The linter currently looks for exemptions by looking at annotations associated with the deployment.  Annotations were mistakenly added at the container level which caused builds to break. This PR is a bug fix. 

Succeeding build: https://github.com/broadinstitute/terra-helmfile/pull/1423/checks?check_run_id=2932978845