### PR TITLE
[DDO-1598] Tiny config connector chart

### DIFF
--- a/charts/config-connector/Chart.yaml
+++ b/charts/config-connector/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: config-connector
+version: 1.0.0
+description: Chart to add the Google Config Connector configuration file
+type: application
+keywords:
+  - dsp
+  - broadinstitute
+  - terra
+sources:
+  - https://github.com/broadinstitute/terra-helm/tree/master/charts
+  - https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-configuring

--- a/charts/config-connector/README.md
+++ b/charts/config-connector/README.md
@@ -1,0 +1,25 @@
+# config-connector
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Chart to add the Google Config Connector configuration file
+
+This chart does not enable Config Connector on its own! The only step it can do is make the configuration file
+that Google requires **once Config Connector has already been enabled in the cluster**.
+
+In other words, this is step three (["Configuring Config Connector"](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-configuring))
+of the [installation instructions](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-install).
+The terra-cluster module in ap-deployments can handle the first two steps and the last step is namespace annotations
+([which must be done manually](https://github.com/helm/helm/issues/3503)).
+
+## Source Code
+
+* <https://github.com/broadinstitute/terra-helm/tree/master/charts>
+* <https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-configuring>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| googleProjectID | string | `nil` | The ID of the project to containing the `googleServiceAccountName`, e.g. broad-dsp-eng-tools |
+| googleServiceAccountName | string | `"config-connector"` | The name of the GSA in `googleProjectID` that's been set up for Config Connector |

--- a/charts/config-connector/README.md.gotmpl
+++ b/charts/config-connector/README.md.gotmpl
@@ -1,0 +1,24 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+This chart does not enable Config Connector on its own! The only step it can do is make the configuration file
+that Google requires **once Config Connector has already been enabled in the cluster**.
+
+In other words, this is step three (["Configuring Config Connector"](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-configuring))
+of the [installation instructions](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-install).
+The terra-cluster module in ap-deployments can handle the first two steps and the last step is namespace annotations
+([which must be done manually](https://github.com/helm/helm/issues/3503)).
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/config-connector/templates/configconnector.yaml
+++ b/charts/config-connector/templates/configconnector.yaml
@@ -1,0 +1,10 @@
+# From https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall#addon-configuring
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  # the name is restricted to ensure that there is only one
+  # ConfigConnector resource installed in your cluster
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: cluster
+  googleServiceAccount: "{{ .Values.googleServiceAccountName }}@{{ .Values.googleProjectID }}.iam.gserviceaccount.com"

--- a/charts/config-connector/values.yaml
+++ b/charts/config-connector/values.yaml
@@ -1,0 +1,4 @@
+# -- The name of the GSA in `googleProjectID` that's been set up for Config Connector
+googleServiceAccountName: config-connector
+# -- (string) The ID of the project to containing the `googleServiceAccountName`, e.g. broad-dsp-eng-tools
+googleProjectID:


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Google requires that you push a boilerplate file like this to a cluster as part of installing config connector. Figured it would be better as a chart than as yet another bespoke manual step.

Context:
I'm enabling config connector on dsp-eng-tools as a forward-looking thing. The first two steps--the GCP cluster config and the IAM config--can be done via Terraform, I did that over in https://github.com/broadinstitute/terraform-ap-deployments/pull/437. There's this step, and then unfortunately you have to (or, at least should) annotate namespaces with the default project.