### PR TITLE
DDO-1409 Deploy ArgoCD Notifications alongside ArgoCD

### DIFF
--- a/charts/dsp-argocd/Chart.lock
+++ b/charts/dsp-argocd/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
   version: 2.9.2
-digest: sha256:7ee5e905ab0703bcf5797a97e11bda7ed48b5b9b5e912bc4188c77dd20ee672d
-generated: "2020-12-09T10:03:26.427384-05:00"
+- name: dsp-argocd-notifications
+  repository: file://local-charts/dsp-argocd-notifications
+  version: 0.0.1
+digest: sha256:7a2325e80402b383d908b9bb91f510de1e9e0018bbd310db8dea65756d738f77
+generated: "2021-08-03T11:36:23.527538-04:00"

--- a/charts/dsp-argocd/Chart.yaml
+++ b/charts/dsp-argocd/Chart.yaml
@@ -4,8 +4,8 @@ version: 0.11.0
 description: Helm Chart with extra resources for the DSP ArgoCD instance
 type: application
 maintainers:
-  - name: Chelsea Hoover
-    email: chelsea@broadinstitute.org
+  - name: DSP DevOps
+    email: dsp-devops@broadinstitute.org
 sources:
   - https://github.com/broadinstitute/terra-helm/tree/master/charts/dsp-argocd
 dependencies:

--- a/charts/dsp-argocd/Chart.yaml
+++ b/charts/dsp-argocd/Chart.yaml
@@ -12,3 +12,7 @@ dependencies:
   - name: argo-cd
     version: 2.9.2
     repository: https://argoproj.github.io/argo-helm
+  - name: dsp-argocd-notifications
+    alias: notifications
+    version: 0.0.1
+    repository: file://local-charts/dsp-argocd-notifications

--- a/charts/dsp-argocd/README.md
+++ b/charts/dsp-argocd/README.md
@@ -20,6 +20,11 @@ Authenticate to the dsp-tools cluster:
 
     gcloud container clusters get-credentials dsp-tools --project=dsp-tools-k8s
 
+Update dependencies (this should be re-run any time you update the chart):
+
+    helm dependency build local-charts/dsp-argocd-notifications
+    helm dependency build
+
 Compare local copy of the chart to the deployed version of the chart:
 
     helm diff upgrade ap-argocd . --namespace=ap-argocd

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/Chart.lock
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: argocd-notifications
+  repository: https://argoproj.github.io/argo-helm
+  version: 1.4.1
+digest: sha256:391cd663f482b2a842847e31ddafb65e91b05cbbde445fb3490f0346c1eeb68d
+generated: "2021-08-03T11:47:10.802585-04:00"

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/Chart.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/Chart.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 description: Helm chart for deploying the DSP ArgoCD notifications instance
 type: application
 maintainers:
-  - name: Chelsea Hoover
-    email: chelsea@broadinstitute.org
+  - name: DSP DevOps
+    email: dsp-devops@broadinstitute.org
 sources:
   - https://github.com/broadinstitute/terra-helm/tree/master/charts/dsp-argocd-notifications
 dependencies:

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/Chart.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: dsp-argocd-notifications
+version: 0.0.1
+description: Helm chart for deploying the DSP ArgoCD notifications instance
+type: application
+maintainers:
+  - name: Chelsea Hoover
+    email: chelsea@broadinstitute.org
+sources:
+  - https://github.com/broadinstitute/terra-helm/tree/master/charts/dsp-argocd-notifications
+dependencies:
+  - name: argocd-notifications
+    version: 1.4.1
+    repository: https://argoproj.github.io/argo-helm
+    alias: upstream

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/_labels.tpl
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/_labels.tpl
@@ -1,0 +1,11 @@
+{{/*
+Create labels to use for resources in this chart
+*/}}
+{{- define "dsp-argocd-notifications.labels" -}}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+app.kubernetes.io/name: {{ .Chart.Name | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/component: "argocd-notifications"
+app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+{{- end -}}

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/psp.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/psp.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}-psp
+  labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/role.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.name }}-pod-runner
+  labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - {{ .Values.name }}-psp

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/roleBinding.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/roleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.name }}-rolebinding
+  labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ required ".Values.upstream.serviceAccount.name is required" .Values.upstream.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.name }}-pod-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/secrets.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: {{ .Values.name }}-secretdef
+  labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
+spec:
+  name: {{ required ".Values.upstream.nameOverride is required" .Values.upstream.nameOverride }}-secret
+  keysMap:
+    slack-token:
+      path: {{ .Values.vault.pathPrefix }}/slack
+      key: token

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/values.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/values.yaml
@@ -18,6 +18,8 @@ upstream:
   argocdUrl: https://ap-argocd.dsp-devops.broadinstitute.org/
 
   # Templates and triggers, pulled from: https://github.com/argoproj/argo-helm/blob/master/charts/argocd-notifications/values.yaml#L121
