### PR TITLE
[DDO-1467] Rawls Chart: use newer liquibase-migration subchart

### DIFF
--- a/charts/rawls/Chart.yaml
+++ b/charts/rawls/Chart.yaml
@@ -14,6 +14,5 @@ sources:
   - https://github.com/broadinstitute/rawls
 dependencies:
   - name: liquibase-migration
-    condition: migration.enabled
-    version: 0.2.0
+    version: 1.1.0
     repository: https://terra-helm.storage.googleapis.com

--- a/charts/rawls/README.md
+++ b/charts/rawls/README.md
@@ -1,6 +1,6 @@
 # rawls
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Chart for Rawls service in Terra
 
@@ -9,16 +9,23 @@ Chart for Rawls service in Terra
 * <https://github.com/broadinstitute/terra-helm/tree/master/charts>
 * <https://github.com/broadinstitute/rawls>
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://terra-helm.storage.googleapis.com | liquibase-migration | 1.1.0 |
+
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| deploymentDefaults.annotation | object | `nil` | Additational metadata to attach |
+| deploymentDefaults.annotations | object | `{}` |  |
+| deploymentDefaults.buffer.enabled | bool | `true` |  |
 | deploymentDefaults.enabled | bool | `true` | Whether a declared deployment is enabled. If false, no resources will be created |
 | deploymentDefaults.expose | bool | `false` | Whether to create a Service for this deployment |
 | deploymentDefaults.imageTag | string | `nil` | Image tag to be used when deploying Pods @default global.applicationVersion |
 | deploymentDefaults.legacyResourcePrefix | string | `nil` | What prefix to use to refer to secrets rendered from firecloud-develop @default deploymentDefaults.name |
-| deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resuorce definitions. Example: `"rawls1-reader"` |
+| deploymentDefaults.name | string | `nil` | A name for the deployment that will be substituted into resource definitions. Example: `"rawls1-reader"` |
 | deploymentDefaults.probes.liveness.enabled | bool | `true` |  |
 | deploymentDefaults.probes.liveness.spec | object | `{"failureThreshold":30,"httpGet":{"path":"/status","port":8080},"initialDelaySeconds":20,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | k8s spec of the liveness probe to deploy, if enabled |
 | deploymentDefaults.probes.readiness.enabled | bool | `true` |  |
@@ -30,6 +37,7 @@ Chart for Rawls service in Terra
 | deploymentDefaults.probes.startup.spec.periodSeconds | int | `10` |  |
 | deploymentDefaults.probes.startup.spec.successThreshold | int | `1` |  |
 | deploymentDefaults.probes.startup.spec.timeoutSeconds | int | `5` |  |
+| deploymentDefaults.proxyImage | string | `"broadinstitute/openidc-proxy:tcell_3_1_0"` | Image that the OIDC proxy uses |
 | deploymentDefaults.replicas | int | `0` | Number of replicas for the deployment |
 | deploymentDefaults.serviceIP | string | `nil` | Static IP to use for the Service. If set, service will be of type LoadBalancer |
 | deploymentDefaults.serviceName | string | `nil` | What to call the Service |
@@ -39,20 +47,19 @@ Chart for Rawls service in Terra
 | ingress.sslPolicy | string | `"tls12-ssl-policy"` | (string) Name of an existing google ssl policy to associate with an ingress frontend-config |
 | ingress.staticIpName | string | `nil` | Required. GCP resource name for ingress static ip |
 | ingress.timeoutSec | int | `120` | Number of seconds to timeout on requests to the ingress |
-| migration.dryRun | bool | `true` | When true, merely print migration SQL; when false, execute it |
-| migration.enabled | bool | `false` | Whether to run a Liquibase migration job pre-sync |
-| migration.failBasedOnLiquibase | bool | `true` | When true, fail the job (and ArgoCD sync!) if the Liquibase command fails |
-| migration.imageTag | string | `nil` | Override the image tag to run the migration on @default global.applicationVersion WARNING: App may behave unexpectedly if its database has been migrated to a different version than the app |
-| migration.secretPrefix | string | `"rawls-backend"` | Prefix for ctmpl and env secrets NOTE: Generally equals some deploymentDefaults.name, as secrets are per-deployment but migrations are per-namespace |
-| migration.serviceAccount | string | `"rawls-sa"` | Name of the k8s SA to use for the job |
-| migration.syncWave | string | `"-1"` | Wave to run migration as a sync hook (presumably after SA's RBAC wave) NOTE: Sync hook, not PreSync, so that SA/RBAC can be made normally via an earlier wave |
+| liquibase-migration.defaults.enabled | bool | `false` |  |
+| liquibase-migration.defaults.migrationArgsClasspath[0] | string | `"$(find /rawls -name 'rawls*.jar')"` |  |
+| liquibase-migration.defaults.migrationConfigFileMount.secretName | string | `"rawls-backend-app-ctmpls"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromVaultSecret.passwordKey | string | `"slick_db_password"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromVaultSecret.path | string | `nil` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromVaultSecret.usernameKey | string | `"slick_db_user"` |  |
+| liquibase-migration.defaults.migrationImage | string | `"gcr.io/broad-dsp-gcr-public/rawls"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.envFrom[0].secretRef.name | string | `"rawls-backend-sqlproxy-env"` |  |
+| liquibase-migration.defaults.sqlproxyCredentialFileMount.secretName | string | `"rawls-backend-sqlproxy-ctmpls"` |  |
 | resources.limits.cpu | int | `8` | Number of CPU units to limit the deployment to |
 | resources.limits.memory | string | `"16Gi"` | Memory to limit the deployment to |
 | resources.requests.cpu | int | `8` | Number of CPU units to request for the deployment |
 | resources.requests.memory | string | `"16Gi"` | Memory to request for the deployment |
