### PR TITLE
[DDO-1449] Add wsmtest-sync account

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -23,6 +23,7 @@ argo-cd:
       accounts.fcprod-jenkins: apiKey
       accounts.local-notsuitable: login
       accounts.local-suitable: login
+      accounts.wsmtest-sync: apiKey
       configManagementPlugins: |
         - name: legacy-configs
           generate:
@@ -66,6 +67,8 @@ argo-cd:
         p, role:terra-ci, applications, sync, */*, allow
         p, role:terra-ci, applications, action/apps/Deployment/restart, */*, allow
         g, terra-ci, role:terra-ci
+        p, role:wsmtest-sync, applications, sync, terra-wsmtest/workspacemanager-wsmtest, allow
+        g, wsmtest-sync, role:wsmtest-sync
   controller:
     extraArgs:
     - --repo-server-timeout-seconds=180


### PR DESCRIPTION
Adds an account to Argo CD able to sync wsmtest. I've generated a token for it and fully tested that this works, and that it rejects attempts to do anything else.

```
curl --fail --silent --show-error --location --request POST 'https://ap-argocd.dsp-devops.broadinstitute.org/api/v1/applications/workspacemanager-wsmtest/sync' \
    --header "Authorization: Bearer $(vault read -field=token secret/suitable/argocd/local-accounts/low-privileged/wsmtest-sync)" \
    | jq .operation
```