### PR TITLE
DDO-1619 argocd: bump cpu + memory for repo server and app controller

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -71,8 +71,15 @@ argo-cd:
     - --repo-server-timeout-seconds=180
     resources:
       requests:
-        cpu: 3.2
-        memory: 4Gi
+        cpu: 6
+        memory: 8Gi
+    tolerations:
+      - key: "bio.terra/node-pool"
+        operator: "Equal"
+        value: "n2-standard-32"
+        effect: "NoSchedule"
+    nodeSelectors:
+      name: "n2-standard-32"
   repoServer:
     image:
       repository: us-central1-docker.pkg.dev/dsp-artifact-registry/terra-helmfile-images/argocd-custom-image
@@ -94,8 +101,16 @@ argo-cd:
         value: "false"
     resources:
       requests:
-        cpu: 3.2
-        memory: 4Gi
+        cpu: 24
+        memory: 16Gi
+    tolerations:
+      - key: "bio.terra/node-pool"
+        operator: "Equal"
+        value: "n2-standard-32"
+        effect: "NoSchedule"
+    nodeSelectors:
+      name: "n2-standard-32"
+
 # Path in Vault where ArgoCD secrets live
 vault:
   pathPrefix: secret/suitable/argocd


### PR DESCRIPTION
* Configure repo server and app controller to use new node pool with big n2-standard-32 nodes 💪 (https://github.com/broadinstitute/terraform-dsp-tools-k8s/pull/21)
* Bump cpu + memory for repo server and app controller
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
