### PR TITLE
DUOS-1457: Add sendGridStatusUrl to chart configs

### DIFF
--- a/charts/consent/Chart.yaml
+++ b/charts/consent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consent
-version: 0.31.0
+version: 0.31.1
 type: application
 description: A Helm chart for DUOS Consent
 keywords:

--- a/charts/consent/Chart.yaml
+++ b/charts/consent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: consent
-version: 0.31.1
+version: 0.31.0
 type: application
 description: A Helm chart for DUOS Consent
 keywords:

--- a/charts/consent/README.md
+++ b/charts/consent/README.md
@@ -85,6 +85,7 @@ A Helm chart for DUOS Consent
 | replicas | int | `3` |  |
 | sendgridApiKey | string | `nil` |  |
 | sendgridApiKeyKey | string | `nil` |  |
+| sendGridStatusUrl | string | `nil` |  |
 | sentryDsnKey | string | `nil` |  |
 | sentryDsnPath | string | `nil` |  |
 | servicesLocalUrl | string | `nil` |  |

--- a/charts/consent/templates/_consent.yaml.tpl
+++ b/charts/consent/templates/_consent.yaml.tpl
@@ -62,6 +62,7 @@ mailConfiguration:
   activateEmailNotifications: {{ .Values.emailNotificationsEnabled }}
   googleAccount: duos@broadinstitute.org
   sendGridApiKey: foo {{/* Override on the command line */}}
+  sendGridStatusUrl: {{ .Values.sendGridStatusUrl }}
 freeMarkerConfiguration:
   templateDirectory: /freemarker
   defaultEncoding: UTF-8

--- a/charts/consent/values.yaml
+++ b/charts/consent/values.yaml
@@ -125,6 +125,7 @@ proxyImageVersion:
 replicas: 3
 
 sendgridApiKey:
+sendGridStatusUrl:
 
 sentryDsnPath:
 sentryDsnKey:


### PR DESCRIPTION
## Addresses
Partially addresses: https://broadworkbench.atlassian.net/browse/DUOS-1457
Adds a configuration value for sendgrid's status json

~Depends on: https://github.com/broadinstitute/terra-helmfile/pull/1904~
Tested against https://github.com/broadinstitute/terra-helmfile/pull/1910 and it is working as expected.

<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