-| vault.migration.dbPasswordKey | string | `"slick_db_password"` |  |
-| vault.migration.dbUsernameKey | string | `"slick_db_user"` | Key in Vault secret to DB username |
-| vault.migration.path | string | `nil` | Vault path to secret containing DB credentials |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/rawls/templates/migration.yaml
+++ b/charts/rawls/templates/migration.yaml
@@ -1,5 +1,0 @@
-{{- if .Values.migration.enabled -}}
-{{ template "liquibase-migration.secretDefinition" . }}
----
-{{ template "liquibase-migration.job" . }}
-{{- end -}}

--- a/charts/rawls/values.yaml
+++ b/charts/rawls/values.yaml
@@ -101,24 +101,34 @@ deploymentDefaults:
         failureThreshold: 1080 # 3 hours before restarted, to prevent liveness probes from interrupting long-running liquibase migrations
         successThreshold: 1
 
-vault:
-  # Migration credentials only referenced if migration.enabled == true
-  migration:
-    # vault.migration.path -- Vault path to secret containing DB credentials
-    path: null
-    # vault.migration.dbUsernameKey -- Key in Vault secret to DB username
-    dbUsernameKey: "slick_db_user"
-    # vault.migration.DbPasswordKey -- Key in Vault secret to DB password
-    dbPasswordKey: "slick_db_password"
+liquibase-migration:
+  # In an env-specific file use something like the following to fully enable:
+  # ```
+  # liquibase-migration:   
+  #   migrationJobs:
+  #     - name: "rawls"
+  #       enabled: true
+  #       migrationDatabaseCredentials:
+  #         fromVaultSecret:
+  #           path: "secret/path/in/vault"
+  # ```
+  # See https://github.com/broadinstitute/terra-helm/blob/master/charts/liquibase-migration for more information
 
-migration:
-  # migration.enabled -- (bool) Whether to run a Liquibase migration during sync
-  enabled: false
-  # migration.liquibaseCommand -- (string) Liquibase CLI command, can be "updateSQL" for a no-op dry-run
-  liquibaseCommand: "updateSQL"
-  # migration.imageName -- (string) Required full app image name, without trailing tag
-  imageName: "gcr.io/broad-dsp-gcr-public/rawls"
-  # migration.jarLocation -- (string) Required jar location in app image, expanded by migration.appContainerShell
-  jarLocation: "$(find /rawls -name 'rawls*.jar')"
-  # migration.secretPrefix -- (string) Required prefix of -app-ctmpls, -sqlproxy-ctmpls, -sqlproxy-env secrets
-  secretPrefix: "rawls-backend"
+  defaults:
+    enabled: false
+    sqlproxyCredentialFileMount:
+      secretName: "rawls-backend-sqlproxy-ctmpls"
+    sqlproxyContainerConfig:
+      envFrom:
+        - secretRef:
+            name: "rawls-backend-sqlproxy-env"
+    migrationImage: "gcr.io/broad-dsp-gcr-public/rawls"
+    migrationArgsClasspath:
+      - "$(find /rawls -name 'rawls*.jar')"
+    migrationConfigFileMount:
+      secretName: "rawls-backend-app-ctmpls"
+    migrationDatabaseCredentials:
+      fromVaultSecret:
+        path: null
+        usernameKey: "slick_db_user"
+        passwordKey: "slick_db_password"


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Rawls has had devops's formerly-experimental Liquibase migrations job present in dev for a while. Now that we've gotten to a mature state in the underlying liquibase-migration chart, we'd like to have Rawls use that newer chart and enable this functionality in all environments.

For a bit more background, we have a mechanism that runs Liquibase migrations for Rawls's database using Rawls's own changelogs, JDBC driver, etc during Argo CD sync before Rawls starts. When Rawls does start, Liquibase simply sees that there's no migration necessary, vastly improving the max time that Rawls might take to start up--Rawls won't ever need to wait for an hour-long migration on start. This means we can detect and fix issues faster. There's no changes needed to Rawls's codebase whatsoever, just a free startup speed boost.

This has been present in rawls-dev for months, and has been present in all Leonardo environments for over a month now too. This PR bumps the underlying chart in use here, and the corresponding terra-helmfile PR () will enable migrations as the changes here propagate through the release cadence.