### PR TITLE
* DDO-1352 Add 30-second sleep for Agora couldSQL proxy

### DIFF
--- a/charts/agora/Chart.lock
+++ b/charts/agora/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: ingresslib
-  repository: file://../ingresslibchart
-  version: 0.3.0
-digest: sha256:52b08e7d291bd7f21f628bff7e8598ca174e9c2ae51fec89299182c329b8c891
-generated: "2021-08-23T10:13:03.529598-04:00"

--- a/charts/agora/Chart.lock
+++ b/charts/agora/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ingresslib
+  repository: file://../ingresslibchart
+  version: 0.3.0
+digest: sha256:52b08e7d291bd7f21f628bff7e8598ca174e9c2ae51fec89299182c329b8c891
+generated: "2021-08-23T10:13:03.529598-04:00"

--- a/charts/agora/README.md
+++ b/charts/agora/README.md
@@ -33,13 +33,15 @@ Chart for Agora service in Terra
 | probes.readiness.spec.timeoutSeconds | int | `5` |  |
 | probes.startup.enabled | bool | `true` |  |
 | probes.startup.spec.failureThreshold | int | `1080` |  |
-| probes.startup.spec.httpGet.path | string | `"/version"` |  |
-| probes.startup.spec.httpGet.port | int | `8080` |  |
+| probes.startup.spec.httpGet.path | string | `"/status"` |  |
+| probes.startup.spec.httpGet.port | int | `8000` |  |
 | probes.startup.spec.periodSeconds | int | `10` |  |
 | probes.startup.spec.successThreshold | int | `1` |  |
 | probes.startup.spec.timeoutSeconds | int | `5` |  |
+| proxyImage | string | `"broadinstitute/openidc-proxy:tcell_3_1_0"` |  |
 | replicas | int | `3` | Number of replicas for the deployment |
 | resources.limits.cpu | int | `4` | Number of CPU units to limit the deployment to |
 | resources.limits.memory | string | `"15Gi"` | Memory to limit the deployment to |
 | resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
 | resources.requests.memory | string | `"15Gi"` | Memory to request for the deployment |
+| startupSleep | int | `30` | Allows CloudSQL proxy time to start up. See DDO-1352 |

--- a/charts/agora/templates/deployment.yaml
+++ b/charts/agora/templates/deployment.yaml
@@ -54,6 +54,20 @@ spec:
       - name: prometheusjmx-jar
         emptyDir: {}
       containers:
+      - name: {{ .Chart.Name }}-sqlproxy
+        image: broadinstitute/cloudsqlproxy:1.11_20180808
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep {{ .Values.startupSleep }}"]
+        envFrom:
+        - secretRef:
+            name: {{ .Chart.Name }}-sqlproxy-env
+        volumeMounts:
+        - mountPath: /etc/sqlproxy-service-account.json
+          subPath: sqlproxy-service-account.json
+          name: sqlproxy-ctmpls
+          readOnly: true
       - name: {{ .Chart.Name }}-app
         image: "{{ .Values.imageRepository }}:{{ .Values.imageTag | default .Values.global.applicationVersion }}"
         ports:
@@ -149,16 +163,6 @@ spec:
           readOnly: true
         - mountPath: /var/log/modsecurity
           name: {{ .Chart.Name }}-modsecurity-logs
-      - name: {{ .Chart.Name }}-sqlproxy
-        image: broadinstitute/cloudsqlproxy:1.11_20180808
-        envFrom:
-        - secretRef:
-            name: {{ .Chart.Name }}-sqlproxy-env
-        volumeMounts:
-        - mountPath: /etc/sqlproxy-service-account.json
-          subPath: sqlproxy-service-account.json
-          name: sqlproxy-ctmpls
-          readOnly: true
       initContainers:
       - name: download-prometheusjmx-jar
         image: alpine:3.12.0

--- a/charts/agora/values.yaml
+++ b/charts/agora/values.yaml
@@ -26,6 +26,9 @@ resources:
     # resources.limits.memory -- Memory to limit the deployment to
     memory: 15Gi
 
+# startupSleep -- Allows CloudSQL proxy time to start up. See DDO-1352
+startupSleep: 30
+
 probes:
   readiness:
     # probes.readiness.enable -- Whether to configure a readiness probe


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Add 30s sleep via post-start command to prevent app container from starting at the same time as cloud-sql proxy container.
Updates:
* Moves cloudsql proxy container before application container.
* Adds 30 second sleep using post-start.