### PR TITLE
DDO-1433 Use terra-helmfile-app ArgoCD plugin

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -76,7 +76,7 @@ argo-cd:
   repoServer:
     image:
       repository: us-central1-docker.pkg.dev/dsp-artifact-registry/terra-helmfile-images/argocd-custom-image
-      tag: main-6b05f48
+      tag: main-b514df5
     env:
       - name: VAULT_ADDR
         value: https://clotho.broadinstitute.org:8200

--- a/charts/terra-argocd-app/templates/app.yaml
+++ b/charts/terra-argocd-app/templates/app.yaml
@@ -26,12 +26,12 @@ spec:
 {{- end }}
     path: .
     plugin:
-      name: helmfile
+      name: terra-helmfile-app
       env:
-      - name: HELMFILE_ENV
+      - name: TERRA_ENV
         value: {{ quote .environment }}
-      - name: HELMFILE_SELECTOR
-        value: "group=terra,app={{ .app }}"
+      - name: TERRA_APP
+        value: {{ quote .app }}
 {{- if .syncPolicy }}
     syncPolicy:
 {{ .syncPolicy | toYaml | indent 6 }}


### PR DESCRIPTION
**Bugfix**: I realized recently that our ArgoCD apps for Terra services were still invoking `helmfile` directly, with selectors, instead of running the `render` script. This PR fixes that:
* Bump ArgoCD image to include the terra-helmfile-app plugin (https://github.com/broadinstitute/terra-helmfile-images/pull/19)
* Update Terra ArgoCD apps to use the terra-helmfile-app plugin