### PR TITLE
[DDO-1628] Add liquibase capabilities to workspace manager in argo

### DIFF
--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -19,3 +19,6 @@ dependencies:
   - name: pdb-lib
     version: 0.4.0
     repository: https://broadinstitute.github.io/terra-helm/
+  - name: liquibase-migration
+    version: 1.1.0
+    repository: https://terra-helm.storage.googleapis.com

--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -6,6 +6,8 @@ Chart for Terra Workspace Manager
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://broadinstitute.github.io/terra-helm/ | pdb-lib | 0.4.0 |
+| https://terra-helm.storage.googleapis.com | liquibase-migration | 1.1.0 |
 | https://terra-helm.storage.googleapis.com | postgres | 0.1.0 |
 
 ## Values
@@ -47,6 +49,35 @@ Chart for Terra Workspace Manager
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
 | initDB | bool | `false` | Whether the WSM and Stairway DBs should be initialized on startup. Used for preview environments. |
+| liquibase-migration.defaults.enabled | bool | `false` |  |
+| liquibase-migration.defaults.k8sServiceAccount | string | `"workspacemanager-service-sa"` |  |
+| liquibase-migration.defaults.migrationArgsClasspath[0] | string | `"app/libs/*"` |  |
+| liquibase-migration.defaults.migrationArgsClasspath[1] | string | `"app/resources/"` |  |
+| liquibase-migration.defaults.migrationArgsConfigDriver | string | `"org.postgresql.Driver"` |  |
+| liquibase-migration.defaults.migrationArgsConfigUrl | string | `"jdbc:postgresql://127.0.0.1:5432/${DB_NAME}"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromKubernetesSecret.databaseNameKey | string | `"db"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromKubernetesSecret.passwordKey | string | `"password"` |  |
+| liquibase-migration.defaults.migrationDatabaseCredentials.fromKubernetesSecret.usernameKey | string | `"username"` |  |
+| liquibase-migration.defaults.migrationImage | string | `"gcr.io/terra-kernel-k8s/terra-workspace-manager"` |  |
+| liquibase-migration.defaults.sqlproxyArgsInstances | string | `"$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[0].name | string | `"SQL_INSTANCE_PROJECT"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[0].valueFrom.secretKeyRef.key | string | `"project"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[0].valueFrom.secretKeyRef.name | string | `"workspacemanager-cloudsql-postgres-instance"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[1].name | string | `"SQL_INSTANCE_REGION"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[1].valueFrom.secretKeyRef.key | string | `"region"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[1].valueFrom.secretKeyRef.name | string | `"workspacemanager-cloudsql-postgres-instance"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[2].name | string | `"SQL_INSTANCE_NAME"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[2].valueFrom.secretKeyRef.key | string | `"name"` |  |
+| liquibase-migration.defaults.sqlproxyContainerConfig.env[2].valueFrom.secretKeyRef.name | string | `"workspacemanager-cloudsql-postgres-instance"` |  |
+| liquibase-migration.defaults.sqlproxyCredentialFileMount.mountFilePath | string | `"/secrets/cloudsql/service-account.json"` |  |
+| liquibase-migration.defaults.sqlproxyCredentialFileMount.secretName | string | `"workspacemanager-cloudsql-sa"` |  |
+| liquibase-migration.migrationJobs[0].migrationArgsConfigChangelog | string | `"db/changelog.xml"` |  |
+| liquibase-migration.migrationJobs[0].migrationDatabaseCredentials.fromKubernetesSecret.name | string | `"workspacemanager-postgres-db-creds"` |  |
+| liquibase-migration.migrationJobs[0].name | string | `"workspacemanager"` |  |
+| liquibase-migration.migrationJobs[1].migrationArgsConfigChangelog | string | `"stairway/db/changelog.xml"` |  |
+| liquibase-migration.migrationJobs[1].migrationDatabaseCredentials.fromKubernetesSecret.name | string | `"workspacemanager-stairway-db-creds"` |  |
+| liquibase-migration.migrationJobs[1].name | string | `"workspacemanager-stairway"` |  |
+| liquibase-migration.name | string | `"workspacemanager"` |  |
 | name | string | `"workspacemanager"` | A name for the deployment that will be substituted into resuorce definitions |
 | postgres.dbs | list | `["workspace","stairway"]` | (array(string)) List of databases to create. |
 | postgres.enabled | bool | `false` | Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options. |

