### PR TITLE
[DDO-1467] Buffer Chart: Add liquibase-migration subchart

### DIFF
--- a/charts/buffer/Chart.yaml
+++ b/charts/buffer/Chart.yaml
@@ -11,3 +11,7 @@ keywords:
 sources:
   - https://github.com/broadinstitute/terra-helm/tree/master/charts
   - https://github.com/DataBiosphere/terra-resource-buffer
+dependencies:
+  - name: liquibase-migration
+    version: 1.1.0
+    repository: https://terra-helm.storage.googleapis.com

--- a/charts/buffer/README.md
+++ b/charts/buffer/README.md
@@ -1,6 +1,6 @@
 # buffer
 
-![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Resource Buffering Service
 
@@ -8,6 +8,12 @@ Chart for Resource Buffering Service
 
 * <https://github.com/broadinstitute/terra-helm/tree/master/charts>
 * <https://github.com/DataBiosphere/terra-resource-buffer>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://terra-helm.storage.googleapis.com | liquibase-migration | 1.1.0 |
 
 ## Values
 
@@ -41,6 +47,35 @@ Chart for Resource Buffering Service
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
+| liquibase-migration.defaults.enabled | bool | `false` |  |
+| liquibase-migration.defaults.k8sServiceAccount | string | `"buffer-service-sa"` |  |
+| liquibase-migration.defaults.migrationArgsClasspath[0] | string | `"app/libs/*"` |  |
+| liquibase-migration.defaults.migrationArgsClasspath[1] | string | `"app/resources/"` |  |
+| liquibase-migration.defaults.migrationArgsConfigDriver | string | `"org.postgresql.Driver"` |  |
+| liquibase-migration.defaults.migrationArgsConfigUrl | string | `"jdbc:postgresql://127.0.0.1:5432/${DB_NAME}"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromKubernetesSecret.databaseNameKey | string | `"db"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromKubernetesSecret.passwordKey | string | `"password"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromKubernetesSecret.usernameKey | string | `"username"` |  |
+| liquibase-migration.defaults.migrationImage | string | `"gcr.io/terra-kernel-k8s/terra-resource-buffer"` |  |
+| liquibase-migration.defaults.sqlproxyArgsInstances | string | `"$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[0].name | string | `"SQL_INSTANCE_PROJECT"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[0].valueFrom.secretKeyRef.key | string | `"project"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[0].valueFrom.secretKeyRef.name | string | `"buffer-cloudsql-postgres-instance"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[1].name | string | `"SQL_INSTANCE_REGION"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[1].valueFrom.secretKeyRef.key | string | `"region"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[1].valueFrom.secretKeyRef.name | string | `"buffer-cloudsql-postgres-instance"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[2].name | string | `"SQL_INSTANCE_NAME"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[2].valueFrom.secretKeyRef.key | string | `"name"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[2].valueFrom.secretKeyRef.name | string | `"buffer-cloudsql-postgres-instance"` |  |
+| liquibase-migration.defaults.sqlproxyCredentialFileMount.mountFilePath | string | `"/secrets/cloudsql/service-account.json"` |  |
+| liquibase-migration.defaults.sqlproxyCredentialFileMount.secretName | string | `"buffer-cloudsql-sa"` |  |
+| liquibase-migration.migrationJobs[0].migrationArgsConfigChangelog | string | `"db/changelog.xml"` |  |
+| liquibase-migration.migrationJobs[0].migrationDatabaseCredentials.fromKubernetesSecret.name | string | `"buffer-postgres-db-creds"` |  |
+| liquibase-migration.migrationJobs[0].name | string | `"buffer"` |  |
+| liquibase-migration.migrationJobs[1].migrationArgsConfigChangelog | string | `"stairway/db/changelog.xml"` |  |
+| liquibase-migration.migrationJobs[1].migrationDatabaseCredentials.fromKubernetesSecret.name | string | `"buffer-stairway-db-creds"` |  |
+| liquibase-migration.migrationJobs[1].name | string | `"buffer-stairway"` |  |
+| liquibase-migration.name | string | `"buffer"` |  |
 | name | string | `"buffer"` | A name for the deployment that will be substituted into resuorce definitions |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |

--- a/charts/buffer/values.yaml
+++ b/charts/buffer/values.yaml
@@ -183,3 +183,67 @@ buffer:
 
 # cleanupAfterHandout -- Whether to publish message to Janitor after resource is handed out.
 cleanupAfterHandout: false
+
+liquibase-migration:
+  # In an env-specific file use something like the following to fully enable:
+  # ```
+  # liquibase-migration:   
+  #   defaults:
+  #     enabled: true
+  # ```
+  # See https://github.com/broadinstitute/terra-helm/blob/master/charts/liquibase-migration for more information
+
+  migrationJobs:
+  - name: buffer
+    # on filesystem, on classpath via app/resources/
+    migrationArgsConfigChangelog: "db/changelog.xml"
+    migrationDatabaseCredentials:
+      fromKubernetesSecret:
+        name: "buffer-postgres-db-creds"
+  - name: buffer-stairway
+    # inside stairway jar, on classpath via app/libs/*
+    migrationArgsConfigChangelog: "stairway/db/changelog.xml"
+    migrationDatabaseCredentials:
+      fromKubernetesSecret:
+        name: "buffer-stairway-db-creds"
+
+  # Template definition buffer.labels attempts to read .Values.name from within liquibase-migration.
+  # Either we must pass the name again, move it to globals, or disable liquibase-migration labels.
+  name: "buffer"
+
+  defaults:
+    enabled: false
+    k8sServiceAccount: "buffer-service-sa"
+    sqlproxyCredentialFileMount:
+      secretName: "buffer-cloudsql-sa"
+      mountFilePath: "/secrets/cloudsql/service-account.json"
+    sqlproxyArgsInstances: "$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432"
+    sqlproxyContainerConfig:
+      env:
+        - name: "SQL_INSTANCE_PROJECT"
+          valueFrom:
+            secretKeyRef:
+              name: "buffer-cloudsql-postgres-instance"
+              key: "project"
+        - name: "SQL_INSTANCE_REGION"
+          valueFrom:
+            secretKeyRef:
+              name: "buffer-cloudsql-postgres-instance"
+              key: "region"
+        - name: "SQL_INSTANCE_NAME"
+          valueFrom:
+            secretKeyRef:
+              name: "buffer-cloudsql-postgres-instance"
+              key: "name"
+    migrationImage: "gcr.io/terra-kernel-k8s/terra-resource-buffer"
+    migrationArgsClasspath:
+      - "app/libs/*"
+      - "app/resources/"
+    migrationArgsConfigDriver: "org.postgresql.Driver"
+    migrationArgsConfigUrl: "jdbc:postgresql://127.0.0.1:5432/${DB_NAME}"
+    migrationDatabaseCredentials:
+      fromKubernetesSecret:
+        usernameKey: "username"
+        passwordKey: "password"
+        databaseNameKey: "db"
+


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
The liquibase-migration helper chart has been reworked and has been tested in dev. This PR adds it to Buffer's chart and the accompanying terra-helmfile PR (https://github.com/broadinstitute/terra-helmfile/pull/1730) will enable the migrations as the updated chart propagates through the release cadence.

For background:
When apps start and block their startup on running possibly-lengthy Liquibase migrations, it is harder to detect and fix actual issues with app startup (in other words, hour-long startups are within the realm of expected behavior, so automated checks need to not fire). 

Our solution is to _also_ run an app's migrations before the app ever starts, using an Argo CD sync hook. We use the app image's own changelogs, liquibase version, JDBC driver, etc. When the app starts, Liquibase simply exits quickly because no migration is necessary. No changes are needed to the app's codebase, it is a free speed boost to startup where enabled. We've done this for Rawls and Leonardo and we've now adapted our helper chart to work for apps like Buffer.



Here, this PR adds this new pre-migration feature for both Buffer's own database and Buffer's stairway database. Both migrations run simultaneously on separate pods with their own Cloud SQL proxies. Any issues would cause errors during Argo CD sync during "sync wave -1", meaning before literally anything else has been touched.