### PR TITLE
DDO-1411 Switch OpenDJ liveness probe to port 636

### DIFF
--- a/charts/opendj/templates/statefulset.yaml
+++ b/charts/opendj/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
           protocol: TCP
         livenessProbe:
           tcpSocket:
-            port: 389
+            port: 636
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 30


### PR DESCRIPTION
The primary symptom of DDO-1411 is that OpenDJ stops accepting new connections on port 636, so let's adjust OpenDJ's liveness probe to monitor 636 instead of 389.