### PR TITLE
[IA-2938] Add Azure secrets to crljanitor chart

### DIFF
--- a/charts/crljanitor/README.md
+++ b/charts/crljanitor/README.md
@@ -1,6 +1,6 @@
 # crljanitor
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Cloud Resource Manager Janitor
 
@@ -52,6 +52,7 @@ Chart for Cloud Resource Manager Janitor
 | startupSleep | int | `30` | Allows CloudSQL proxy time to start up. See DDO-1352 |
 | trackResourcePubsubEnabled | bool | `true` | Whether to enable using pubsub to receive new tracked resources. |
 | vault.adminUserFilePath | string | `"config/terra/crl-janitor/common/iam"` | (string) Vault path prefix for admin user list. Required if vault.enabled. Use the same users as admin for all env by default. Override if needed in helmfile repo. |
+| vault.azureManagedAppPublisherPath | string | `"secret/dsde/azure/common/managed-app-publisher"` | (string) Vault path for Azure managed app publisher credentials. Uses the same path for all envs by default. Override if needed in helmfile repo. |
 | vault.configPathPrefix | string | `nil` | Vault path prefix for configs. Required if vault.enabled. |
 | vault.enabled | bool | `true` | When enabled, syncs required secrets from Vault |
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |

--- a/charts/crljanitor/templates/deployment.yaml
+++ b/charts/crljanitor/templates/deployment.yaml
@@ -112,6 +112,21 @@ spec:
             secretKeyRef:
               name: crl-janitor-admin-user-list
               key: admin-users
+        - name: AZURE_MANAGED_APP_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-azure-managed-app-creds
+              key: client-id
+        - name: AZURE_MANAGED_APP_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-azure-managed-app-creds
+              key: client-secret
+        - name: AZURE_MANAGED_APP_TENANT_ID
+          valueFrom:
+            secretKeyRef:
+              name: crl-janitor-azure-managed-app-creds
+              key: tenant-id
         # Environment variables for OpenCensus resource auto detection.
         - name: CONTAINER_NAME
           valueFrom:

--- a/charts/crljanitor/templates/secrets.yaml
+++ b/charts/crljanitor/templates/secrets.yaml
@@ -112,4 +112,23 @@ spec:
     admin-users:
       path: {{ .Values.vault.adminUserFilePath }}
       key: admin-users
+---
+apiVersion: secrets-manager.tuenti.io/v1alpha1
+kind: SecretDefinition
+metadata:
+  name: secretdefinition-crl-janitor-azure-managed-app-creds
+  labels:
+    {{ template "crljanitor.labels" . }}
+spec:
+  name: crl-janitor-azure-managed-app-creds
+  keysMap:
+    client-id:
+      path: {{ .Values.vault.pathPrefix }}/crl_janitor/azure-managed-app-client
+      key: client-id
+    client-secret:
+      path: {{ .Values.vault.pathPrefix }}/crl_janitor/azure-managed-app-client
+      key: client-secret
+    tenant-id:
+      path: {{ .Values.vault.pathPrefix }}/crl_janitor/azure-managed-app-client
+      key: tenant-id
 {{ end }}

--- a/charts/crljanitor/templates/secrets.yaml
+++ b/charts/crljanitor/templates/secrets.yaml
@@ -123,12 +123,12 @@ spec:
   name: crl-janitor-azure-managed-app-creds
   keysMap:
     client-id:
-      path: {{ .Values.vault.pathPrefix }}/crl_janitor/azure-managed-app-client
+      path: {{ .Values.vault.azureManagedAppPublisherPath }}
       key: client-id
     client-secret:
-      path: {{ .Values.vault.pathPrefix }}/crl_janitor/azure-managed-app-client
+      path: {{ .Values.vault.azureManagedAppPublisherPath }}
       key: client-secret
     tenant-id:
-      path: {{ .Values.vault.pathPrefix }}/crl_janitor/azure-managed-app-client
+      path: {{ .Values.vault.azureManagedAppPublisherPath }}
       key: tenant-id
 {{ end }}

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -39,7 +39,7 @@ vault:
   adminUserFilePath: config/terra/crl-janitor/common/iam
   # vault.azureManagedAppPublisherPath -- (string) Vault path for Azure managed app publisher credentials.
   # Uses the same path for all envs by default. Override if needed in helmfile repo.
-  azureManagedAppPublisherPath: secret/dsde/azure/common/managed-app-publisher
+  azureManagedAppPublisherPath: secret/dsde/terra/azure/common/managed-app-publisher
 
 # serviceIP -- (string) External IP of the service. Required.
 serviceIP:

--- a/charts/crljanitor/values.yaml
+++ b/charts/crljanitor/values.yaml
@@ -37,6 +37,9 @@ vault:
   # vault.adminUserFilePath -- (string) Vault path prefix for admin user list. Required if vault.enabled.
   # Use the same users as admin for all env by default. Override if needed in helmfile repo.
   adminUserFilePath: config/terra/crl-janitor/common/iam
+  # vault.azureManagedAppPublisherPath -- (string) Vault path for Azure managed app publisher credentials.
+  # Uses the same path for all envs by default. Override if needed in helmfile repo.
+  azureManagedAppPublisherPath: secret/dsde/azure/common/managed-app-publisher
 
 # serviceIP -- (string) External IP of the service. Required.
 serviceIP:


### PR DESCRIPTION
This updates the Janitor chart to read a new vault secret `secret/dsde/terra/azure/common/managed-app-publisher` and set it in the environment.

The secret path is set statically in `values` for now, but I expect it will need to be passed via `terra-helmfile` once we can Terraform different Azure environments (see https://broadworkbench.atlassian.net/browse/DDO-1772).

See related Janitor PR: https://github.com/DataBiosphere/terra-resource-janitor/pull/120
