### PR TITLE
Move Buffer ingress to V1

### DIFF
--- a/charts/buffer/templates/ingress/ingress.yaml
+++ b/charts/buffer/templates/ingress/ingress.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   defaultBackend:
     service:
-      name: { .Values.name }}-service
+      name: {{ .Values.name }}-service
       port:
         number: 443
 {{- end }}

--- a/charts/buffer/templates/ingress/ingress.yaml
+++ b/charts/buffer/templates/ingress/ingress.yaml
@@ -1,12 +1,12 @@
 {{ if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.name }}-ingress
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/frontend-config: "{{ .Values.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.cert.preSharedCerts) }}
@@ -17,7 +17,9 @@ spec:
   tls:
   - secretName: {{ .Values.name }}-cert
 {{- end }}
-  backend:
-    serviceName: {{ .Values.name }}-service
-    servicePort: 443
+  defaultBackend:
+    service:
+      name: { .Values.name }}-service
+      port:
+        number: 443
 {{- end }}


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Moving Buffer's ingress out of beta to v1. This has been tested and verified [here](https://console.cloud.google.com/kubernetes/ingress/us-central1-a/terra-qa/buffer-qa-01/buffer-ingress/yaml/view?project=broad-dsde-qa). 

Please note:
`networking.gke.io/v1beta1.FrontendConfig` is now `networking.gke.io/frontend-config `([link](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_frontendconfig_with_your_ingress))
`spec.backend` is renamed to `spec.defaultBackend`
The backend serviceName field is renamed to `service.name`
Numeric backend `servicePort` fields are renamed to `service.port.number`