### PR TITLE
[DDO-1425] Bump gha-runner-instances to use our image

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -115,7 +115,7 @@ apps:
       version: 0.2.0
     instances:
       chart: dsp-gha-runner-instances
-      version: 0.2.0
+      version: 0.3.0
   sysbox:
     notificationChannel: ap-k8s-monitor
     namespace: kube-system


### PR DESCRIPTION
Tested that it works by having Helm use 0.3.0 manually. Even if we need to change the image in the future, this pulls nightly of it, and we can override it in the values file in terra-helm-definitions.