--- a/charts/workspacemanager/templates/role.yaml
+++ b/charts/workspacemanager/templates/role.yaml
@@ -2,6 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Values.name }}-service-role
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 rules:

--- a/charts/workspacemanager/templates/rolebinding.yaml
+++ b/charts/workspacemanager/templates/rolebinding.yaml
@@ -2,6 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Values.name }}-service-role-binding
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 roleRef:

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -4,6 +4,9 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   name: {{ .Values.name }}-postgres-db-creds
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
@@ -23,6 +26,9 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   name: {{ .Values.name }}-stairway-db-creds
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
@@ -42,6 +48,9 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   name: {{ .Values.name }}-postgres-instance
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
@@ -61,6 +70,9 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   name: {{ .Values.name }}-sqlproxy-sa
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:

--- a/charts/workspacemanager/templates/service-account.yaml
+++ b/charts/workspacemanager/templates/service-account.yaml
@@ -2,5 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}-service-sa
+  annotations:
+    # Used by liquibase-migration during wave -1
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -231,3 +231,69 @@ terraDataRepoUrl: https://jade.datarepo-dev.broadinstitute.org
 spendBillingAccountId:
 # spendProfileId -- the Spend Profile Id to associate with the billing account.
 spendProfileId:
+
+###############################################################
+# End of values exposed to app via the env                    #
+###############################################################
+
+liquibase-migration:
+  # In an env-specific file use something like the following to fully enable:
+  # ```
+  # liquibase-migration:
+  #   defaults:
+  #     enabled: true
+  # ```
+  # See https://github.com/broadinstitute/terra-helm/blob/master/charts/liquibase-migration for more information
+
+  migrationJobs:
+  - name: workspacemanager
+    # on filesystem, on classpath via app/resources/
+    migrationArgsConfigChangelog: "db/changelog.xml"
+    migrationDatabaseCredentials:
+      fromKubernetesSecret:
+        name: "workspacemanager-postgres-db-creds"
+  - name: workspacemanager-stairway
+    # inside stairway jar, on classpath via app/libs/*
+    migrationArgsConfigChangelog: "stairway/db/changelog.xml"
+    migrationDatabaseCredentials:
+      fromKubernetesSecret:
+        name: "workspacemanager-stairway-db-creds"
+
+  # Workaround pending DDO-1579
+  name: "workspacemanager"
+
+  defaults:
+    enabled: false
+    k8sServiceAccount: "workspacemanager-service-sa"
+    sqlproxyCredentialFileMount:
+      secretName: "workspacemanager-cloudsql-sa"
+      mountFilePath: "/secrets/cloudsql/service-account.json"
+    sqlproxyArgsInstances: "$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432"
+    sqlproxyContainerConfig:
+      env:
+        - name: "SQL_INSTANCE_PROJECT"
+          valueFrom:
+            secretKeyRef:
+              name: "workspacemanager-cloudsql-postgres-instance"
+              key: "project"
+        - name: "SQL_INSTANCE_REGION"
+          valueFrom:
+            secretKeyRef:
+              name: "workspacemanager-cloudsql-postgres-instance"
+              key: "region"
+        - name: "SQL_INSTANCE_NAME"
+          valueFrom:
+            secretKeyRef:
+              name: "workspacemanager-cloudsql-postgres-instance"
+              key: "name"
+    migrationImage: "gcr.io/terra-kernel-k8s/terra-workspace-manager"
+    migrationArgsClasspath:
+      - "app/libs/*"
+      - "app/resources/"
+    migrationArgsConfigDriver: "org.postgresql.Driver"
+    migrationArgsConfigUrl: "jdbc:postgresql://127.0.0.1:5432/${DB_NAME}"
+    migrationDatabaseCredentials:
+      fromKubernetesSecret:
+        usernameKey: "username"
+        passwordKey: "password"
+        databaseNameKey: "db"


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
Just like #513, add the capability for WSM to run liquibase migrations inside Argo CD before the app itself starts, improving startup times and reliability. Like discussed in #513, there's improvements we can do over time here (we've got a ticket for fixing name duplication, for example). We're just getting everything standardized and tested so we can plan out next steps in the future.

More information in DDO-1628