### PR TITLE
[DDO-1354] Adding liquibase-migration chart to leonardo's

### DIFF
--- a/charts/leonardo/Chart.yaml
+++ b/charts/leonardo/Chart.yaml
@@ -11,3 +11,8 @@ sources:
   - https://github.com/broadinstitute/terra-helm/
   - https://github.com/DataBiosphere/leonardo
   - https://github.com/broadinstitute/leonardo-cron-jobs
+dependencies:
+  - name: liquibase-migration
+    condition: migration.enabled
+    version: 0.2.0
+    repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/leonardo/README.md
+++ b/charts/leonardo/README.md
@@ -1,20 +1,24 @@
-leonardo
-========
+# leonardo
 
-A Helm chart for Leonardo, Terra's Jupyter notebook integration service
+A Helm chart for Leonardo, a Terra service for interactive analysis applications
 
+## Requirements
 
+| Repository | Name | Version |
+|------------|------|---------|
+| https://broadinstitute.github.io/terra-helm/ | liquibase-migration | 0.2.0 |
 
-## Chart Values
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | commonCronjob.reportDestinationBucket | string | `nil` |  |
+| cronjob.enabled | bool | `false` |  |
 | cronjob.googleProject | string | `nil` |  |
 | cronjob.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/resource-validator"` |  |
-| cronjob.imageTag | string | `"59b370b"` |  |
+| cronjob.imageTag | string | `"2ebc9e3"` |  |
 | cronjob.name | string | `"leonardo-resource-validator-cronjob"` |  |
-| deploymentDefaults.annotation | object | `nil` | Additational metadata to attach |
+| deploymentDefaults.annotations | object | `{}` |  |
 | deploymentDefaults.enabled | bool | `true` | Whether a declared deployment is enabled. If false, no resources will be created |
 | deploymentDefaults.imageRepository | string | `"gcr.io/broad-dsp-gcr-public/leonardo"` | Image repo to pull Leonardo images from |
 | deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @default global.applicationVersion |
@@ -24,7 +28,7 @@ A Helm chart for Leonardo, Terra's Jupyter notebook integration service
 | deploymentDefaults.probes.readiness.enabled | bool | `true` |  |
 | deploymentDefaults.probes.readiness.spec | object | `{"failureThreshold":6,"httpGet":{"path":"/status","port":8080},"initialDelaySeconds":15,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the readiness probe to deploy, if enabled |
 | deploymentDefaults.probes.startup.enabled | bool | `true` |  |
-| deploymentDefaults.probes.startup.spec | object | `{"failureThreshold":1080,"httpGet":{"path":"/version","port":8080},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the liveness probe to deploy, if enabled |
+| deploymentDefaults.probes.startup.spec | object | `{"failureThreshold":1080,"httpGet":{"path":"/version","port":8080},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the startup probe to deploy, if enabled |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deployments.standalone.name | string | `"leonardo"` | Name to use for the default standalone Leonardo deployment |
 | deployments.standalone.replicas | int | `1` | Number of replicas in the default standalone Leonardo deployment |
@@ -35,8 +39,21 @@ A Helm chart for Leonardo, Terra's Jupyter notebook integration service
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `28800` | Load balancer backend timeout (Leonardo has a large backend timeout to support long-lived websockets -- see DDO-132 / IA-1665) |
+| janitorCron.enabled | bool | `false` |  |
+| janitorCron.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/janitor"` |  |
+| janitorCron.imageTag | string | `"2ebc9e3"` |  |
+| janitorCron.name | string | `"leonardo-janitor-cronjob"` |  |
+| migration.enabled | bool | `false` | (bool) Whether to run a Liquibase migration during sync |
+| migration.imageName | string | `"gcr.io/broad-dsp-gcr-public/leonardo"` | (string) Required full app image name, without trailing tag |
+| migration.jarLocation | string | `"$(find /leonardo -name 'leonardo*.jar')"` | (string) Required jar location in app image, expanded by migration.appContainerShell |
+| migration.liquibaseCommand | string | `"updateSQL"` | (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run |
+| migration.secretPrefix | string | `"leonardo-backend"` | (string) Required prefix of -app-ctmpls, -sqlproxy-ctmpls, -sqlproxy-env secrets |
 | monitoring.enabled | bool | `true` | Whether to enable Prometheus monitoring for Leonardo pods |
+| vault.migration.dbPasswordKey | string | `"db_password"` |  |
+| vault.migration.dbUsernameKey | string | `"db_user"` | Key in Vault secret to DB username |
+| vault.migration.path | string | `nil` | Vault path to secret containing DB credentials |
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |
+| zombieMonitorCron.enabled | bool | `false` |  |
 | zombieMonitorCron.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/zombie-monitor"` |  |
-| zombieMonitorCron.imageTag | string | `"59b370b"` |  |
+| zombieMonitorCron.imageTag | string | `"2ebc9e3"` |  |
 | zombieMonitorCron.name | string | `"leonardo-zombie-monitor-cronjob"` |  |

--- a/charts/leonardo/templates/migration.yaml
+++ b/charts/leonardo/templates/migration.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.migration.enabled -}}
+{{ template "liquibase-migration.secretDefinition" . }}
+---
+{{ template "liquibase-migration.job" . }}
+{{- end -}}

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -125,7 +125,7 @@ vault:
     dbPasswordKey: "db_password"
 
 migration:
