### PR TITLE
[No ticket]Refactor PDB to accept match labels from inheriting charts.

### DIFF
--- a/charts/pdblib/templates/_pdb.yaml
+++ b/charts/pdblib/templates/_pdb.yaml
@@ -8,7 +8,8 @@ spec:
   # https://v1-20.docs.kubernetes.io/docs/tasks/run-application/configure-pdb/#rounding-logic-when-specifying-percentages
   minAvailable: 65%
   selector:
-    matchLabels: {}
+    # Expects value to be filled by inheriting charts
+    matchLabels:
 {{- end }}
 
 {{- define "libchart.pdb" -}}

--- a/charts/pdblib/templates/_pdb.yaml
+++ b/charts/pdblib/templates/_pdb.yaml
@@ -1,4 +1,4 @@
-{{- define "libchart.pdb" -}}
+{{- define "libchart.pdb.tpl" -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -8,6 +8,9 @@ spec:
   # https://v1-20.docs.kubernetes.io/docs/tasks/run-application/configure-pdb/#rounding-logic-when-specifying-percentages
   minAvailable: 65%
   selector:
-    matchLabels:
-      deployment: {{ .Values.name }}-deployment
+    matchLabels: {}
 {{- end }}
+
+{{- define "libchart.pdb" -}}
+{{- include "pdblib.util.merge" (append . "libchart.pdb.tpl") -}}
+{{- end -}}

--- a/charts/pdblib/templates/_util.yaml
+++ b/charts/pdblib/templates/_util.yaml
@@ -1,0 +1,14 @@
+{{- /*
+libchart.util.merge will merge two YAML templates and output the result.
+This takes an array of three values:
+- the top context
+- the template name of the overrides (destination)
+- the template name of the base (source)
+*/}}
+
+{{- define "pdblib.util.merge" -}}
+{{- $top := first . -}}
+{{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}
+{{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
+{{- toYaml (merge $overrides $tpl) -}}
+{{- end -}}

--- a/charts/pdblib/templates/_util.yaml
+++ b/charts/pdblib/templates/_util.yaml
@@ -1,14 +1,18 @@
 {{- /*
-libchart.util.merge will merge two YAML templates and output the result.
+pdblib.util.merge will merge two YAML templates and output the result.
 This takes an array of three values:
 - the top context
 - the template name of the overrides (destination)
 - the template name of the base (source)
+An error will be thrown if the top context does not provide values for
+.spec.selector.matchLabels
 */}}
 
 {{- define "pdblib.util.merge" -}}
 {{- $top := first . -}}
 {{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}
 {{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
-{{- toYaml (merge $overrides $tpl) -}}
+{{- $mergedmanifest := merge $overrides $tpl -}}
+{{ required "spec.selector.matchLabels are required." $mergedmanifest.spec.selector.matchLabels }}
+{{- toYaml $mergedmanifest -}}
 {{- end -}}

--- a/charts/pdblib/templates/_util.yaml
+++ b/charts/pdblib/templates/_util.yaml
@@ -13,6 +13,6 @@ An error will be thrown if the top context does not provide values for
 {{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}
 {{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
 {{- $mergedmanifest := merge $overrides $tpl -}}
-{{ required "spec.selector.matchLabels are required." $mergedmanifest.spec.selector.matchLabels }}
+{{ $_ := required "spec.selector.matchLabels are required." $mergedmanifest.spec.selector.matchLabels }}
 {{- toYaml $mergedmanifest -}}
 {{- end -}}


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
PR allows match labels defined in inheriting charts and checks to make sure they're defined. 