### PR TITLE
[DDO-1355] Use "update" as the liquibase command for real operation

### DIFF
--- a/charts/leonardo/values.yaml
+++ b/charts/leonardo/values.yaml
@@ -130,7 +130,7 @@ migration:
   enabled: false
   # migration.liquibaseCommand -- (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run, "update" for normal operation
   # See https://docs.liquibase.com/commands/home.html
-  liquibaseCommand: "updateSQL"
+  liquibaseCommand: "update"
   # migration.imageName -- (string) Required full app image name, without trailing tag
   imageName: "gcr.io/broad-dsp-gcr-public/leonardo"
   # migration.jarLocation -- (string) Required jar location in app image, expanded by migration.appContainerShell


### PR DESCRIPTION
no-op no longer the default, leonardo charts that explicitly enable liquibase migrations will now also have explicitly change the command if no-op is desired