### PR TITLE
* DDO-1352 Add 30-second sleep for WSM couldSQL proxy

### DIFF
--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -99,6 +99,7 @@ Chart for Terra Workspace Manager
 | serviceGoogleProject | string | `"broad-dsde-dev"` | the id of the google project which the instance is associated with |
 | spendBillingAccountId | string | `nil` | the Google Billing account Id for WSM to use for workspace projects. |
 | spendProfileId | string | `nil` | the Spend Profile Id to associate with the billing account. |
+| startupSleep | int | `30` | Allows CloudSQL proxy time to start up. See DDO-1352 |
 | terraDataRepoUrl | string | `"https://jade.datarepo-dev.broadinstitute.org"` | corresponding data repo instance for the environment |
 | vault.enabled | bool | `true` | When enabled, syncs required secrets from Vault |
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -76,6 +76,40 @@ spec:
         emptyDir: {}
       {{- end }}
       containers:
+      {{- if not .Values.postgres.enabled }}
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep {{ .Values.startupSleep }}"]
+        env:
+        - name: SQL_INSTANCE_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-cloudsql-postgres-instance
+              key: project
+        - name: SQL_INSTANCE_REGION
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-cloudsql-postgres-instance
+              key: region
+        - name: SQL_INSTANCE_NAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.name }}-cloudsql-postgres-instance
+              key: name
+        command: ["/cloud_sql_proxy",
+                  "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
+                  "-credential_file=/secrets/cloudsql/service-account.json"]
+        securityContext:
+          runAsUser: 2  # non-root user
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: cloudsql-sa-creds
+          mountPath: /secrets/cloudsql
+          readOnly: true
+      {{- end }}
       - name: {{ .Values.name }}
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
@@ -218,36 +252,6 @@ spec:
         startupProbe:
           {{- toYaml .Values.probes.startup.spec | nindent 10 }}
         {{- end }}
-      {{- if not .Values.postgres.enabled }}
-      - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:1.16
-        env:
-        - name: SQL_INSTANCE_PROJECT
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
-              key: project
-        - name: SQL_INSTANCE_REGION
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
-              key: region
-        - name: SQL_INSTANCE_NAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
-              key: name
-        command: ["/cloud_sql_proxy",
-                  "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
-                  "-credential_file=/secrets/cloudsql/service-account.json"]
-        securityContext:
-          runAsUser: 2  # non-root user
-          allowPrivilegeEscalation: false
-        volumeMounts:
-        - name: cloudsql-sa-creds
-          mountPath: /secrets/cloudsql
-          readOnly: true
-      {{- end }}
       {{- if .Values.proxy.enabled }}
       - name: oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -40,6 +40,9 @@ resources:
     # resources.limits.memory -- Memory to limit the deployment to
     memory: 8Gi
 
+# startupSleep -- Allows CloudSQL proxy time to start up. See DDO-1352
+startupSleep: 30
+
 probes:
   readiness:
     # probes.readiness.enable -- Whether to configure a readiness probe


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Add 30s sleep via post-start command to prevent app container from starting at the same time as cloud-sql proxy container.
Updates:
* Cloudsql proxy to gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
* Moves cloudsql proxy container before application container.
* Adds 30 second sleep using post-start.