### PR TITLE
Revert #602

### DIFF
--- a/charts/externalcreds/Chart.yaml
+++ b/charts/externalcreds/Chart.yaml
@@ -12,6 +12,10 @@ sources:
   - https://github.com/broadinstitute/terra-helm/tree/master/charts
   - https://github.com/DataBiosphere/terra-external-credentials-manager
 dependencies:
+  - name: postgres
+    condition: postgres.enabled
+    version: 0.1.0
+    repository: https://terra-helm.storage.googleapis.com
   - name: pdb-lib
     version: 0.4.0
     repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/externalcreds/values.yaml
+++ b/charts/externalcreds/values.yaml
@@ -177,6 +177,13 @@ proxy:
   # proxy.reloadOnCertUpdate -- Whether to reload the deployment when the cert is updated. Requires stakater/Reloader service to be running in the cluster.
   reloadOnCertUpdate: true
 
+postgres:
+  # postgres.enabled -- Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options.
+  enabled: false
+  # postgres.dbs -- (array(string)) List of databases to create.
+  dbs:
+    - externalcreds
+
 # Requires deployment of Prometheus to cluster
 prometheus:
   enabled: true

--- a/charts/workspacemanager/Chart.yaml
+++ b/charts/workspacemanager/Chart.yaml
@@ -12,6 +12,10 @@ sources:
   - https://github.com/broadinstitute/terra-helm/tree/master/charts
   - https://github.com/DataBiosphere/terra-workspace-manager
 dependencies:
+  - name: postgres
+    condition: postgres.enabled
+    version: 0.1.0
+    repository: https://terra-helm.storage.googleapis.com
   - name: pdb-lib
     version: 0.4.0
     repository: https://broadinstitute.github.io/terra-helm/

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -179,6 +179,14 @@ proxy:
   # proxy.reloadOnCertUpdate -- Whether to reload the deployment when the cert is updated. Requires stakater/Reloader service to be running in the cluster.
   reloadOnCertUpdate: true
 
+postgres:
+  # postgres.enabled -- Whether to enable ephemeral Postgres container. Used for preview/test environments. See the postgres chart for more config options.
+  enabled: false
+  # postgres.dbs -- (array(string)) List of databases to create.
+  dbs:
+    - workspace
+    - stairway
+
 # Requires deployment of Prometheus to cluster
 prometheus:
   enabled: true


### PR DESCRIPTION
 Revert #602 "DDO-1668 Remove postgres chart dep from externalcreds and workspacemanager charts (#602)"

This reverts commit 5793935f64aaa18f0a051e2c3ba0d5bf1d7eb6cf.

<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
