### PR TITLE
DDO-1530 Enable GCS publishing

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -33,9 +33,7 @@ jobs:
         run: echo '${{ secrets.HELM_GCP_PUBLISH_KEY }}' > helm_service_account.json
 
       - name: Run chart-releaser
-        # TODO: Revert back to image after merging github-actions PR
-        # uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
-        uses: databiosphere/github-actions/actions/chart-releaser@ch-DDO-1530
+        uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
           GCS_PUBLISHING_ENABLED: true

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -36,6 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
           GCS_PUBLISHING_ENABLED: true
+          GCS_SA_KEY: "${{ secrets.HELM_GCP_PUBLISH_KEY }}"
 
       - name: Set up GCS Google Service Account
         if: ${{ always() }}

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -30,7 +30,9 @@ jobs:
           git config user.email "broadbot@broadinstitute.org"
 
       - name: Run chart-releaser
-        uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
+        # TODO: Revert back to image after merging github-actions PR
+        # uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
+        uses: databiosphere/github-actions/actions/chart-releaser@ch-DDO-1530
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
 

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: databiosphere/github-actions/actions/chart-releaser@ch-DDO-1530
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
+          GCS_PUBLISHING_ENABLED: true
 
       - name: Set up GCS Google Service Account
         if: ${{ always() }}

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -29,6 +29,9 @@ jobs:
           git config user.name "broadbot"
           git config user.email "broadbot@broadinstitute.org"
 
+      - name: Set up Helm Publish SA
+        run: echo '${{ secrets.HELM_GCP_PUBLISH_KEY }}' > helm_service_account.json
+
       - name: Run chart-releaser
         # TODO: Revert back to image after merging github-actions PR
         # uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
@@ -36,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
           GCS_PUBLISHING_ENABLED: true
-          GCS_SA_KEY: "${{ secrets.HELM_GCP_PUBLISH_KEY }}"
+          GCS_SA_KEY_FILE: "./helm_service_account.json"
 
       - name: Set up GCS Google Service Account
         if: ${{ always() }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
       - 'charts/**/Chart.yaml'
       - 'README.md'
       - '.github/**'
- 
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -35,10 +35,15 @@ jobs:
           git config user.name "broadbot"
           git config user.email "broadbot@broadinstitute.org"
 
+      - name: Set up Helm Publish SA
+        run: echo '${{ secrets.HELM_GCP_PUBLISH_KEY }}' > helm_service_account.json
+
       - name: Run chart-releaser
         uses: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:latest
         env:
           GITHUB_TOKEN: "${{ secrets.CR_TOKEN }}"
+          GCS_PUBLISHING_ENABLED: true
+          GCS_SA_KEY_FILE: "./helm_service_account.json"
 
       - name: Set up GCS Google Service Account
         if: ${{ always() }}

--- a/charts/agora/templates/deployment.yaml
+++ b/charts/agora/templates/deployment.yaml
@@ -1,4 +1,3 @@
-# TEST
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/agora/templates/deployment.yaml
+++ b/charts/agora/templates/deployment.yaml
@@ -1,3 +1,4 @@
+# TEST
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Update terra-helm chart-releaser workflows to publish charts to GCS.

Related:
* https://github.com/DataBiosphere/github-actions/pull/29