### PR TITLE
[DDO-1654] Always reference GCS helm repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ A helm repo for Terra from Broad Data Science Platforms Group
 
 ## How Do I install the repo?
 ```
-helm repo add terra-helm https://broadinstitute.github.io/terra-helm
+helm repo add terra-helm https://terra-helm.storage.googleapis.com
 helm repo update
 ```
 ## How Do I Install These Charts?
 
-Just `helm install terra-helm/<chart>`. This is the default repository for Helm which is located at https://broadinstitute.github.io/terra-helm/ and is installed by default.
+Just `helm install terra-helm/<chart>`. This is the default repository for Helm which is located at https://terra-helm.storage.googleapis.com and is installed by default.
 
 For more information on using Helm, refer to the [Helm documentation](https://github.com/kubernetes/helm#docs).
 

--- a/charts/agora/Chart.yaml
+++ b/charts/agora/Chart.yaml
@@ -15,10 +15,10 @@ sources:
 dependencies:
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/agora/README.md
+++ b/charts/agora/README.md
@@ -6,7 +6,7 @@ Chart for Agora service in Terra
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm/ | ingresslib | 0.6.0 |
+| https://terra-helm.storage.googleapis.com | ingresslib | 0.6.0 |
 
 ## Values
 

--- a/charts/buffer/Chart.yaml
+++ b/charts/buffer/Chart.yaml
@@ -14,13 +14,13 @@ sources:
 dependencies:
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: liquibase-migration
     version: 1.1.0
     repository: https://terra-helm.storage.googleapis.com
   - name: pdb-lib
     version: 0.2.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/buffer/README.md
+++ b/charts/buffer/README.md
@@ -13,9 +13,9 @@ Chart for Resource Buffering Service
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm/ | ingresslib | 0.6.0 |
+| https://terra-helm.storage.googleapis.com | ingresslib | 0.6.0 |
 | https://terra-helm.storage.googleapis.com | liquibase-migration | 1.1.0
-| https://broadinstitute.github.io/terra-helm/ | pdb-lib | 0.2.0
+| https://terra-helm.storage.googleapis.com | pdb-lib | 0.2.0
 
 ## Values
 

--- a/charts/consent/Chart.yaml
+++ b/charts/consent/Chart.yaml
@@ -15,10 +15,10 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: liquibase-migration
     version: 1.1.0
     repository: https://terra-helm.storage.googleapis.com

--- a/charts/cromiam/Chart.yaml
+++ b/charts/cromiam/Chart.yaml
@@ -15,7 +15,7 @@ sources:
 dependencies:
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/duos/Chart.yaml
+++ b/charts/duos/Chart.yaml
@@ -15,7 +15,7 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/firecloudorch/Chart.yaml
+++ b/charts/firecloudorch/Chart.yaml
@@ -16,7 +16,7 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/firecloudui/Chart.yaml
+++ b/charts/firecloudui/Chart.yaml
@@ -14,10 +14,10 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/firecloudui/README.md
+++ b/charts/firecloudui/README.md
@@ -6,8 +6,8 @@ Chart for Firecloud UI service in Terra
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm/ | ingresslib | 0.10.0 |
-| https://broadinstitute.github.io/terra-helm/ | pdb-lib | 0.4.0 |
+| https://terra-helm.storage.googleapis.com | ingresslib | 0.10.0 |
+| https://terra-helm.storage.googleapis.com | pdb-lib | 0.4.0 |
 
 ## Values
 

--- a/charts/jobmanager/Chart.yaml
+++ b/charts/jobmanager/Chart.yaml
@@ -14,10 +14,10 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -6,8 +6,8 @@ Chart for Job Manager service in Terra
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm/ | ingresslib | 0.10.0 |
-| https://broadinstitute.github.io/terra-helm/ | pdb-lib | 0.4.0 |
+| https://terra-helm.storage.googleapis.com | ingresslib | 0.10.0 |
+| https://terra-helm.storage.googleapis.com | pdb-lib | 0.4.0 |
 
 ## Values
 

--- a/charts/leonardo/Chart.yaml
+++ b/charts/leonardo/Chart.yaml
@@ -17,10 +17,10 @@ dependencies:
     repository: https://terra-helm.storage.googleapis.com/
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: ingresslib
     version: 0.12.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/leonardo/README.md
+++ b/charts/leonardo/README.md
@@ -6,8 +6,8 @@ A Helm chart for Leonardo, a Terra service for interactive analysis applications
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm/ | ingresslib | 0.12.0 |
-| https://broadinstitute.github.io/terra-helm/ | pdb-lib | 0.4.0 |
+| https://terra-helm.storage.googleapis.com | ingresslib | 0.12.0 |
+| https://terra-helm.storage.googleapis.com | pdb-lib | 0.4.0 |
 | https://terra-helm.storage.googleapis.com/ | liquibase-migration | 1.1.0 |
 
 ## Values

--- a/charts/ontology/Chart.yaml
+++ b/charts/ontology/Chart.yaml
@@ -15,7 +15,7 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/rawls/Chart.yaml
+++ b/charts/rawls/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     repository: https://terra-helm.storage.googleapis.com
   - name: pdb-lib
     version: 0.4.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: sherlock-reporter
     condition: sherlock.enabled
     version: 0.3.0

--- a/charts/terra-ap-prometheus-operator/install.sh
+++ b/charts/terra-ap-prometheus-operator/install.sh
@@ -9,7 +9,7 @@ kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/re
 kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 
 # Ensures user has chart added to local helm repos 
-helm repo add terra-helm https://terra-helm.storage.googleapis.com
+helm repo add https://broadinstitute.github.io/terra-helm
 helm repo update
 
 helm install prometheus-stackdriver terra-helm/terra-ap-prometheus-operator -n monitoring --version=0.0.1 -f monitoring-configs.yaml --debug

--- a/charts/terra-ap-prometheus-operator/install.sh
+++ b/charts/terra-ap-prometheus-operator/install.sh
@@ -9,7 +9,7 @@ kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/re
 kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 
 # Ensures user has chart added to local helm repos 
-helm repo add https://broadinstitute.github.io/terra-helm
+helm repo add terra-helm https://terra-helm.storage.googleapis.com
 helm repo update
 
 helm install prometheus-stackdriver terra-helm/terra-ap-prometheus-operator -n monitoring --version=0.0.1 -f monitoring-configs.yaml --debug

--- a/charts/terra-argocd-app/README.md
+++ b/charts/terra-argocd-app/README.md
@@ -10,7 +10,7 @@ Current chart version is `0.1.2`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm | terra-argocd-templates | 0.0.4 |
+| https://terra-helm.storage.googleapis.com | terra-argocd-templates | 0.0.4 |
 
 ## Chart Values
 

--- a/charts/thurloe/Chart.yaml
+++ b/charts/thurloe/Chart.yaml
@@ -14,7 +14,7 @@ sources:
 dependencies:
   - name: pdb-lib
     version: 0.1.0
-    repository: https://broadinstitute.github.io/terra-helm/
+    repository: https://terra-helm.storage.googleapis.com
   - name: liquibase-migration
     version: 1.1.0
     repository: https://terra-helm.storage.googleapis.com

--- a/charts/thurloe/README.md
+++ b/charts/thurloe/README.md
@@ -6,7 +6,7 @@ Chart for Thurloe service in Terra
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://broadinstitute.github.io/terra-helm/ | pdb-lib | 0.1.0 |
+| https://terra-helm.storage.googleapis.com | pdb-lib | 0.1.0 |
 | https://terra-helm.storage.googleapis.com | liquibase-migration | 1.1.0 |
 
 ## Values


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
A big mass rename, except for terra-ap-prometheus-operator because the chart doesn't build properly.

I did some poking and that chart references a dependency so old it was deleted. The chart itself doesn't actually change in the renaming, just the helper install.sh that references adding the helm repo