### PR TITLE
* DDO-1352 Add 30-second sleep for CRL Janitor couldSQL proxy

### DIFF
--- a/charts/crljanitor/README.md
+++ b/charts/crljanitor/README.md
@@ -1,6 +1,6 @@
 # crljanitor
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Cloud Resource Manager Janitor
 
@@ -37,6 +37,7 @@ Chart for Cloud Resource Manager Janitor
 | serviceAllowedAddresses | object | `{}` | A map of addresses in the form `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | serviceFirewallEnabled | bool | `false` | Whether to restrict access to the service to the IPs supplied via serviceAllowedAddresses |
 | serviceIP | string | `nil` | External IP of the service. Required. |
+| startupSleep | int | `30` |  |
 | trackResourcePubsubEnabled | bool | `true` | Whether to enable using pubsub to receive new tracked resources. |
 | vault.adminUserFilePath | string | `"config/terra/crl-janitor/common/iam"` | (string) Vault path prefix for admin user list. Required if vault.enabled. Use the same users as admin for all env by default. Override if needed in helmfile repo. |
 | vault.configPathPrefix | string | `nil` | Vault path prefix for configs. Required if vault.enabled. |

--- a/charts/crljanitor/README.md
+++ b/charts/crljanitor/README.md
@@ -37,7 +37,7 @@ Chart for Cloud Resource Manager Janitor
 | serviceAllowedAddresses | object | `{}` | A map of addresses in the form `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | serviceFirewallEnabled | bool | `false` | Whether to restrict access to the service to the IPs supplied via serviceAllowedAddresses |
 | serviceIP | string | `nil` | External IP of the service. Required. |
-| startupSleep | int | `30` |  |
+| startupSleep | int | `30` | Allows CloudSQL proxy time to start up. See DDO-1352 |
 | trackResourcePubsubEnabled | bool | `true` | Whether to enable using pubsub to receive new tracked resources. |
 | vault.adminUserFilePath | string | `"config/terra/crl-janitor/common/iam"` | (string) Vault path prefix for admin user list. Required if vault.enabled. Use the same users as admin for all env by default. Override if needed in helmfile repo. |
 | vault.configPathPrefix | string | `nil` | Vault path prefix for configs. Required if vault.enabled. |

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
-            {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
+            {{ .Values.imageConfig.repository }}:{{ default .Values.global.applicationVersion .Values.imageConfig.tag }}
           {{- end }}"
         imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
         {{- if not .Values.proxy.enabled }}

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -17,11 +17,43 @@ spec:
     spec:
       serviceAccountName: terra-crl-janitor-service-sa
       containers:
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep {{ .Values.startupSleep }}"]
+        env:
+        - name: SQL_INSTANCE_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-cloudsql-postgres-instance
+              key: project
+        - name: SQL_INSTANCE_REGION
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-cloudsql-postgres-instance
+              key: region
+        - name: SQL_INSTANCE_NAME
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-cloudsql-postgres-instance
+              key: name
+        command: ["/cloud_sql_proxy",
+                  "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
+                  "-credential_file=/secrets/cloudsql/service-account.json"]
+        securityContext:
+          runAsUser: 2  # non-root user
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: cloudsql-sa-creds
+          mountPath: /secrets/cloudsql
+          readOnly: true
       - name: terra-crl-janitor
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
-            {{ .Values.imageConfig.repository }}:{{ default .Values.global.applicationVersion .Values.imageConfig.tag }}
+            {{ .Values.imageConfig.repository }}:{{ default .Values.appVersion .Values.imageConfig.tag }}
           {{- end }}"
         imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
         {{- if not .Values.proxy.enabled }}
@@ -93,34 +125,6 @@ spec:
           - name: app-sa-creds
             mountPath: /secrets/app
             readOnly: true
-      - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.16
-        env:
-        - name: SQL_INSTANCE_PROJECT
-          valueFrom:
-            secretKeyRef:
-              name: crl-janitor-cloudsql-postgres-instance
-              key: project
-        - name: SQL_INSTANCE_REGION
-          valueFrom:
-            secretKeyRef:
-              name: crl-janitor-cloudsql-postgres-instance
-              key: region
-        - name: SQL_INSTANCE_NAME
-          valueFrom:
-            secretKeyRef:
-              name: crl-janitor-cloudsql-postgres-instance
-              key: name
-        command: ["/cloud_sql_proxy",
-                  "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
-                  "-credential_file=/secrets/cloudsql/service-account.json"]
-        securityContext:
-          runAsUser: 2  # non-root user
-          allowPrivilegeEscalation: false
-        volumeMounts:
-        - name: cloudsql-sa-creds
-          mountPath: /secrets/cloudsql
-          readOnly: true
       {{- if .Values.proxy.enabled }}
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -20,7 +20,13 @@ imageConfig:
   # @default -- The chart's appVersion value will be used
   tag:
   imagePullPolicy: Always
+
 replicas: 1
+
+
+# Allows CloudSQL proxy time to start up. See DDO-1352
+startupSleep: 30
+
 vault:
   # vault.enabled -- When enabled, syncs required secrets from Vault
   enabled: true

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -24,7 +24,7 @@ imageConfig:
 replicas: 1
 
 
-# Allows CloudSQL proxy time to start up. See DDO-1352
+# startupSleep -- Allows CloudSQL proxy time to start up. See DDO-1352
 startupSleep: 30
 
 vault:


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Moves cloudsql proxy container before application container. Adds 30 second sleep using post-start.
Env-dif can be seen [here](https://github.com/broadinstitute/terra-helmfile/pull/1625/checks?check_run_id=3495447673#step:8:348).