### PR TITLE
DDO-1630 Fix ArgoCD ingress

### DIFF
--- a/charts/dsp-argocd/values.yaml
+++ b/charts/dsp-argocd/values.yaml
@@ -47,6 +47,7 @@ argo-cd:
         cloud.google.com/backend-config: '{"default": "dsp-argocd-backendconfig"}'
     ingress:
       enabled: true
+      pathType: ImplementationSpecific
       paths:
         - /*
       tls:


### PR DESCRIPTION
Today ArgoCD's ssl cert expired. Cert-manager had updated the cert, but the Ingress wasn't picking it up (thanks to @mflinn-broad for the note). We noticed the following in the Ingress logs:
```
  Normal   Sync       21s (x8 over 5h39m)   loadbalancer-controller  Scheduled for sync
  Warning  Translate  19s (x44 over 5h39m)  loadbalancer-controller  Translation failed: invalid ingress spec: only 
  "ImplementationSpecific" path type is supported
```

From: https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress#creating_an_ingress

> For GKE clusters running versions earlier than 1.21.3-gke.1600, the only supported value for the pathType field is ImplementationSpecific. For clusters running version 1.21.3-gke.1600 or later, Prefix and Exact values are also supported for pathType.

Changing the path type to `ImplementationSpecific` fixed the breakage. I think this broke the last time I upgraded the ArgoCD helm chart (suspect PR [here](https://github.com/argoproj/argo-helm/commit/1e3a4afd0583a4c35dba2b8783f9fded82667dfc)), and we just didn't notice until the cert expired.
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
