### PR TITLE
* DDO-1352 Add 30-second sleep for Hydra couldSQL proxy

### DIFF
--- a/charts/hydra/README.md
+++ b/charts/hydra/README.md
@@ -1,6 +1,6 @@
 # hydra
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for the Hydra deployment used by Identity Concentrator in Terra
 
@@ -19,6 +19,7 @@ Chart for the Hydra deployment used by Identity Concentrator in Terra
 | ingress.istioGatewayName | string | `"template-gateway"` |  |
 | ingress.istioGatewayNamespace | string | `"istio-system"` |  |
 | replicas | int | `1` |  |
+| startupSleep | int | `30` | Allows CloudSQL proxy time to start up. See DDO-1352 |
 | vault.enabled | bool | `true` |  |
 
 ----------------------------------------------

--- a/charts/hydra/templates/deployment.yaml
+++ b/charts/hydra/templates/deployment.yaml
@@ -18,6 +18,21 @@ spec:
     spec:
       serviceAccountName: hydra-sa
       containers:
+        - name: cloudsql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "sleep {{ .Values.startupSleep }}"]
+          env:
+            - name: SQL_INSTANCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-cloudsql-postgres-instance-name
+                  key: name
+          command: ["/cloud_sql_proxy",
+                    "-instances=terra-kernel-k8s:us-central1:$(SQL_INSTANCE_NAME)=tcp:5432",
+                    "-credential_file=/secrets/sa/service-account.json"]
         - name: hydra
           image: "{{- if .Values.image -}}
               {{ .Values.image }}
@@ -52,17 +67,6 @@ spec:
             httpGet:
               port: 4444
               path: /health/ready
-        - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.16
-          env:
-            - name: SQL_INSTANCE_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: hydra-cloudsql-postgres-instance-name
-                  key: name
-          command: ["/cloud_sql_proxy",
-                    "-instances=terra-kernel-k8s:us-central1:$(SQL_INSTANCE_NAME)=tcp:5432",
-                    "-credential_file=/secrets/sa/service-account.json"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false

--- a/charts/hydra/values.yaml
+++ b/charts/hydra/values.yaml
@@ -11,6 +11,10 @@ imageConfig:
   # tag: latest
   imagePullPolicy: Always
 replicas: 1
+
+# startupSleep -- Allows CloudSQL proxy time to start up. See DDO-1352
+startupSleep: 30
+
 vault:
   enabled: true
   # pathPrefix is required if Vault secret sync is enabled


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Add 30s sleep via post-start command to prevent app container from starting at the same time as cloud-sql proxy container.
Updates:
* Cloudsql proxy to gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
* Moves cloudsql proxy container before application container.
* Adds 30 second sleep using post-start.