+  # Note that we use toJson to escape error message strings as recommended here:
+  #   https://github.com/argoproj-labs/argocd-notifications/issues/194#issuecomment-826415852
   templates:
     template.app-deployed: |
       email:
@@ -95,7 +97,7 @@ upstream:
       email:
         subject: Failed to sync application {{.app.metadata.name}}.
       message: |
-        {{if eq .serviceType "slack"}}:exclamation:{{end}}  The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}} with the following error: {{.app.status.operationState.message}}
+        {{if eq .serviceType "slack"}}:exclamation:{{end}}  The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}}
         Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
       slack:
         attachments: |-
@@ -119,7 +121,7 @@ upstream:
             {{if $index}},{{end}}
             {
               "title": "{{$c.type}}",
-              "value": "{{$c.message}}",
+              "value": {{$c.message | toJson}},
               "short": true
             }
             {{end}}
@@ -153,7 +155,7 @@ upstream:
             {{if $index}},{{end}}
             {
               "title": "{{$c.type}}",
-              "value": "{{$c.message}}",
+              "value": {{$c.message | toJson}},
               "short": true
             }
             {{end}}
@@ -192,7 +194,7 @@ upstream:
             {{if $index}},{{end}}
             {
               "title": "{{$c.type}}",
-              "value": "{{$c.message}}",
+              "value": {{$c.message | toJson}},
               "short": true
             }
             {{end}}
