### PR TITLE
* DDO-1359 Update image tag

### DIFF
--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -139,7 +139,7 @@ spec:
           {{- toYaml $settings.probes.startup.spec | nindent 10 }}
         {{- end }}
       - name: {{ $settings.name }}-proxy
-        image: {{ $settings.sourceProxyImage }}:{{ $settings.imageTag }}
+        image: {{ $settings.proxyImage }}
         ports:
           - containerPort: 443
           - containerPort: 80

--- a/charts/cromwell/templates/_deployment.tpl
+++ b/charts/cromwell/templates/_deployment.tpl
@@ -139,7 +139,7 @@ spec:
           {{- toYaml $settings.probes.startup.spec | nindent 10 }}
         {{- end }}
       - name: {{ $settings.name }}-proxy
-        image: {{ $settings.proxyImage }}
+        image: {{ $settings.sourceProxyImage }}:{{ $settings.imageTag }}
         ports:
           - containerPort: 443
           - containerPort: 80

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -16,7 +16,7 @@ deploymentDefaults:
   name: null
   # deploymentDefaults.imageTag -- Image tag to be used when deploying Pods
   # @defautl global.applicationVersion
-  imageTag: null
+  imageTag: tcell_3_1_0
   # deploymentDefaults.replicas -- Number of replicas for the deployment
   replicas: 0
   # deploymentDefaults.expose -- Whether to create a Service for this deployment

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -35,7 +35,7 @@ deploymentDefaults:
   # deploymentDefaults.tolerations -- (array) Optional array of tolerations
   tolerations: null
   # deploymentDefaults.proxyImage -- Image that the OIDC proxy uses
-  proxyImage: broadinstitute/openidc-proxy:tcell-mpm-big
+  sourceProxyImage: broadinstitute/openidc-proxy
   probes:
     readiness:
       # deploymentDefaults.probes.readiness.enabled -- Whether to configure a readiness probe

--- a/charts/cromwell/values.yaml
+++ b/charts/cromwell/values.yaml
@@ -16,7 +16,7 @@ deploymentDefaults:
   name: null
   # deploymentDefaults.imageTag -- Image tag to be used when deploying Pods
   # @defautl global.applicationVersion
-  imageTag: tcell_3_1_0
+  imageTag: null
   # deploymentDefaults.replicas -- Number of replicas for the deployment
   replicas: 0
   # deploymentDefaults.expose -- Whether to create a Service for this deployment
@@ -35,7 +35,7 @@ deploymentDefaults:
   # deploymentDefaults.tolerations -- (array) Optional array of tolerations
   tolerations: null
   # deploymentDefaults.proxyImage -- Image that the OIDC proxy uses
-  sourceProxyImage: broadinstitute/openidc-proxy
+  proxyImage: broadinstitute/openidc-proxy:tcell_3_1_0
   probes:
     readiness:
       # deploymentDefaults.probes.readiness.enabled -- Whether to configure a readiness probe

--- a/charts/leonardo/templates/deployments/_deployment.tpl
+++ b/charts/leonardo/templates/deployments/_deployment.tpl
@@ -164,7 +164,7 @@ spec:
           {{- toYaml $settings.probes.startup.spec | nindent 10 }}
         {{- end }}
       - name: {{ $settings.name }}-proxy
-        image: broadinstitute/openidc-proxy:tcell-mpm-big
+        image: {{ $settings.sourceProxyImage }}:{{ $settings.imageTag }}
         ports:
           - containerPort: 443
           - containerPort: 80

--- a/charts/leonardo/templates/deployments/_deployment.tpl
+++ b/charts/leonardo/templates/deployments/_deployment.tpl
@@ -164,7 +164,7 @@ spec:
           {{- toYaml $settings.probes.startup.spec | nindent 10 }}
         {{- end }}
       - name: {{ $settings.name }}-proxy
-        image: {{ $settings.sourceProxyImage }}:{{ $settings.imageTag }}
+        image: {{ $settings.proxyImage }}
         ports:
           - containerPort: 443
           - containerPort: 80

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -58,6 +58,8 @@ deploymentDefaults:
         periodSeconds: 10
         failureThreshold: 1080 # 3 hours before restarted, to prevent liveness probes from interrupting long-running liquibase migrations
         successThreshold: 1
+  # deploymentDefaults.proxyImage -- Image that the OIDC proxy uses
+  sourceProxyImage: broadinstitute/openidc-proxy
 # A map of Leonardo deployments. In Terra's production environment,
 # Leonardo is deployed as two services (backend and frontend)
 # with different configurations.

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -16,7 +16,7 @@ deploymentDefaults:
   imageRepository: gcr.io/broad-dsp-gcr-public/leonardo
   # deploymentDefaults.imageTag -- Image tag to be used when deploying Pods
   # @default global.applicationVersion
-  imageTag: tcell_3_1_0
+  imageTag: null
   # deploymentDefaults.replicas -- Number of replicas for the deployment
   replicas: 0
   probes:
@@ -59,7 +59,7 @@ deploymentDefaults:
         failureThreshold: 1080 # 3 hours before restarted, to prevent liveness probes from interrupting long-running liquibase migrations
         successThreshold: 1
   # deploymentDefaults.proxyImage -- Image that the OIDC proxy uses
-  sourceProxyImage: broadinstitute/openidc-proxy
+  proxyImage: broadinstitute/openidc-proxy:tcell_3_1_0
 # A map of Leonardo deployments. In Terra's production environment,
 # Leonardo is deployed as two services (backend and frontend)
 # with different configurations.

--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -16,7 +16,7 @@ deploymentDefaults:
   imageRepository: gcr.io/broad-dsp-gcr-public/leonardo
   # deploymentDefaults.imageTag -- Image tag to be used when deploying Pods
   # @default global.applicationVersion
-  imageTag: null
+  imageTag: tcell_3_1_0
   # deploymentDefaults.replicas -- Number of replicas for the deployment
   replicas: 0
   probes:


### PR DESCRIPTION
This PR updates the Cromwell and Leonardo proxy image tag as well as refactoring to pull the image in from values.yaml. 

example:
```
      - name: cromwell2-proxy
        image: broadinstitute/openidc-proxy:tcell_3_1_0
```

If this is successful, more work will be done to switch all other services over. https://broadworkbench.atlassian.net/browse/DDO-357