### PR TITLE
[DDO-1424] name sysbox psp correctly, allow host paths

### DIFF
--- a/charts/sysbox/templates/psp.yaml
+++ b/charts/sysbox/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: sysbox-daemonset-psp
+  name: sysbox-psp
   labels:
     {{- include "sysbox.labels" . | nindent 4 }}
   annotations:
@@ -17,4 +17,6 @@ spec:
   fsGroup:
     rule: RunAsAny
   volumes:
+  - '*'
+  allowedHostPaths:
   - '*'


### PR DESCRIPTION
Hopefully this will be the only one of these. Helps to name the psp the same as what the role actually references, and of course hostPaths are their own field here.