### PR TITLE
[DDO-1646] Fix argument typo in liquibase-migration

### DIFF
--- a/charts/liquibase-migration/README.md
+++ b/charts/liquibase-migration/README.md
@@ -43,7 +43,6 @@ helm-docs can't parse all the comments in the values file, [see it for more deta
 | defaults.migrationDelay | string | `"15s"` | Time to wait before attempting to start Liquibase, to allow proxy to boot |
 | defaults.migrationImage | string | `nil` | Image to use for the migration, usually the application image with bundled Liquibase |
 | defaults.migrationImageTag | string | `nil` | Image tag to use for the migration image; **warning** that setting this can cause inconsistent migrations (default recommended) |
-| defaults.migrationPreflightShellCode | string | `nil` | Arbitrary shell code to run before the migration (does not need trailing `&& \`) |
 | defaults.migrationShell | list | `["bash","-c"]` | Docker command directive to invoke a shell in the container, to expand migrationArgs* values |
 | defaults.sqlproxyArgsInstances | string | Mimics behavior of legacy broadinstitute/cloudsqlproxy image | Instances argument passed to the proxy executable, expanded by proxyShell |
 | defaults.sqlproxyArgsMaxConnections | string | Mimics behavior of legacy broadinstitute/cloudsqlproxy image | Max connections argument passed to the proxy executable, expanded by proxyShell |

--- a/charts/liquibase-migration/templates/manifests.yaml
+++ b/charts/liquibase-migration/templates/manifests.yaml
@@ -168,9 +168,6 @@ spec:
         command: {{ $config.migrationShell | toYaml | nindent 10 }}
         args:
         - |-
-          {{- if $config.migrationPreflightShellCode }}
-          {{- $config.migrationPreflightShellCode | nindent 10 }} && \
-          {{- end }}
           {{- if $config.migrationDelay }}
           sleep {{ $config.migrationDelay }} && \
           {{- end }}

--- a/charts/liquibase-migration/values.yaml
+++ b/charts/liquibase-migration/values.yaml
@@ -53,8 +53,6 @@ defaults:
   migrationImageTag:
   # -- Docker command directive to invoke a shell in the container, to expand migrationArgs* values
   migrationShell: ["bash", "-c"]
-  # -- (string) Arbitrary shell code to run before the migration (does not need trailing `&& \`)
-  migrationPreflightShellCode: null
   # -- Time to wait before attempting to start Liquibase, to allow proxy to boot
   migrationDelay: "15s"
   # -- (list) Java classpath location(s) containing Liquibase, JDBC driver, any packaged changelogs, and all dependencies;


### PR DESCRIPTION
Fixes an argument typo and does indentation better (this has never been needed before but is now for Cromwell)