### PR TITLE
[No Ticket] Make sherlock-reporter Post-Sync hook rather than sync

### DIFF
--- a/charts/sherlock-reporter/templates/_job.yaml
+++ b/charts/sherlock-reporter/templates/_job.yaml
@@ -3,7 +3,7 @@
 {{- $appImageName := .Values.sherlock.appImageName | required "A valid sherlock.appImageName is required (without trailing tag)" -}}
 {{- $appName := .Values.sherlock.appName | default .Release.Name -}}
 {{- $labelRef := .Values.sherlock.labelRef | default (printf "%s.labels" $appName) -}}
-{{- $syncWave := .Values.sherlock.syncWave | default "-1" -}}
+{{- $syncWave := .Values.sherlock.syncWave | default "1" -}}
 {{- $appImageTag := .Values.sherlock.appImageTag | default .Values.global.applicationVersion -}}
 {{- $serviceAccount := .Values.sherlock.serviceAccount | default (printf "%s-sa" $appName) -}}
 {{- $sherlockImageName := .Values.sherlock.sherlockImageName | default "us-central1-docker.pkg.dev/dsp-artifact-registry/sherlock/cli" -}}

--- a/charts/sherlock-reporter/values.yaml
+++ b/charts/sherlock-reporter/values.yaml
@@ -18,8 +18,8 @@ sherlock:
   # sherlock.labelRef -- (string) Template reference to `include` in resource labels
   # @default -- Set to "${appName}.labels"
   labelRef: null
-  # sherlock.syncWave -- (string) ArgoCD wave to apply these resources in
-  syncWave: "-1"
+  # sherlock.syncWave -- (string) ArgoCD wave to apply these resources in. This should be the last resourse to sync
+  syncWave: "1"
   # sherlock.appimageTag -- (string) version of the service being deployed to report to sherlock
   # @default -- Set to global.applicationVersion
   appImageTag: null


### PR DESCRIPTION
Update the sherlock library job to ensure that it only reports a deploy to sherlock after all other sync operations have completed