@@ -205,8 +207,31 @@ upstream:
         {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
         Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
       slack:
-        attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n  \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n    \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n    \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n    \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
-
+        attachments: |-
+          [{
+            "title": "{{ .app.metadata.name}}",
+            "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "color": "#18be52",
+            "fields": [{
+              "title": "Sync Status",
+              "value": "{{.app.status.sync.status}}",
+              "short": true
+            },{
+              "title": "Repository",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            }
+            {{range $index, $c := .app.status.conditions}}
+            {{if not $index}},{{end}}
+            {{if $index}},{{end}}
+            {
+              "title": "{{$c.type}}",
+              "value": {{$c.message | toJson}},
+              "short": true
+            }
+            {{end}}
+            ]
+          }]
   triggers:
     trigger.on-deployed: |
       - description: Application is synced and healthy. Triggered once per commit.

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/values.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/values.yaml
@@ -1,0 +1,241 @@
+name: dsp-argocd-notifications
+
+# Path in Vault where ArgoCD secrets live
+vault:
+  secretName: dsp-argocd-notifications-secret # This is expected by the argocd-notifications helm chart
+  pathPrefix: secret/suitable/argocd/notifications
+
+# Values for the argocd notifications subchart
+upstream:
+  # Referenced by resources in the downstream chart
+  nameOverride: argocd-notifications
+  serviceAccount:
+    # Referenced by resources in the downstream chart
+    name: argocd-notifications-controller
+  # Don't create secret, we manage it w/ secrets-manager
+  secret:
+    create: false
+  argocdUrl: https://ap-argocd.dsp-devops.broadinstitute.org/
+
+  # Templates and triggers, pulled from: https://github.com/argoproj/argo-helm/blob/master/charts/argocd-notifications/values.yaml#L121
+  templates:
+    template.app-deployed: |
+      email:
+        subject: New version of an application {{.app.metadata.name}} is up and running.
+      message: |
+        {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} is now running new version of deployments manifests.
+      slack:
+        attachments: |
+          [{
+            "title": "{{ .app.metadata.name}}",
+            "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "color": "#18be52",
+            "fields": [
+            {
+              "title": "Sync Status",
+              "value": "{{.app.status.sync.status}}",
+              "short": true
+            },
+            {
+              "title": "Repository",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            },
+            {
+              "title": "Revision",
+              "value": "{{.app.status.sync.revision}}",
+              "short": true
+            }
+            {{range $index, $c := .app.status.conditions}}
+            {{if not $index}},{{end}}
+            {{if $index}},{{end}}
+            {
+              "title": "{{$c.type}}",
+              "value": "{{$c.message}}",
+              "short": true
+            }
+            {{end}}
+            ]
+          }]
+    template.app-health-degraded: |
+      email:
+        subject: Application {{.app.metadata.name}} has degraded.
+      message: |
+        {{if eq .serviceType "slack"}}:exclamation:{{end}} Application {{.app.metadata.name}} has degraded.
+        Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+      slack:
+        attachments: |-
+          [{
+            "title": "{{ .app.metadata.name}}",
+            "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "color": "#f4c030",
+            "fields": [
+            {
+              "title": "Sync Status",
+              "value": "{{.app.status.sync.status}}",
+              "short": true
+            },
+            {
+              "title": "Repository",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            }
+            {{range $index, $c := .app.status.conditions}}
+            {{if not $index}},{{end}}
+            {{if $index}},{{end}}
+            {
+              "title": "{{$c.type}}",
+              "value": "{{$c.message}}",
+              "short": true
+            }
+            {{end}}
+            ]
+          }]
+    template.app-sync-failed: |
+      email:
+        subject: Failed to sync application {{.app.metadata.name}}.
+      message: |
+        {{if eq .serviceType "slack"}}:exclamation:{{end}}  The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}} with the following error: {{.app.status.operationState.message}}
+        Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+      slack:
+        attachments: |-
+          [{
+            "title": "{{ .app.metadata.name}}",
+            "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "color": "#E96D76",
+            "fields": [
+            {
+              "title": "Sync Status",
+              "value": "{{.app.status.sync.status}}",
+              "short": true
+            },
+            {
+              "title": "Repository",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            }
+            {{range $index, $c := .app.status.conditions}}
+            {{if not $index}},{{end}}
+            {{if $index}},{{end}}
+            {
+              "title": "{{$c.type}}",
+              "value": "{{$c.message}}",
+              "short": true
+            }
+            {{end}}
+            ]
+          }]
+    template.app-sync-running: |
+      email:
+        subject: Start syncing application {{.app.metadata.name}}.
+      message: |
+        The sync operation of application {{.app.metadata.name}} has started at {{.app.status.operationState.startedAt}}.
+        Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+      slack:
+        attachments: |-
+          [{
+            "title": "{{ .app.metadata.name}}",
+            "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "color": "#0DADEA",
+            "fields": [
+            {
+              "title": "Sync Status",
+              "value": "{{.app.status.sync.status}}",
+              "short": true
+            },
+            {
+              "title": "Repository",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            }
+            {{range $index, $c := .app.status.conditions}}
+            {{if not $index}},{{end}}
+            {{if $index}},{{end}}
+            {
+              "title": "{{$c.type}}",
+              "value": "{{$c.message}}",
+              "short": true
+            }
+            {{end}}
+            ]
+          }]
+    template.app-sync-status-unknown: |
+      email:
+        subject: Application {{.app.metadata.name}} sync status is 'Unknown'
+      message: |
+        {{if eq .serviceType "slack"}}:exclamation:{{end}} Application {{.app.metadata.name}} sync is 'Unknown'.
+        Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+        {{if ne .serviceType "slack"}}
+        {{range $c := .app.status.conditions}}
+            * {{$c.message}}
+        {{end}}
+        {{end}}
+      slack:
+        attachments: |-
+          [{
+            "title": "{{ .app.metadata.name}}",
+            "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+            "color": "#E96D76",
+            "fields": [
+            {
+              "title": "Sync Status",
+              "value": "{{.app.status.sync.status}}",
+              "short": true
+            },
+            {
+              "title": "Repository",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            }
+            {{range $index, $c := .app.status.conditions}}
+            {{if not $index}},{{end}}
+            {{if $index}},{{end}}
+            {
+              "title": "{{$c.type}}",
+              "value": "{{$c.message}}",
+              "short": true
+            }
+            {{end}}
+            ]
+          }]
+    template.app-sync-succeeded: |
+      email:
+        subject: Application {{.app.metadata.name}} has been successfully synced.
+      message: |
+        {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
+        Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+      slack:
+        attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n  \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n    \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n    \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n    \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+
+  triggers:
+    trigger.on-deployed: |
+      - description: Application is synced and healthy. Triggered once per commit.
+        oncePer: app.status.sync.revision
+        send:
+        - app-deployed
+        when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'
+    trigger.on-health-degraded: |
+      - description: Application has degraded
+        send:
+        - app-health-degraded
+        when: app.status.health.status == 'Degraded'
+    trigger.on-sync-failed: |
+      - description: Application syncing has failed
+        send:
+        - app-sync-failed
+        when: app.status.operationState.phase in ['Error', 'Failed']
+    trigger.on-sync-running: |
+      - description: Application is being synced
+        send:
+        - app-sync-running
+        when: app.status.operationState.phase in ['Running']
+    trigger.on-sync-status-unknown: |
+      - description: Application status is 'Unknown'
+        send:
+        - app-sync-status-unknown
+        when: app.status.sync.status == 'Unknown'
+    trigger.on-sync-succeeded: |
+      - description: Application syncing has succeeded
+        send:
+        - app-sync-succeeded
+        when: app.status.operationState.phase in ['Succeeded']

--- a/charts/dsp-argocd/templates/apps/terra-app-generator.yaml
+++ b/charts/dsp-argocd/templates/apps/terra-app-generator.yaml
@@ -21,6 +21,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: terra-app-generator
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: ap-k8s-monitor
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: ap-k8s-monitor
 spec:
   destination:
     namespace:  {{ .Release.Namespace }}


### PR DESCRIPTION
* Update the dsp-argocd Helm chart to also deploy [ArgoCD Notifications](https://github.com/argoproj-labs/argocd-notifications) (it's necessary to deploy it in the same namespace where ArgoCD creates Application resources)
  * I've configured it in a local subchart instead of an external subchart to save pointless version bump PRs
* Add annotations to the terra-app-generator app to send a Slack notification to #ap-k8s-monitor when a sync fails
