### PR TITLE
[DDO-1545] Remove references to sysbox from runner instances

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -115,7 +115,7 @@ apps:
       version: 0.2.0
     instances:
       chart: dsp-gha-runner-instances
-      version: 0.4.0
+      version: 0.5.0
   sysbox:
     notificationChannel: ap-k8s-monitor
     namespace: kube-system

--- a/charts/dsp-gha-runner-instances/README.md
+++ b/charts/dsp-gha-runner-instances/README.md
@@ -1,6 +1,6 @@
 # dsp-gha-runner-instances
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Self-hosted GHA runner instances relying on dsp-gha-runner-controller
 

--- a/charts/dsp-gha-runner-instances/values.yaml
+++ b/charts/dsp-gha-runner-instances/values.yaml
@@ -38,7 +38,7 @@ runnerDefaults:
 # for different docker configurations
 dockerConfigs:
   
-  # 'privilegedDockerInDocker' INSECURELY uses a privileged container to run
+  # 'privilegedDockerInDocker' uses a privileged container to run
   # docker-in-docker via internal dockerd
   # - https://github.com/actions-runner-controller/actions-runner-controller#runner-with-dind
   privilegedDockerInDocker:
@@ -47,7 +47,7 @@ dockerConfigs:
       dockerEnabled: false
       dockerdWithinRunnerContainer: true
   
-  # 'privilegedSidecar' INSECURELY uses a privileged sidecar container to run
+  # 'privilegedSidecar' uses a privileged sidecar container to run
   # docker-out-of-docker
   # - https://github.com/actions-runner-controller/actions-runner-controller#additional-tweaks
   privilegedSidecar:

--- a/charts/dsp-gha-runner-instances/values.yaml
+++ b/charts/dsp-gha-runner-instances/values.yaml
@@ -37,27 +37,6 @@ runnerDefaults:
 # -- (object) Lists/configures "shortcuts" to metadata/spec configurations
 # for different docker configurations
 dockerConfigs:
-  # 'sysboxDockerInDocker' uses the sysbox OCI runtime to run docker-in-docker
-  # without any privileged containers.
-  # This requires additional setup per https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md.
-  sysboxDockerInDocker:
-    metadata:
-      annotations:
-        # Configure user namespace for the pod
-        # - https://github.com/nestybox/sysbox#using-sysbox
-        # - https://frasertweedale.github.io/blog-redhat/posts/2020-12-01-openshift-crio-userns.html#computing-the-gid-range
-        io.kubernetes.cri-o.userns-mode: 'auto:size=65536'
-    spec:
-      # From the controller's perspective, don't provide any privileges, assume no Docker
-      dockerEnabled: false
-      dockerdWithinRunnerContainer: false
-      # Use our custom image that expects a sysbox runtime
-      # - https://github.com/broadinstitute/dsp-github-action-runner-image
-      image: 'us-central1-docker.pkg.dev/dsp-artifact-registry/dsp-github-action-runner/dsp-github-action-runner:nightly'
-      # Run these pods on a specific pool and runtime class
-      nodeSelector:
-        cloud.google.com/gke-nodepool: sysbox-v1
-      runtimeClassName: sysbox-runc
   
   # 'privilegedDockerInDocker' INSECURELY uses a privileged container to run
   # docker-in-docker via internal dockerd
@@ -86,7 +65,7 @@ dockerConfigs:
       dockerdWithinRunnerContainer: false
 
 # -- (string) Name of a key on .dockerConfigs to use for docker configuration
-defaultDockerConfig: sysboxDockerInDocker
+defaultDockerConfig: privilegedDockerInDocker
 
 
 #


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
This'll make runners no longer require sysbox.

**Merge order:** first for DDO-1545 (before #523)

**Post-merge:** deploy the new Argo CD chart version