### PR TITLE
* DDO-1352 Add 30-second sleep for ExternalCreds couldSQL proxy

### DIFF
--- a/charts/externalcreds/README.md
+++ b/charts/externalcreds/README.md
@@ -1,6 +1,6 @@
 # externalcreds
 
-![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.46.0](https://img.shields.io/badge/Version-0.46.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Terra External Credentials Manager
 
@@ -19,6 +19,8 @@ Chart for Terra External Credentials Manager
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| appDeployments[0].name | string | `"frontend"` |  |
+| appDeployments[1].name | string | `"backend"` |  |
 | cloudTraceEnabled | bool | `true` | Whether to enable gcp cloud trace |
 | global.applicationVersion | string | `"latest"` | What version of the application to deploy |
 | global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
@@ -91,12 +93,13 @@ Chart for Terra External Credentials Manager
 | proxy.tcell.hostIdentifier | string | `nil` | Identifier used for logging to TCell. Required if proxy.tcell.enabled is true |
 | proxy.tcell.vaultPrefix | string | `nil` | Prefix for TCell secrets in vault. Required if proxy.tcell.enabled is true. |
 | replicas | int | `0` | Number of replicas for the deployment |
-| resources.limits.cpu | int | `1` | Number of CPU units to limit the deployment to |
+| resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
 | resources.limits.memory | string | `"8Gi"` | Memory to limit the deployment to |
-| resources.requests.cpu | int | `1` | Number of CPU units to request for the deployment |
+| resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
 | resources.requests.memory | string | `"8Gi"` | Memory to request for the deployment |
 | samAddress | string | `"https://sam.dsde-dev.broadinstitute.org/"` | Address of SAM instance this deploy will talk to |
 | samplingProbability | float | `1` | the frequency with which calls should be traced. |
+| startupSleep | int | `30` | Allows CloudSQL proxy time to start up. See DDO-1352 |
 | vault.enabled | bool | `true` | When enabled, syncs required secrets from Vault |
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |
 

--- a/charts/externalcreds/templates/deployment.yaml
+++ b/charts/externalcreds/templates/deployment.yaml
@@ -87,6 +87,40 @@ spec:
         emptyDir: {}
       {{- end }}
       containers:
+      {{- if not $.Values.postgres.enabled }}
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep {{ $.Values.startupSleep }}"]
+        env:
+        - name: SQL_INSTANCE_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.name }}-cloudsql-postgres-instance
+              key: project
+        - name: SQL_INSTANCE_REGION
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.name }}-cloudsql-postgres-instance
+              key: region
+        - name: SQL_INSTANCE_NAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.name }}-cloudsql-postgres-instance
+              key: name
+        command: ["/cloud_sql_proxy",
+                  "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
+                  "-credential_file=/secrets/cloudsql/service-account.json"]
+        securityContext:
+          runAsUser: 2  # non-root user
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: cloudsql-sa-creds
+          mountPath: /secrets/cloudsql
+          readOnly: true
+      {{- end }}
       - name: {{ $.Values.name }}
         image: "{{- if $.Values.image -}}
             {{ $.Values.image }}
@@ -188,36 +222,6 @@ spec:
                   "/app/resources:/app/classes:/app/libs/*",
                   "bio.terra.externalcreds.ExternalCredsCronApplication"]
         {{- end }}
-      {{- if not $.Values.postgres.enabled }}
-      - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.16
-        env:
-        - name: SQL_INSTANCE_PROJECT
-          valueFrom:
-            secretKeyRef:
-              name: {{ $.Values.name }}-cloudsql-postgres-instance
-              key: project
-        - name: SQL_INSTANCE_REGION
-          valueFrom:
-            secretKeyRef:
-              name: {{ $.Values.name }}-cloudsql-postgres-instance
-              key: region
-        - name: SQL_INSTANCE_NAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ $.Values.name }}-cloudsql-postgres-instance
-              key: name
-        command: ["/cloud_sql_proxy",
-                  "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
-                  "-credential_file=/secrets/cloudsql/service-account.json"]
-        securityContext:
-          runAsUser: 2  # non-root user
-          allowPrivilegeEscalation: false
-        volumeMounts:
-        - name: cloudsql-sa-creds
-          mountPath: /secrets/cloudsql
-          readOnly: true
-      {{- end }}
       {{- if $.Values.proxy.enabled }}
       - name: oidc-proxy
         image: "{{ $.Values.proxy.image.repository }}:{{ $.Values.proxy.image.version }}"

--- a/charts/externalcreds/values.yaml
+++ b/charts/externalcreds/values.yaml
@@ -36,6 +36,9 @@ resources:
     # resources.limits.memory -- Memory to limit the deployment to
     memory: 8Gi
 
+# startupSleep -- Allows CloudSQL proxy time to start up. See DDO-1352
+startupSleep: 30
+
 probes:
   readiness:
     # probes.readiness.enable -- Whether to configure a readiness probe


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Moves cloudsql proxy container before application container. Adds 30 second sleep using post-start.