### PR TITLE
DDO-1762 Hook sherlock into prometheus/grafana

### DIFF
--- a/charts/sherlock/README.md
+++ b/charts/sherlock/README.md
@@ -1,6 +1,6 @@
 # sherlock
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Sherlock - DSP's environment tracking and management service
 
@@ -37,6 +37,7 @@ Chart for Sherlock - DSP's environment tracking and management service
 | probes.liveness.spec | object | `nil` | Spec for the liveness probe |
 | probes.readiness.enabled | bool | `false` | (boolean) If the readiness probe should be enabled |
 | probes.readiness.spec | object | `nil` | Spec for the readiness probe |
+| prometheus.scrape.enabled | bool | `true` | (bool) Whether to create a ServiceMonitor to enable prometheus scraping of metrics |
 | replicas | int | `1` | (number) Number of sherlock pods to run |
 | resources.limits.cpu | string | `"500m"` | (string) Number of CPU units to limit the deployment to |
 | resources.limits.memory | string | `"4Gi"` | (string) Memory to limit the deployment to |

--- a/charts/sherlock/templates/serviceMonitor.yaml
+++ b/charts/sherlock/templates/serviceMonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheus.scrape.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sherlock-service-monitor
+  labels: 
+    {{ include "sherlock.labels" . | nindent 4 }}
+    release: terra-prometheus
+spec:
+  jobLabel: {{ .Values.name }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: sherlock
+  endpoints:
+    - port: http
+{{- end }}
+  

--- a/charts/sherlock/templates/serviceMonitor.yaml
+++ b/charts/sherlock/templates/serviceMonitor.yaml
@@ -19,4 +19,3 @@ spec:
       scheme: http
       scrapeTimeout: 30s
 {{- end }}
-  

--- a/charts/sherlock/templates/serviceMonitor.yaml
+++ b/charts/sherlock/templates/serviceMonitor.yaml
@@ -13,5 +13,10 @@ spec:
       app.kubernetes.io/component: sherlock
   endpoints:
     - port: http
+      interval: 2m
+      honorLabels: true
+      path: /metrics
+      scheme: http
+      scrapeTimeout: 30s
 {{- end }}
   

--- a/charts/sherlock/values.yaml
+++ b/charts/sherlock/values.yaml
@@ -107,4 +107,5 @@ secrets:
 
 prometheus:
   scrape:
+    # -- (bool) Whether to create a ServiceMonitor to enable prometheus scraping of metrics
     enabled: true

--- a/charts/sherlock/values.yaml
+++ b/charts/sherlock/values.yaml
@@ -105,6 +105,6 @@ secrets:
       # -- (string) ID of GCP project containing WI SA.
       projectID: ""
 
-promethues:
+prometheus:
   scrape:
     enabled: true

--- a/charts/sherlock/values.yaml
+++ b/charts/sherlock/values.yaml
@@ -104,3 +104,7 @@ secrets:
       accountName: ""
       # -- (string) ID of GCP project containing WI SA.
       projectID: ""
+
+promethues:
+  scrape:
+    enabled: true


### PR DESCRIPTION
This PR adds a `ServiceMonitor` CRD so that sherlock's `/metrics` endpoint can be scraped by prometheus.