-  # migration.enabled -- (bool) Whether to run a Liquibase migration during sync
+  # migration.enabled -- (bool) Whether to run a Liquibase migration during sync (when enabled, creates K8s resources)
   enabled: false
   # migration.liquibaseCommand -- (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run, "update" for normal operation
   # See https://docs.liquibase.com/commands/home.html

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -115,3 +115,23 @@ zombieMonitorCron:
 vault:
   # vault.pathPrefix -- (string) Vault path prefix for secrets. Required if vault.enabled.
   pathPrefix:
+  # Migration credentials only referenced if migration.enabled == true
+  migration:
+    # vault.migration.path -- Vault path to secret containing DB credentials
+    path: null
+    # vault.migration.dbUsernameKey -- Key in Vault secret to DB username
+    dbUsernameKey: "db_user"
+    # vault.migration.DbPasswordKey -- Key in Vault secret to DB password
+    dbPasswordKey: "db_password"
+
+migration:
+  # migration.enabled -- (bool) Whether to run a Liquibase migration during sync
+  enabled: false
+  # migration.liquibaseCommand -- (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run
+  liquibaseCommand: "updateSQL"
+  # migration.imageName -- (string) Required full app image name, without trailing tag
+  imageName: "gcr.io/broad-dsp-gcr-public/leonardo"
+  # migration.jarLocation -- (string) Required jar location in app image, expanded by migration.appContainerShell
+  jarLocation: "$(find /leonardo -name 'leonardo*.jar')"
+  # migration.secretPrefix -- (string) Required prefix of -app-ctmpls, -sqlproxy-ctmpls, -sqlproxy-env secrets
+  secretPrefix: "leonardo-backend"

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -127,7 +127,8 @@ vault:
 migration:
   # migration.enabled -- (bool) Whether to run a Liquibase migration during sync
   enabled: false
-  # migration.liquibaseCommand -- (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run
+  # migration.liquibaseCommand -- (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run, "update" for normal operation
+  # See https://docs.liquibase.com/commands/home.html
   liquibaseCommand: "updateSQL"
   # migration.imageName -- (string) Required full app image name, without trailing tag
   imageName: "gcr.io/broad-dsp-gcr-public/leonardo"


### PR DESCRIPTION
Adds the [liquibase-migration](https://github.com/broadinstitute/terra-helm/tree/master/charts/liquibase-migration) library chart to Leonardo's. Also re-ran the `helm-docs` tool since it seems like no one had run it for a bit.

This won't work--`migration.enabled` shouldn't be set to true anywhere--until https://github.com/broadinstitute/firecloud-develop/pull/2598 has been merged and is in dev. The liquibase-migration chart will expect the liquibase.properties file to already be present in the set of rendered app ctmpl files. 

Once that PR is merged, we can make a terra-helmfile PR with [this diff](https://github.com/broadinstitute/terra-helmfile/compare/DDO-1354-leonardo-liquibase-sync-job) to enable it in dry-run mode for dev (dry-run is defaulted to [here](https://github.com/broadinstitute/terra-helm/pull/414/files#diff-7112dda8e5cc9bfb6e7b7c113a2534b120c2505a761f958bf0ecb14d5a88fff0R131)). We'd merge this PR next, and CI will go and update the chart version in terra-helm so we can drop https://github.com/broadinstitute/terra-helmfile/commit/b84385cda5d3eb0001be4127d893a0fd00f4d0a4 from that helmfile PR (it is there so we can test).