### PR TITLE
* DDO-1352 Add 30-second sleep for Consent couldSQL proxy

### DIFF
--- a/charts/consent/README.md
+++ b/charts/consent/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for DUOS Consent
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Values
 
@@ -73,6 +73,7 @@ A Helm chart for DUOS Consent
 | servicesOntologyUrl | string | `nil` |  |
 | servicesSamUrl | string | `nil` |  |
 | sslPolicy | string | `"tls12-ssl-policy"` |  |
+| startupSleep | int | `30` |  |
 | vaultCertPath | string | `nil` |  |
 | vaultCertSecretKey | string | `nil` |  |
 | vaultChain | string | `nil` |  |

--- a/charts/consent/templates/deployment.yaml
+++ b/charts/consent/templates/deployment.yaml
@@ -27,6 +27,35 @@ spec:
             - app
             - sqlproxy
       containers:
+        - name: {{ .Chart.Name }}-sqlproxy
+          image: broadinstitute/cloudsqlproxy:1.11_20191120
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "sleep {{ .Values.startupSleep }}"]
+          env:
+            - name: CLOUDSQL_CREDENTIAL_FILE
+              value: /etc/service-account.json
+            - name: GOOGLE_PROJECT
+              value: {{ .Values.googleProject }}
+            - name: CLOUDSQL_ZONE
+              value: {{ .Values.googleProjectZone }}
+            - name: CLOUDSQL_INSTANCE
+              value: {{ .Values.cloudSqlInstance }}
+            - name: CLOUDSQL_MAXCONNS
+              value: '300'
+            - name: PORT
+              value: '5432'
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: app-secrets
+              mountPath: /etc/service-account.json
+              subPath: service-account.json
+              readOnly: true
+          securityContext:
+            runAsUser: 2  # non-root user
+            allowPrivilegeEscalation: false
         - name: {{ .Chart.Name }}-app
           image: "{{- if .Values.image -}}
           {{ .Values.image }}
@@ -139,31 +168,6 @@ spec:
               subPath: ca-bundle.crt
               name: proxy-secrets
               readOnly: true
-        - name: {{ .Chart.Name }}-sqlproxy
-          image: broadinstitute/cloudsqlproxy:1.11_20191120
-          env:
-            - name: CLOUDSQL_CREDENTIAL_FILE
-              value: /etc/service-account.json
-            - name: GOOGLE_PROJECT
-              value: {{ .Values.googleProject }}
-            - name: CLOUDSQL_ZONE
-              value: {{ .Values.googleProjectZone }}
-            - name: CLOUDSQL_INSTANCE
-              value: {{ .Values.cloudSqlInstance }}
-            - name: CLOUDSQL_MAXCONNS
-              value: '300'
-            - name: PORT
-              value: '5432'
-          ports:
-            - containerPort: 5432
-          volumeMounts:
-            - name: app-secrets
-              mountPath: /etc/service-account.json
-              subPath: service-account.json
-              readOnly: true
-          securityContext:
-            runAsUser: 2  # non-root user
-            allowPrivilegeEscalation: false
       volumes:
         - name: configs
           configMap:

--- a/charts/consent/values.yaml
+++ b/charts/consent/values.yaml
@@ -39,6 +39,9 @@ image:
 imageRepository:
 imageTag:
 
+# Allows CloudSQL proxy time to start up. See DDO-1352
+startupSleep: 30
+
 probes:
   readiness:
     # probes.readiness.enable -- Whether to configure a readiness probe


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Moves cloudsql proxy container before application container. Adds 30 second sleep using post-start. 
Env-dif can be seen [here](https://github.com/broadinstitute/terra-helmfile/pull/1621#issuecomment-910542814).