### PR TITLE
[CA-1373] Bump sam cloudsqlproxy version

### DIFF
--- a/charts/sam/templates/deployment.yaml
+++ b/charts/sam/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Values.name }}-sqlproxy
-        image: broadinstitute/cloudsqlproxy:1.11_2018117
+        image: broadinstitute/cloudsqlproxy:1.11_20180808
         lifecycle:
           postStart:
             exec:


### PR DESCRIPTION
Ticket: [CA-1373](https://broadworkbench.atlassian.net/browse/CA-1373)
This is the version of `broadinstitute/cloudsqlproxy` that we used on GCE (see [Sam's old docker-compose](https://github.com/broadinstitute/firecloud-develop/blob/ee9ab75d42ffe8405318597f74115093cb8e6e3f/run-context/live/configs/sam/docker-compose.yaml.ctmpl#L39)). Since switching to k8s, Sam has been dropping most of its connections during cloudsql maintenance and not opening new connections once the maintenance is complete. It is unclear whether changing the version of this image will solve the connectivity issue, but it's worth trying.


<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
