### PR TITLE
[DDO-1158] Add gha-runner charts to Argo

### DIFF
--- a/charts/dsp-argocd/templates/apps/gha-runner.yaml
+++ b/charts/dsp-argocd/templates/apps/gha-runner.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gha-runner-controller
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.apps.ghaRunner.notiticationChannel }}
+spec:
+  destination:
+    namespace: {{ .Values.apps.ghaRunner.namespace }}
+    server: {{ .Values.projects.dspCi.cluster }}
+  project: dsp-ci
+  source:
+    path: dsp-tools/{{ .Values.apps.ghaRunner.controller.chart }}
+    plugin:
+      name: helm-values
+      env:
+        - name: HELM_CHART_NAME
+          value: {{ .Values.apps.ghaRunner.controller.chart }}
+        - name: HELM_CHART_VERSION
+          value: {{ .Values.apps.ghaRunner.controller.version }}
+        - name: HELM_CHART_VALUES_FILES
+          value: values.yaml
+    repoURL: https://github.com/broadinstitute/terra-helm-definitions
+  syncPolicy:
+    automated:
+      selfHeal: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gha-runner-instances
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.apps.ghaRunner.notiticationChannel }}
+spec:
+  destination:
+    namespace: {{ .Values.apps.ghaRunner.namespace }}
+    server: {{ .Values.projects.dspCi.cluster }}
+  project: dsp-ci
+  source:
+    path: dsp-tools/{{ .Values.apps.ghaRunner.instances.chart }}
+    plugin:
+      name: helm-values
+      env:
+        - name: HELM_CHART_NAME
+          value: {{ .Values.apps.ghaRunner.instances.chart }}
+        - name: HELM_CHART_VERSION
+          value: {{ .Values.apps.ghaRunner.instances.version }}
+        - name: HELM_CHART_VALUES_FILES
+          value: values.yaml
+    repoURL: https://github.com/broadinstitute/terra-helm-definitions
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/charts/dsp-argocd/templates/apps/gha-runner.yaml
+++ b/charts/dsp-argocd/templates/apps/gha-runner.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: gha-runner-controller
   annotations:
-    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.apps.ghaRunner.notiticationChannel }}
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.apps.ghaRunner.notificationChannel }}
 spec:
   destination:
     namespace: {{ .Values.apps.ghaRunner.namespace }}
@@ -30,7 +30,7 @@ kind: Application
 metadata:
   name: gha-runner-instances
   annotations:
-    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.apps.ghaRunner.notiticationChannel }}
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.apps.ghaRunner.notificationChannel }}
 spec:
   destination:
     namespace: {{ .Values.apps.ghaRunner.namespace }}

--- a/charts/dsp-argocd/templates/projects/dsp-ci.yaml
+++ b/charts/dsp-argocd/templates/projects/dsp-ci.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: dsp-ci
+spec:
+  description: CI runners in the broad-dsp-ci cluster; this project managed via dsp-argocd Helm chart
+  destinations:
+  - namespace: {{ .Values.apps.ghaRunner.namespace }}
+    server: {{ .Values.projects.dspCi.cluster }}
+  sourceRepos:
+    - https://github.com/broadinstitute/terra-helm
+    - https://github.com/broadinstitute/terra-helm-definitions
+    - https://kubernetes-charts.storage.googleapis.com
+    - https://broadinstitute.github.io/datarepo-helm

--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -99,3 +99,20 @@ argo-cd:
 # Path in Vault where ArgoCD secrets live
 vault:
   pathPrefix: secret/suitable/argocd
+
+## DRY for projects/apps
+
+projects:
+  dspCi:
+    cluster: https://104.197.236.29
+
+apps:
+  ghaRunner:
+    notiticationChannel: ap-k8s-monitor
+    namespace: gha-runner
+    controller:
+      chart: dsp-gha-runner-controller
+      version: 0.2.0
+    instances:
+      chart: dsp-gha-runner-instances
+      version: 0.2.0

--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -108,7 +108,7 @@ projects:
 
 apps:
   ghaRunner:
-    notiticationChannel: ap-k8s-monitor
+    notificationChannel: ap-k8s-monitor
     namespace: gha-runner
     controller:
       chart: dsp-gha-runner-controller


### PR DESCRIPTION
I rendered these out to yaml and applied them manually before merging the charts, adjusting the version numbers here, and making this PR.

- I think slack notifs on unknown sync state--common for a moment if you're using branches and stuff--would be too noisy, so only alerting on straight failures
- defining project separately so as to not tightly couple dsp-ci (the whole cluster) to gha-runners (since I bet someone is going to ask us to run jenkins nodes here within 3 months)
- self heal is on because that seems neat