### PR TITLE
[DDO-1579] Out with .Values.name, in with .Values.global.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ brew install norwoodj/tap/helm-docs
 cd charts/[changed chart]
 helm-docs
 ```
+
+## Standards
+
+We have a lot of patterns for charts that we tend to follow, but the standards here are meant to be universal.
+
+This list may grow over time; for a standard to be added here it must already be universal (in other words, this section is a reference for "what is," not a recommendation for "what should be").
+
+1. Storing a name in `.Values.name` is disallowed. Instead, use `.Values.global.name` so names are available from subcharts. See [DDO-1579](https://broadworkbench.atlassian.net/browse/DDO-1579).

--- a/charts/azurepoc/README.md
+++ b/charts/azurepoc/README.md
@@ -16,6 +16,7 @@ Chart for azurepoc service in Terra
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.applicationVersion | string | `"latest"` |  |
+| global.name | string | `"azurepoc"` | name of the application to template into k8s resources |
 | imagePullSecret | string | `nil` | name of k8s secret containing credentials to authenticate to a private image repo |
 | imageRepository | string | `"gcr.io/terra-kernel-k8s/azurepoc"` | url for repo hosting the image deployed in this chart |
 | imageTag | string | `nil` |  |
@@ -23,7 +24,6 @@ Chart for azurepoc service in Terra
 | ingress.hostName | string | `"azurepoc.mflinn.azure.dev.envs-terra.bio"` | hostname for this application. Used for host based routing in the ingress |
 | ingress.tlsIssuer | string | `"letsencrypt-prod-issuer"` | when multiple CAs are configured for a cluster can be used to select a specfic one |
 | ingress.tlsSecretName | string | `"tls-secret"` | name of the k8s secret the tls cert will be stored in |
-| name | string | `"azurepoc"` | name of the application to template into k8s resources |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/status"` |  |

--- a/charts/azurepoc/templates/deployment.yaml
+++ b/charts/azurepoc/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
 {{ include "azurepoc.labels" . | indent 4 }}
 spec:
@@ -23,19 +23,19 @@ spec:
     # This is how the k8s deployment resource determines which pods it manages and monitors
     # any pods with the label below will be managed by this deployment
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment # corresponding label on the pod from the selector section above
+        deployment: {{ .Values.global.name }}-deployment # corresponding label on the pod from the selector section above
 {{ include "azurepoc.labels" . | indent 8 }}
     spec:
       # defined in rbac.yaml
       # This is a k8s service account which is not the same as a GCP service account. 
       # It determines which k8s api resources/methods the pod has access to.
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       containers:
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.imageRepository }}:{{ .Values.imageTag | default .Values.global.applicationVersion }}"
         ports:
         - name: app

--- a/charts/azurepoc/templates/ingress.yaml
+++ b/charts/azurepoc/templates/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name}}-ingress
+  name: {{ .Values.global.name}}-ingress
   labels: {{ include "azurepoc.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
@@ -31,7 +31,7 @@ spec:
       # the target service here, defined in service.yaml
       - path: /*
         backend:
-          serviceName: {{ .Values.name }}-service
+          serviceName: {{ .Values.global.name }}-service
           servicePort: 80
       
     

--- a/charts/azurepoc/templates/service.yaml
+++ b/charts/azurepoc/templates/service.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
 {{ include "azurepoc.labels" . | indent 4 }}
 spec:
@@ -16,7 +16,7 @@ spec:
   # same concecpt as the selector block in deployment.yaml
   # determines which pods should serve requests received by this service
   selector:
-    deployment: {{ .Values.name }}-deployment
+    deployment: {{ .Values.global.name }}-deployment
   ports:
   - name: app
     protocol: TCP

--- a/charts/azurepoc/values.yaml
+++ b/charts/azurepoc/values.yaml
@@ -1,5 +1,8 @@
-# name -- name of the application to template into k8s resources
-name: azurepoc
+global:
+  applicationVersion: latest
+  # global.name -- name of the application to template into k8s resources
+  name: azurepoc
+
 # replicas -- number of app replicas to run
 replicas: 3
 
@@ -9,9 +12,6 @@ imageRepository: gcr.io/terra-kernel-k8s/azurepoc
 imageTag: null
 # imagePullSecret -- name of k8s secret containing credentials to authenticate to a private image repo
 imagePullSecret: null
-
-global:
-  applicationVersion: latest
 
 ingress:
   # ingress.enabled -- (bool) whether to provision an ingress and expose this application to traffic from outside the cluster

--- a/charts/buffer/README.md
+++ b/charts/buffer/README.md
@@ -1,6 +1,6 @@
 # buffer
 
-![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Resource Buffering Service
 
@@ -25,6 +25,7 @@ Chart for Resource Buffering Service
 | buffer.pool.configPath | string | `nil` | The configuration files pools and resources. Currently all pool configs are inside Java binary under resources/ so the value is a relative path from resource/, for example: config/dev |
 | cleanupAfterHandout | bool | `false` | Whether to publish message to Janitor after resource is handed out. |
 | global.applicationVersion | string | `"latest"` | What version of the application to deploy |
+| global.name | string | `"buffer"` | A name for the deployment that will be substituted into resource definitions |
 | global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
 | image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
@@ -79,8 +80,6 @@ Chart for Resource Buffering Service
 | liquibase-migration.migrationJobs[1].migrationArgsConfigChangelog | string | `"stairway/db/changelog.xml"` |  |
 | liquibase-migration.migrationJobs[1].migrationDatabaseCredentials.fromKubernetesSecret.name | string | `"buffer-stairway-db-creds"` |  |
 | liquibase-migration.migrationJobs[1].name | string | `"buffer-stairway"` |  |
-| liquibase-migration.name | string | `"buffer"` |  |
-| name | string | `"buffer"` | A name for the deployment that will be substituted into resuorce definitions |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/status"` |  |

--- a/charts/buffer/templates/_helpers.tpl
+++ b/charts/buffer/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Common labels
 {{- define "buffer.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: buffer
 app.kubernetes.io/part-of: terra
@@ -15,7 +15,7 @@ Selector labels
 */}}
 {{- define "buffer.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 {{- end }}
 
 {{/*

--- a/charts/buffer/templates/configmaps/proxy-apache-httpd-configmap.yaml
+++ b/charts/buffer/templates/configmaps/proxy-apache-httpd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-proxy-configmap
+  name: {{ .Values.global.name }}-proxy-configmap
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 data:

--- a/charts/buffer/templates/configmaps/proxy-tcell-configmap.yaml
+++ b/charts/buffer/templates/configmaps/proxy-tcell-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-tcell-configmap
+  name: {{ .Values.global.name }}-tcell-configmap
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 data:

--- a/charts/buffer/templates/deployment.yaml
+++ b/charts/buffer/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
   {{- if and .Values.proxy.enabled .Values.proxy.reloadOnCertUpdate }}
@@ -22,43 +22,43 @@ spec:
       {{- include "buffer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      name: {{ .Values.name }}-service
+      name: {{ .Values.global.name }}-service
       labels:
         {{- include "buffer.labels" . | nindent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map changes: */}}
-        checksum/{{ .Values.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") . | sha256sum }}
-        checksum/{{ .Values.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-tcell-configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-tcell-configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Values.name }}-service-sa
+      serviceAccountName: {{ .Values.global.name }}-service-sa
       volumes:
       - name: cloudsql-sa-creds
         secret:
-          secretName: {{ .Values.name }}-cloudsql-sa
+          secretName: {{ .Values.global.name }}-cloudsql-sa
       - name: app-sa-creds
         secret:
-          secretName: {{ .Values.name }}-app-sa
+          secretName: {{ .Values.global.name }}-app-sa
       {{- if .Values.proxy.enabled }}
       - name: apache-httpd-proxy-config
         configMap:
-          name: {{ .Values.name }}-proxy-configmap
+          name: {{ .Values.global.name }}-proxy-configmap
           items:
           - key: apache-httpd-proxy-config
-            path: {{ .Values.name }}-proxy.conf
+            path: {{ .Values.global.name }}-proxy.conf
       - name: cert
         secret:
           secretName: {{ .Chart.Name }}-cert
       {{- if .Values.proxy.tcell.enabled }}
       - name: tcell-config
         configMap:
-          name: {{ .Values.name }}-tcell-configmap
+          name: {{ .Values.global.name }}-tcell-configmap
           items:
           - key: tcell-config
             path: tcell-config.conf
       {{- end }}
       {{- end }}
       containers:
-      - name: {{ .Values.name }}-cloudsql-proxy
+      - name: {{ .Values.global.name }}-cloudsql-proxy
         image: gcr.io/cloudsql-docker/gce-proxy:1.24.0-buster
         lifecycle:
           postStart:
@@ -68,17 +68,17 @@ spec:
         - name: SQL_INSTANCE_PROJECT
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: project
         - name: SQL_INSTANCE_REGION
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: region
         - name: SQL_INSTANCE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: name
         command: ["/cloud_sql_proxy",
                   "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
@@ -90,7 +90,7 @@ spec:
         - name: cloudsql-sa-creds
           mountPath: /secrets/cloudsql
           readOnly: true
-      - name: {{ .Values.name }}
+      - name: {{ .Values.global.name }}
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
@@ -107,34 +107,34 @@ spec:
         - name: BUFFER_DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: username
         - name: BUFFER_DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: password
         - name: BUFFER_DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: db
         - name: BUFFER_POOL_CONFIG_PATH
           value: {{ .Values.buffer.pool.configPath }}
         - name: BUFFER_STAIRWAY_DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-stairway-db-creds
+              name: {{ .Values.global.name }}-stairway-db-creds
               key: username
         - name: BUFFER_STAIRWAY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-stairway-db-creds
+              name: {{ .Values.global.name }}-stairway-db-creds
               key: password
         - name: BUFFER_STAIRWAY_DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-stairway-db-creds
+              name: {{ .Values.global.name }}-stairway-db-creds
               key: db
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/app/service-account.json
@@ -148,12 +148,12 @@ spec:
         - name: BUFFER_CRL_JANITOR_TRACK_RESOURCE_PROJECT_ID
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-crl-janitor-track-resource-pubsub
+              name: {{ .Values.global.name }}-crl-janitor-track-resource-pubsub
               key: project
         - name: BUFFER_CRL_JANITOR_TRACK_RESOURCE_TOPIC_ID
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-crl-janitor-track-resource-pubsub
+              name: {{ .Values.global.name }}-crl-janitor-track-resource-pubsub
               key: topic
         {{- end }}
         # Environment variables for OpenCensus resource auto detection.
@@ -171,7 +171,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: TERRA_COMMON_KUBERNETES_POD_NAME_FILTER
-          value: {{ .Values.name }}-deployment
+          value: {{ .Values.global.name }}-deployment
         - name: TERRA_COMMON_KUBERNETES_IN_KUBERNETES
           value: 'true'
         volumeMounts:
@@ -179,7 +179,7 @@ spec:
           mountPath: /secrets/app
           readOnly: true
       {{- if .Values.proxy.enabled }}
-      - name: {{ .Values.name }}-oidc-proxy
+      - name: {{ .Values.global.name }}-oidc-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.version }}"
         ports:
         - containerPort: 443
@@ -191,12 +191,12 @@ spec:
         - name: TCELL_AGENT_APP_ID
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-tcell-secrets
+              name: {{ .Values.global.name }}-proxy-tcell-secrets
               key: app-id
         - name: TCELL_AGENT_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-tcell-secrets
+              name: {{ .Values.global.name }}-proxy-tcell-secrets
               key: api-key
         - name: ENABLE_TCELL
           value: 'yes'
@@ -204,7 +204,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/apache2/sites-available/site.conf
           name: apache-httpd-proxy-config
-          subPath: {{ .Values.name }}-proxy.conf
+          subPath: {{ .Values.global.name }}-proxy.conf
         - mountPath: /etc/ssl/certs/server.crt
           subPath: tls.crt
           name: cert

--- a/charts/buffer/templates/ingress/cert.yaml
+++ b/charts/buffer/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  secretName: {{ .Values.name }}-cert
+  secretName: {{ .Values.global.name }}-cert
   renewBefore: {{ .Values.ingress.cert.certManager.renewBefore }}
   dnsNames:
   - {{ template "buffer.fqdn" . }}
@@ -17,11 +17,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/buffer/templates/role.yaml
+++ b/charts/buffer/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/buffer/templates/rolebinding.yaml
+++ b/charts/buffer/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-service-role-binding
+  name: {{ .Values.global.name }}-service-role-binding
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
@@ -9,9 +9,9 @@ metadata:
     {{- include "buffer.labels" . | nindent 4 }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa

--- a/charts/buffer/templates/secrets.yaml
+++ b/charts/buffer/templates/secrets.yaml
@@ -2,14 +2,14 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   keysMap:
     db:
       path: {{ .Values.vault.pathPrefix }}/buffer/postgres/db-creds
@@ -24,14 +24,14 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-stairway-db-creds
+  name: {{ .Values.global.name }}-stairway-db-creds
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-stairway-db-creds
+  name: {{ .Values.global.name }}-stairway-db-creds
   keysMap:
     db:
       path: {{ .Values.vault.pathPrefix }}/buffer/postgres/stairway-db-creds
@@ -46,14 +46,14 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-instance
+  name: {{ .Values.global.name }}-postgres-instance
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-cloudsql-postgres-instance
+  name: {{ .Values.global.name }}-cloudsql-postgres-instance
   keysMap:
     project:
       path: {{ .Values.vault.pathPrefix }}/buffer/postgres/instance
@@ -68,14 +68,14 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-cloudsql-sa
+  name: {{ .Values.global.name }}-cloudsql-sa
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-cloudsql-sa
+  name: {{ .Values.global.name }}-cloudsql-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/buffer/sqlproxy-sa
@@ -85,11 +85,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-app-sa
+  name: {{ .Values.global.name }}-app-sa
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-app-sa
+  name: {{ .Values.global.name }}-app-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/buffer/app-sa
@@ -107,11 +107,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-crl-janitor-track-resource-pubsub
+  name: {{ .Values.global.name }}-crl-janitor-track-resource-pubsub
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-crl-janitor-track-resource-pubsub
+  name: {{ .Values.global.name }}-crl-janitor-track-resource-pubsub
   keysMap:
     project:
       path: {{ .Values.vault.janitorPubSubConfigPath }}/pubsub
@@ -125,11 +125,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-tcell-secrets
+  name: {{ .Values.global.name }}-proxy-tcell-secrets
   labels:
     {{- include "buffer.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-tcell-secrets
+  name: {{ .Values.global.name }}-proxy-tcell-secrets
   keysMap:
     app-id:
       path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_app_id

--- a/charts/buffer/templates/service-account.yaml
+++ b/charts/buffer/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/buffer/values.yaml
+++ b/charts/buffer/values.yaml
@@ -5,9 +5,8 @@ global:
   # global.terraEnv -- (string) Terget Terra environment name. Required.
   # @default -- Is set by Helmfile on deploy
   terraEnv: null
-
-# name -- A name for the deployment that will be substituted into resuorce definitions
-name: buffer
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: buffer
 
 # image -- (string) Used for local Skaffold deploys
 # @default -- Is set by Skaffold on local deploys
@@ -208,11 +207,6 @@ liquibase-migration:
     migrationDatabaseCredentials:
       fromKubernetesSecret:
         name: "buffer-stairway-db-creds"
-
-
-  # Template definition buffer.labels attempts to read .Values.name from within liquibase-migration.
-  # Either we must pass the name again, move it to globals, or disable liquibase-migration labels.
-  name: "buffer"
 
   defaults:
     enabled: false

--- a/charts/config-connector/README.md
+++ b/charts/config-connector/README.md
@@ -1,6 +1,6 @@
 # config-connector
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart to add the Google Config Connector configuration file
 

--- a/charts/consent/README.md
+++ b/charts/consent/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for DUOS Consent
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Values
 

--- a/charts/crljanitor/README.md
+++ b/charts/crljanitor/README.md
@@ -1,6 +1,6 @@
 # crljanitor
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Cloud Resource Manager Janitor
 

--- a/charts/diskmanager/README.md
+++ b/charts/diskmanager/README.md
@@ -1,6 +1,6 @@
 # diskmanager
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A helm chart to deploy a cronjob to manage backups of stateful set persistent disks
 
@@ -23,10 +23,10 @@ A helm chart to deploy a cronjob to manage backups of stateful set persistent di
 | config.region | string | `"us-central1"` | gcp region of cluster |
 | config.targetAnnotation | string | `"bio.terra/snapshot-policy"` | The annotation that must be present on pvcs in order to attach snapshot policy to the associated disk |
 | config.zone | string | `"us-central1-a"` | zone of cluster |
+| global.name | string | `"diskmanager"` | A name for the deployment that will be substituted into resource definitions |
 | imageConfig.pullPolicy | string | `"Always"` | determines if the image is pulled on pod startup or not |
 | imageConfig.repository | string | `"us-central1-docker.pkg.dev/dsp-artifact-registry/disk-manager/disk-manager"` | docker image repository hosting diskmanager images |
 | imageConfig.tag | string | `"main"` | image tag version of diskmanager to deploy |
-| name | string | `"diskmanager"` | A name for the deployment that will be substituted into resuorce definitions |
 | nodeSelector | object | `{}` | selector for node pool to run diskmanager cronjob on |
 | schedule | string | `"0 1 * * *"` | cron format schedule for the diskmanager cronjob, default is everyday at 01:00 |
 | tolerations | object | `{}` | tolerations to enable runnning on particular nodes |

--- a/charts/diskmanager/templates/config/configMap.yaml
+++ b/charts/diskmanager/templates/config/configMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-cm
+  name: {{ .Values.global.name }}-cm
   labels:
     {{- include "diskmanager.labels" . | nindent 4 }}
 data:

--- a/charts/diskmanager/templates/cronjob.yaml
+++ b/charts/diskmanager/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Values.name }}-cronjob
+  name: {{ .Values.global.name }}-cronjob
   labels:
     {{- include "diskmanager.labels" . | nindent 4 }}
 spec:
@@ -18,26 +18,26 @@ spec:
           restartPolicy: Never
           nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 12 }}
           tolerations: {{ .Values.tolerations | toYaml | nindent 12}}
-          serviceAccountName: {{ .Values.name }}-sa
+          serviceAccountName: {{ .Values.global.name }}-sa
           containers:
           - image: "{{ .Values.imageConfig.repository }}:{{ .Values.imageConfig.tag }}"
             imagePullPolicy: {{ .Values.imageConfig.pullPolicy }}
-            name: {{ .Values.name }}
+            name: {{ .Values.global.name }}
             env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /app/application_default_credentials.json
             volumeMounts:
             - mountPath: /etc/disk-manager/config.yaml
               subPath: config.yaml
-              name: {{ .Values.name }}-config
+              name: {{ .Values.global.name }}-config
               readOnly: true
             - mountPath: /app
-              name: {{ .Values.name }}-gcp-sa
+              name: {{ .Values.global.name }}-gcp-sa
               readOnly: true
           volumes:
-          - name: {{ .Values.name }}-config
+          - name: {{ .Values.global.name }}-config
             configMap:
-              name: {{ .Values.name }}-cm
-          - name: {{ .Values.name }}-gcp-sa
+              name: {{ .Values.global.name }}-cm
+          - name: {{ .Values.global.name }}-gcp-sa
             secret:
-              secretName: {{ .Values.name }}-gcp-sa
+              secretName: {{ .Values.global.name }}-gcp-sa

--- a/charts/diskmanager/templates/role.yaml
+++ b/charts/diskmanager/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   labels:
     {{- include "diskmanager.labels" . | nindent 4 }}
 rules:

--- a/charts/diskmanager/templates/roleBinding.yaml
+++ b/charts/diskmanager/templates/roleBinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   labels:
     {{- include "diskmanager.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/diskmanager/templates/secrets.yaml
+++ b/charts/diskmanager/templates/secrets.yaml
@@ -1,11 +1,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-gcp-sa-secretdefinition
+  name: {{ .Values.global.name }}-gcp-sa-secretdefinition
   labels:
     {{- include "diskmanager.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-gcp-sa
+  name: {{ .Values.global.name }}-gcp-sa
   keysMap:
     application_default_credentials.json:
       path: {{ required "A valid .Values.vault.pathPrefix value is required" .Values.vault.pathPrefix }}/diskmanager/terraform/diskmanager-sa

--- a/charts/diskmanager/templates/serviceAccount.yaml
+++ b/charts/diskmanager/templates/serviceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   labels:
     {{- include "diskmanager.labels" . | nindent 4 }}

--- a/charts/diskmanager/values.yaml
+++ b/charts/diskmanager/values.yaml
@@ -1,5 +1,6 @@
-# name -- A name for the deployment that will be substituted into resuorce definitions
-name: diskmanager
+global:
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: diskmanager
 
 config:
   # config.targetAnnotation -- The annotation that must be present on pvcs in order to attach snapshot policy to the associated disk

--- a/charts/dsp-argocd/README.md
+++ b/charts/dsp-argocd/README.md
@@ -1,6 +1,6 @@
 # dsp-argocd
 
-![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm Chart with extra resources for the DSP ArgoCD instance
 
@@ -143,7 +143,7 @@ These steps will be migrated to a declarative configuration at some point, but f
 | apps.ghaRunner.controller.chart | string | `"dsp-gha-runner-controller"` |  |
 | apps.ghaRunner.controller.version | string | `"0.2.0"` |  |
 | apps.ghaRunner.instances.chart | string | `"dsp-gha-runner-instances"` |  |
-| apps.ghaRunner.instances.version | string | `"0.5.0"` |  |
+| apps.ghaRunner.instances.version | string | `"0.7.0"` |  |
 | apps.ghaRunner.namespace | string | `"gha-runner"` |  |
 | apps.ghaRunner.notificationChannel | string | `"ap-k8s-monitor"` |  |
 | argo-cd.controller.extraArgs[0] | string | `"--repo-server-timeout-seconds=180"` |  |

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/README.md
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/README.md
@@ -24,7 +24,7 @@ Helm chart for deploying the DSP ArgoCD notifications instance
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| name | string | `"dsp-argocd-notifications"` |  |
+| global.name | string | `"dsp-argocd-notifications"` | A name for the deployment that will be substituted into resource definitions |
 | upstream.argocdUrl | string | `"https://ap-argocd.dsp-devops.broadinstitute.org/"` |  |
 | upstream.nameOverride | string | `"argocd-notifications"` |  |
 | upstream.secret.create | bool | `false` |  |

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/psp.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Values.name }}-psp
+  name: {{ .Values.global.name }}-psp
   labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
 spec:
   privileged: false

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/role.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/role.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-pod-runner
+  name: {{ .Values.global.name }}-pod-runner
   labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-  - {{ .Values.name }}-psp
+  - {{ .Values.global.name }}-psp

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/roleBinding.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/roleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-rolebinding
+  name: {{ .Values.global.name }}-rolebinding
   labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
@@ -9,5 +9,5 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-pod-runner
+  name: {{ .Values.global.name }}-pod-runner
   apiGroup: rbac.authorization.k8s.io

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/secrets.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-secretdef
+  name: {{ .Values.global.name }}-secretdef
   labels: {{- include "dsp-argocd-notifications.labels" . | nindent 4 }}
 spec:
   name: {{ required ".Values.upstream.nameOverride is required" .Values.upstream.nameOverride }}-secret

--- a/charts/dsp-argocd/local-charts/dsp-argocd-notifications/values.yaml
+++ b/charts/dsp-argocd/local-charts/dsp-argocd-notifications/values.yaml
@@ -1,4 +1,6 @@
-name: dsp-argocd-notifications
+global:
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: dsp-argocd-notifications
 
 # Path in Vault where ArgoCD secrets live
 vault:

--- a/charts/dsp-atlantis/README.md
+++ b/charts/dsp-atlantis/README.md
@@ -1,6 +1,6 @@
 # dsp-atlantis
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for DSP Atlantis deployment
 
@@ -39,7 +39,7 @@ Chart for DSP Atlantis deployment
 | cleanup.enabled | bool | `false` | Whether to automatically clear provider cache |
 | cleanup.saName | string | `"atlantis-cleanup-sa"` |  |
 | cleanup.timeoutSeconds | int | `3600` | How many seconds to wait before assuming job is hung and killing it |
-| name | string | `"atlantis"` |  |
+| global.name | string | `"atlantis"` | A name for the deployment that will be substituted into resource definitions |
 | serviceAccount | string | `"atlantis"` |  |
 | vault.azure.pathPrefix | string | `"/path/to/azure/secrets"` |  |
 | vault.cleanup.key | string | `nil` | Key in Vault where base64-encoded GCP service account key for pod cleanup is stored |

--- a/charts/dsp-atlantis/templates/azureCredentials.yaml
+++ b/charts/dsp-atlantis/templates/azureCredentials.yaml
@@ -2,7 +2,7 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-azure-creds-secretdefinition
+  name: {{ .Values.global.name }}-azure-creds-secretdefinition
   labels:
     {{- include "dsp-atlantis.labels" . | nindent 4 }}
 spec:
@@ -16,7 +16,7 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-azure-env-secretdefinition
+  name: {{ .Values.global.name }}-azure-env-secretdefinition
   labels:
     {{- include "dsp-atlantis.labels" . | nindent 4 }}
 spec:

--- a/charts/dsp-atlantis/templates/githubCredentials.yaml
+++ b/charts/dsp-atlantis/templates/githubCredentials.yaml
@@ -6,7 +6,7 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   # name of object as seen in argoCD
-  name: {{ .Values.name }}-github-provider-secretdefinition
+  name: {{ .Values.global.name }}-github-provider-secretdefinition
   labels:
     {{- include "dsp-atlantis.labels" . | nindent 4 }}
 spec:

--- a/charts/dsp-atlantis/values.yaml
+++ b/charts/dsp-atlantis/values.yaml
@@ -1,4 +1,7 @@
-name: atlantis
+global:
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: atlantis
+
 serviceAccount: atlantis
 cert:
   secretName: atlantis-cert

--- a/charts/dsp-cert-manager/README.md
+++ b/charts/dsp-cert-manager/README.md
@@ -1,6 +1,6 @@
 # dsp-cert-manager
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Installs cert-manager, configures psps and creates Let's encrypt cluster issuers
 

--- a/charts/dsp-gha-runner-controller/README.md
+++ b/charts/dsp-gha-runner-controller/README.md
@@ -1,6 +1,6 @@
 # dsp-gha-runner-controller
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Controller for self-hosted GHA runner CRDs from dsp-gha-runner-instances
 

--- a/charts/dsp-gha-runner-instances/README.md
+++ b/charts/dsp-gha-runner-instances/README.md
@@ -1,6 +1,6 @@
 # dsp-gha-runner-instances
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Self-hosted GHA runner instances relying on dsp-gha-runner-controller
 

--- a/charts/dsp-grafana/README.md
+++ b/charts/dsp-grafana/README.md
@@ -1,6 +1,6 @@
 # dsp-grafana
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper providing GKE ingress, CloudSQL sidecar, and secrets around Grafana
 
@@ -31,7 +31,7 @@ To update the version of Grafana used by this chart, set `grafana.image.tag` in 
 | githubTeamSync.targetGrafanaOrgId | int | `1` | The numeric ID of the Grafana org to target |
 | githubTeamSync.teamGrantingGrafanaAdmin | string | `nil` | A specific team to also be granted admin, like `broadinstitute/dsp-devops. Can be set to empty to have none. |
 | githubTeamSync.timeoutSeconds | int | `900` | Timeout for the cronjob |
-| global.name | string | `"grafana"` |  |
+| global.name | string | `"grafana"` | A name for the deployment that will be substituted into resource definitions |
 | grafana | object | Baseline settings for subchart | Settings for Grafana subchart, use grafana.image.tag to override the subchart's default Grafana version |
 | grafana."grafana.ini".database | object | `{"host":"localhost:5432","ssl_mode":"disable","type":"postgres"}` | Leave most config to the env but do set fields relating to the CloudSQL requirements |
 | grafana.admin.existingSecret | string | `"grafana-admin-account"` | Derive the admin account credentials from a secret (created by secrets.AdminAccount) |

--- a/charts/dsp-grafana/values.yaml
+++ b/charts/dsp-grafana/values.yaml
@@ -1,4 +1,5 @@
 global:
+  # global.name -- A name for the deployment that will be substituted into resource definitions
   name: grafana
 
 ingress:

--- a/charts/duos/README.md
+++ b/charts/duos/README.md
@@ -1,6 +1,6 @@
 # duos
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for DUOS
 

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # elasticsearch
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 a helm chart to deploy monitoring infrastructure
 
@@ -72,7 +72,7 @@ a helm chart to deploy monitoring infrastructure
 | elasticsearch.volumeClaimTemplate.storageClassName | string | `"terra-ssd-zonal"` |  |
 | expose | bool | `false` | If true will create a loadbalancer service for each pod, enables using the transport client from outside the cluster |
 | exposeIPs | list | `[]` | List of ips to associate with each ES pod |
-| name | string | `"elasticsearch"` |  |
+| global.name | string | `"elasticsearch"` | A name for the deployment that will be substituted into resource definitions |
 | replicaCount | int | `3` | number of elasticsearch replicas to expose. |
 | vault.pathPrefix | string | `nil` | path where elasticsearch secrets are stored in vault |
 

--- a/charts/elasticsearch/templates/backup/cronjob.yaml
+++ b/charts/elasticsearch/templates/backup/cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Values.name }}-backup-cronjob
+  name: {{ .Values.global.name }}-backup-cronjob
   labels: {{ include "elasticsearch.labels" . | nindent 4 }}
 spec:
   schedule: "0 8 * * *" # Backup every day at 3 am EST
@@ -17,12 +17,12 @@ spec:
         metadata:
           labels: {{ include "elasticsearch.labels" . | nindent 12 }}
         spec:
-          serviceAccountName: {{ .Values.name }}-backup-sa
+          serviceAccountName: {{ .Values.global.name }}-backup-sa
           restartPolicy: OnFailure
           nodeSelector: {{ .Values.backup.nodeSelector | toYaml | nindent 12 }}
           tolerations: {{ .Values.backup.tolerations | toYaml | nindent 12 }}
           containers:
-          - name: {{ .Values.name }}-backup
+          - name: {{ .Values.global.name }}-backup
             image: {{ .Values.backup.imageRepo}}:{{ .Values.backup.imageTag }}
             command: ['sh', '-c']
             args:

--- a/charts/elasticsearch/templates/backup/role.yaml
+++ b/charts/elasticsearch/templates/backup/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-backup-role
+  name: {{ .Values.global.name }}-backup-role
   labels: {{ include "elasticsearch.labels" . | nindent 4 }}
 rules: 
 - apiGroups: ['policy']

--- a/charts/elasticsearch/templates/backup/roleBinding.yaml
+++ b/charts/elasticsearch/templates/backup/roleBinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-backup-sa-binding
+  name: {{ .Values.global.name }}-backup-sa-binding
   labels: {{ include "elasticsearch.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-backup-sa
+  name: {{ .Values.global.name }}-backup-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-backup-role
+  name: {{ .Values.global.name }}-backup-role
   apiGroup: rbac.authorization.k8s.io
 {{ end -}}

--- a/charts/elasticsearch/templates/backup/serviceAccount.yaml
+++ b/charts/elasticsearch/templates/backup/serviceAccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-backup-sa
+  name: {{ .Values.global.name }}-backup-sa
   labels: {{ include "elasticsearch.labels" . | nindent 4 }}
 {{ end -}}

--- a/charts/elasticsearch/templates/expose.yaml
+++ b/charts/elasticsearch/templates/expose.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.name }}-{{ $index }}
+  name: {{ $.Values.global.name }}-{{ $index }}
   labels: {{ include "elasticsearch.labels" $ | nindent 4 }}
 spec:
   type: LoadBalancer

--- a/charts/elasticsearch/templates/gcsSecret.yaml
+++ b/charts/elasticsearch/templates/gcsSecret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "elasticsearch.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-gcs-sa
+  name: {{ .Values.global.name }}-gcs-sa
   keysMap:
     snapshot_credentials.json:
       path: {{ .Values.vault.pathPrefix }}/elasticsearch/terraform/backup-sa

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -1,5 +1,9 @@
 # Set default values on chart from elastic.co
-name: elasticsearch
+
+global:
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: elasticsearch
+
 # replicaCount -- number of elasticsearch replicas to expose.
 replicaCount: 3
 # expose -- If true will create a loadbalancer service for each pod, enables using the transport client from outside the cluster

--- a/charts/externalcreds/README.md
+++ b/charts/externalcreds/README.md
@@ -1,6 +1,6 @@
 # externalcreds
 
-![Version: 0.60.0](https://img.shields.io/badge/Version-0.60.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.61.0](https://img.shields.io/badge/Version-0.61.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Terra External Credentials Manager
 
@@ -26,6 +26,7 @@ Chart for Terra External Credentials Manager
 | authorizationChangeEventsEnabled | bool | `true` | only enable google pubsub topic for live envs |
 | cloudTraceEnabled | bool | `true` | Whether to enable gcp cloud trace |
 | global.applicationVersion | string | `"latest"` | What version of the application to deploy |
+| global.name | string | `"externalcreds"` | A name for the deployment that will be substituted into resource definitions |
 | global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
 | image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
@@ -54,7 +55,6 @@ Chart for Terra External Credentials Manager
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
 | initDB | bool | `false` | Whether the ECM should be initialized on startup. Used for preview environments. |
-| name | string | `"externalcreds"` | A name for the deployment that will be substituted into resuorce definitions |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/version"` |  |

--- a/charts/externalcreds/templates/_labels.tpl
+++ b/charts/externalcreds/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "externalcreds.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: externalcreds
 app.kubernetes.io/part-of: terra

--- a/charts/externalcreds/templates/configmaps/allowed-jwks-configmap.yaml
+++ b/charts/externalcreds/templates/configmaps/allowed-jwks-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-allowed-jwks
+  name: {{ .Values.global.name }}-allowed-jwks
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 data:

--- a/charts/externalcreds/templates/configmaps/prometheus-configmap.yaml
+++ b/charts/externalcreds/templates/configmaps/prometheus-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-prometheus-configmap
+  name: {{ .Values.global.name }}-prometheus-configmap
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 data:

--- a/charts/externalcreds/templates/configmaps/proxy-apache-httpd-configmap.yaml
+++ b/charts/externalcreds/templates/configmaps/proxy-apache-httpd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-proxy-configmap
+  name: {{ .Values.global.name }}-proxy-configmap
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 data:

--- a/charts/externalcreds/templates/configmaps/tcell_configmap.yaml
+++ b/charts/externalcreds/templates/configmaps/tcell_configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-tcell-configmap
+  name: {{ .Values.global.name }}-tcell-configmap
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 data:

--- a/charts/externalcreds/templates/deployment.yaml
+++ b/charts/externalcreds/templates/deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Values.name }}-{{ .name }}-deployment
+  name: {{ $.Values.global.name }}-{{ .name }}-deployment
   labels:
 {{ include "externalcreds.labels" $ | indent 4 }}
   {{- if and $.Values.proxy.enabled $.Values.proxy.reloadOnCertUpdate }}
@@ -21,64 +21,64 @@ spec:
   replicas: {{ if eq .name "frontend" }}{{ $.Values.replicas }}{{ else }}1{{ end }}
   selector:
     matchLabels:
-      deployment: {{ $.Values.name }}-{{ .name }}-deployment
+      deployment: {{ $.Values.global.name }}-{{ .name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ $.Values.name }}-{{ .name }}-deployment
+        deployment: {{ $.Values.global.name }}-{{ .name }}-deployment
 {{ include "externalcreds.labels" $ | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map changes: */}}
-        checksum/{{ $.Values.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") $ | sha256sum }}
-        checksum/{{ $.Values.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/tcell_configmap.yaml") $ | sha256sum }}
+        checksum/{{ $.Values.global.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") $ | sha256sum }}
+        checksum/{{ $.Values.global.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/tcell_configmap.yaml") $ | sha256sum }}
         {{- if $.Values.prometheus.enabled }}
-        checksum/{{ $.Values.name }}-prometheus-configmap: {{ include (print $.Template.BasePath "/configmaps/prometheus-configmap.yaml") $ | sha256sum }}
+        checksum/{{ $.Values.global.name }}-prometheus-configmap: {{ include (print $.Template.BasePath "/configmaps/prometheus-configmap.yaml") $ | sha256sum }}
         {{- end }}
     spec:
-      serviceAccountName: {{ $.Values.name }}-service-sa
+      serviceAccountName: {{ $.Values.global.name }}-service-sa
       volumes:
       - name: cloudsql-sa-creds
         secret:
-          secretName: {{ $.Values.name }}-sqlproxy-sa
+          secretName: {{ $.Values.global.name }}-sqlproxy-sa
       - name: app-sa-creds
         secret:
-          secretName: {{ $.Values.name }}-app-sa
+          secretName: {{ $.Values.global.name }}-app-sa
       - name: app-providers
         secret:
-          secretName: {{ $.Values.name }}-providers
+          secretName: {{ $.Values.global.name }}-providers
       - name: app-swagger-client-id
         secret:
-          secretName: {{ $.Values.name }}-swagger-client-id
+          secretName: {{ $.Values.global.name }}-swagger-client-id
       - name: app-allowed-jwks
         configMap:
-          name: {{ $.Values.name }}-allowed-jwks
+          name: {{ $.Values.global.name }}-allowed-jwks
           items:
             - key: allowed-jwks.yaml
               path: allowed-jwks.yaml
       {{- if $.Values.proxy.enabled }}
       - name: apache-httpd-proxy-config
         configMap:
-          name: {{ $.Values.name }}-proxy-configmap
+          name: {{ $.Values.global.name }}-proxy-configmap
           items:
           - key: apache-httpd-proxy-config
-            path: {{ $.Values.name }}-proxy.conf
+            path: {{ $.Values.global.name }}-proxy.conf
       - name: cert
         secret:
-          secretName: {{ $.Values.name }}-cert
+          secretName: {{ $.Values.global.name }}-cert
       {{- if $.Values.proxy.tcell.enabled }}
       - name: tcell-config
         configMap:
-          name: {{ $.Values.name }}-tcell-configmap
+          name: {{ $.Values.global.name }}-tcell-configmap
           items:
           - key: tcell-config
             path: tcell-config.conf
       {{- end }}
       {{- end }}
       {{- if $.Values.prometheus.enabled }}
-      - name: {{ $.Values.name }}-prometheusjmx-config
+      - name: {{ $.Values.global.name }}-prometheusjmx-config
         configMap:
-          name: {{ $.Values.name }}-prometheus-configmap
-      - name: {{ $.Values.name }}-prometheusjmx-jar
+          name: {{ $.Values.global.name }}-prometheus-configmap
+      - name: {{ $.Values.global.name }}-prometheusjmx-jar
         emptyDir: {}
       {{- end }}
       containers:
@@ -92,17 +92,17 @@ spec:
         - name: SQL_INSTANCE_PROJECT
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-cloudsql-postgres-instance
+              name: {{ $.Values.global.name }}-cloudsql-postgres-instance
               key: project
         - name: SQL_INSTANCE_REGION
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-cloudsql-postgres-instance
+              name: {{ $.Values.global.name }}-cloudsql-postgres-instance
               key: region
         - name: SQL_INSTANCE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-cloudsql-postgres-instance
+              name: {{ $.Values.global.name }}-cloudsql-postgres-instance
               key: name
         command: ["/cloud_sql_proxy",
                   "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
@@ -114,7 +114,7 @@ spec:
         - name: cloudsql-sa-creds
           mountPath: /secrets/cloudsql
           readOnly: true
-      - name: {{ $.Values.name }}
+      - name: {{ $.Values.global.name }}
         image: "{{- if $.Values.image -}}
             {{ $.Values.image }}
           {{- else -}}
@@ -135,22 +135,22 @@ spec:
         env:
         {{- if $.Values.prometheus.enabled }}
         - name: JAVA_TOOL_OPTIONS
-          value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ $.Values.name }}-prometheusjmx-config/prometheusJmx.yaml"
+          value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ $.Values.global.name }}-prometheusjmx-config/prometheusJmx.yaml"
         {{- end }}
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-postgres-db-creds
+              name: {{ $.Values.global.name }}-postgres-db-creds
               key: username
         - name: DATABASE_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-postgres-db-creds
+              name: {{ $.Values.global.name }}-postgres-db-creds
               key: password
         - name: DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-postgres-db-creds
+              name: {{ $.Values.global.name }}-postgres-db-creds
               key: db
         {{- if $.Values.initDB }}
         - name: INIT_DB
@@ -184,9 +184,9 @@ spec:
           mountPath: /app/resources/rendered/allowed_jwks.yaml
           subPath: allowed-jwks.yaml
         {{- if $.Values.prometheus.enabled }}
-        - name: {{ $.Values.name }}-prometheusjmx-config
-          mountPath: /etc/{{ $.Values.name }}-prometheusjmx-config
-        - name: {{ $.Values.name }}-prometheusjmx-jar
+        - name: {{ $.Values.global.name }}-prometheusjmx-config
+          mountPath: /etc/{{ $.Values.global.name }}-prometheusjmx-config
+        - name: {{ $.Values.global.name }}-prometheusjmx-jar
           mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
         {{- end }}
@@ -215,37 +215,37 @@ spec:
         - name: AOU_PREPROD_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: aou-preprod
         - name: AOU_PERF_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: aou-perf
         - name: AOU_PROD_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: aou-prod
         - name: AOU_DEV_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: aou-dev
         - name: AOU_STABLE_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: aou-stable
         - name: AOU_STAGING_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: aou-staging
         - name: TERRA_ID_ALLOWLIST
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-oauth-allowlist
+              name: {{ $.Values.global.name }}-proxy-oauth-allowlist
               key: terra
         - name: REMOTE_USER_CLAIM
           value: sub
@@ -263,19 +263,19 @@ spec:
         - name: PROXY_LDAP_BIND_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-ldap-bind-password
+              name: {{ $.Values.global.name }}-proxy-ldap-bind-password
               key: password
         {{- end }}
         {{- if $.Values.proxy.tcell.enabled }}
         - name: TCELL_AGENT_APP_ID
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-tcell-secrets
+              name: {{ $.Values.global.name }}-proxy-tcell-secrets
               key: app-id
         - name: TCELL_AGENT_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ $.Values.name }}-proxy-tcell-secrets
+              name: {{ $.Values.global.name }}-proxy-tcell-secrets
               key: api-key
         - name: ENABLE_TCELL
           value: 'yes'
@@ -286,7 +286,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/apache2/sites-available/site.conf
           name: apache-httpd-proxy-config
-          subPath: {{ $.Values.name }}-proxy.conf
+          subPath: {{ $.Values.global.name }}-proxy.conf
         - mountPath: /etc/ssl/certs/server.crt
           subPath: tls.crt
           name: cert
@@ -314,10 +314,10 @@ spec:
         command: [
           "wget",
           "-O",
-          "/{{ $.Values.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ $.Values.prometheus.jmxJarRepo }}/{{ $.Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ $.Values.prometheus.jmxJarVersion }}.jar"
+          "/{{ $.Values.global.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ $.Values.prometheus.jmxJarRepo }}/{{ $.Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ $.Values.prometheus.jmxJarVersion }}.jar"
         ]
         volumeMounts:
-        - name: {{ $.Values.name }}-prometheusjmx-jar
-          mountPath: /{{ $.Values.name }}-prometheusjmx-jar
+        - name: {{ $.Values.global.name }}-prometheusjmx-jar
+          mountPath: /{{ $.Values.global.name }}-prometheusjmx-jar
       {{- end }}
 {{- end }}

--- a/charts/externalcreds/templates/ingress/cert.yaml
+++ b/charts/externalcreds/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  secretName: {{ .Values.name }}-cert
+  secretName: {{ .Values.global.name }}-cert
   renewBefore: {{ .Values.ingress.cert.certManager.renewBefore }}
   dnsNames:
   - {{ template "externalcreds.fqdn" . }}
@@ -17,11 +17,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/externalcreds/templates/ingress/service.yaml
+++ b/charts/externalcreds/templates/ingress/service.yaml
@@ -3,5 +3,5 @@
 {{- define "externalcreds.service" -}}
 spec:
   selector:
-    deployment: {{ .Values.name }}-frontend-deployment
+    deployment: {{ .Values.global.name }}-frontend-deployment
 {{- end }}

--- a/charts/externalcreds/templates/podMonitor.yaml
+++ b/charts/externalcreds/templates/podMonitor.yaml
@@ -2,11 +2,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Values.name }}-jvm-monitor
+  name: {{ .Values.global.name }}-jvm-monitor
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  jobLabel: {{ .Values.name }}-jvm
+  jobLabel: {{ .Values.global.name }}-jvm
   selector:
     matchLabels:
       app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/externalcreds/templates/role.yaml
+++ b/charts/externalcreds/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 rules:

--- a/charts/externalcreds/templates/rolebinding.yaml
+++ b/charts/externalcreds/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-service-role-binding
+  name: {{ .Values.global.name }}-service-role-binding
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa

--- a/charts/externalcreds/templates/secrets.yaml
+++ b/charts/externalcreds/templates/secrets.yaml
@@ -2,11 +2,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   keysMap:
     db:
       path: {{ .Values.vault.pathPrefix }}/externalcreds/postgres/db-creds
@@ -21,11 +21,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-instance
+  name: {{ .Values.global.name }}-postgres-instance
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-cloudsql-postgres-instance
+  name: {{ .Values.global.name }}-cloudsql-postgres-instance
   keysMap:
     project:
       path: {{ .Values.vault.pathPrefix }}/externalcreds/postgres/instance
@@ -40,11 +40,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-sqlproxy-sa
+  name: {{ .Values.global.name }}-sqlproxy-sa
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-sqlproxy-sa
+  name: {{ .Values.global.name }}-sqlproxy-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/externalcreds/sqlproxy-sa
@@ -55,11 +55,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-oauth-allowlist
+  name: {{ .Values.global.name }}-proxy-oauth-allowlist
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-oauth-allowlist
+  name: {{ .Values.global.name }}-proxy-oauth-allowlist
   keysMap:
     aou-preprod:
       path: secret/dsde/firecloud/common/preprod_researchallofus_oauth_client_ids
@@ -87,11 +87,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-ldap-bind-password
+  name: {{ .Values.global.name }}-proxy-ldap-bind-password
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-ldap-bind-password
+  name: {{ .Values.global.name }}-proxy-ldap-bind-password
   keysMap:
     password:
       path: {{ .Values.proxy.ldap.passwordVaultPath }}
@@ -102,11 +102,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-tcell-secrets
+  name: {{ .Values.global.name }}-proxy-tcell-secrets
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-tcell-secrets
+  name: {{ .Values.global.name }}-proxy-tcell-secrets
   keysMap:
     app-id:
       path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_app_id
@@ -120,11 +120,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-app-sa
+  name: {{ .Values.global.name }}-app-sa
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-app-sa
+  name: {{ .Values.global.name }}-app-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/externalcreds/app-sa
@@ -134,11 +134,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-providers
+  name: {{ .Values.global.name }}-providers
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-providers
+  name: {{ .Values.global.name }}-providers
   keysMap:
     providers.yaml:
       path: {{ .Values.vault.pathPrefix }}/externalcreds/providers
@@ -147,11 +147,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-swagger-client-id
+  name: {{ .Values.global.name }}-swagger-client-id
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-swagger-client-id
+  name: {{ .Values.global.name }}-swagger-client-id
   keysMap:
     swagger-client-id:
       path: {{ .Values.vault.pathPrefix }}/externalcreds/swagger-client-id

--- a/charts/externalcreds/templates/service-account.yaml
+++ b/charts/externalcreds/templates/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa
   labels:
 {{ include "externalcreds.labels" . | indent 4 }}

--- a/charts/externalcreds/values.yaml
+++ b/charts/externalcreds/values.yaml
@@ -5,9 +5,8 @@ global:
   # global.terraEnv -- (string) Terget Terra environment name. Required.
   # @default -- Is set by Helmfile on deploy
   terraEnv: null
-
-# name -- A name for the deployment that will be substituted into resuorce definitions
-name: externalcreds
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: externalcreds
 
 # replicas -- Number of replicas for the deployment
 replicas: 0

--- a/charts/filebeat/README.md
+++ b/charts/filebeat/README.md
@@ -1,6 +1,6 @@
 # terra-filebeat
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for shipping logs to logit.io via filebeat in terra k8s clusters
 

--- a/charts/firecloudorch/README.md
+++ b/charts/firecloudorch/README.md
@@ -1,6 +1,6 @@
 # firecloudorch
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Chart for firecloud-orchestration service in Terra
 
@@ -27,6 +27,7 @@ Chart for firecloud-orchestration service in Terra
 | elasticsearch.transportProbe.spec | object | `{"exec":{"command":["./etc/probe/probe.sh"]},"failureThreshold":3,"initialDelaySeconds":20,"periodSeconds":90,"successThreshold":1,"timeoutSeconds":5}` | Spec for the custom liveness probe |
 | elasticsearch.transportProbe.timeout | int | `10` | timeout in seconds for probe requests |
 | global.applicationVersion | string | `"latest"` | What version of the Cromwell application to deploy |
+| global.name | string | `"firecloudorch"` | A name for the deployment that will be substituted into resource definitions |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/broad-dsp-gcr-public/firecloud-orchestration"` | Image repository |
 | imageConfig.tag | string | global.applicationVersion | Image tag. |
@@ -40,7 +41,6 @@ Chart for firecloud-orchestration service in Terra
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
-| name | string | `"firecloudorch"` |  |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/version"` |  |

--- a/charts/firecloudorch/templates/deployment.yaml
+++ b/charts/firecloudorch/templates/deployment.yaml
@@ -1,9 +1,9 @@
 {{- $imageTag := .Values.imageConfig.tag | default .Values.global.applicationVersion -}}
-{{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Values.name -}}
+{{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Values.global.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
 spec:
@@ -16,17 +16,17 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
 {{ include "firecloudorch.labels" . | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-configmap: {{ include (print $.Template.BasePath "/config/configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-configmap: {{ include (print $.Template.BasePath "/config/configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       # Containers are configured to talk to each other by name
       # via docker-compose links; make corresponding aliases
       # to loopback in /etc/hosts
@@ -35,31 +35,31 @@ spec:
         hostnames:
         - app
       volumes:
-      - name: {{ .Values.name }}-cm
+      - name: {{ .Values.global.name }}-cm
         configMap:
-          name: {{ .Values.name }}-cm
+          name: {{ .Values.global.name }}-cm
       - name: app-ctmpls
         secret:
           secretName: {{ $legacyResourcePrefix }}-app-ctmpls
       - name: proxy-ctmpls
         secret:
           secretName: {{ $legacyResourcePrefix }}-proxy-ctmpls
-      - name: {{ .Values.name}}-gc-logs
+      - name: {{ .Values.global.name}}-gc-logs
         emptyDir: {}
-      - name: {{ .Values.name }}-proxy-security-logs
+      - name: {{ .Values.global.name }}-proxy-security-logs
         emptyDir: {}
-      - name: {{ .Values.name }}-prometheusjmx-jar
+      - name: {{ .Values.global.name }}-prometheusjmx-jar
         emptyDir: {}
       {{- if .Values.elasticsearch.transportProbe.enabled }}
-      - name: {{ .Values.name }}-es-probe-tools
+      - name: {{ .Values.global.name }}-es-probe-tools
         emptyDir: {}
-      - name: {{ .Values.name }}-es-probe-cm
+      - name: {{ .Values.global.name }}-es-probe-cm
         configMap:
-          name: {{ .Values.name }}-es-probe-cm
+          name: {{ .Values.global.name }}-es-probe-cm
           defaultMode: 0555
       {{- end }}
       containers:
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.imageConfig.repository }}:{{ $imageTag }}"
         ports:
         - name: status
@@ -103,8 +103,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/{{ .Values.name }}-cm
-          name: {{ .Values.name }}-cm
+        - mountPath: /etc/{{ .Values.global.name }}-cm
+          name: {{ .Values.global.name }}-cm
           readOnly: true
         - mountPath: /etc/firecloud-orchestration.conf
           subPath: firecloud-orchestration.conf
@@ -135,17 +135,17 @@ spec:
           name: app-ctmpls
           readOnly: true
         - mountPath: /var/log/gc
-          name: {{ .Values.name }}-gc-logs
+          name: {{ .Values.global.name }}-gc-logs
         - mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
-          name: {{ .Values.name }}-prometheusjmx-jar
+          name: {{ .Values.global.name }}-prometheusjmx-jar
           readOnly: true
         - mountPath: /usr/bin/jq
           subPath: jq
-          name: {{ .Values.name }}-es-probe-tools
+          name: {{ .Values.global.name }}-es-probe-tools
         - mountPath: /etc/probe/probe.sh
           subPath: probe.sh
-          name: {{ .Values.name }}-es-probe-cm
+          name: {{ .Values.global.name }}-es-probe-cm
         {{- if .Values.probes.readiness.enabled }}
         readinessProbe:
           {{- toYaml .Values.probes.readiness.spec | nindent 10 }}
@@ -157,7 +157,7 @@ spec:
         livenessProbe:
           {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
         {{- end }}
-      - name: {{ .Values.name }}-proxy
+      - name: {{ .Values.global.name }}-proxy
         image: {{ .Values.proxyImage }}
         ports:
           - containerPort: 443
@@ -196,7 +196,7 @@ spec:
           name: proxy-ctmpls
           readOnly: true
         - mountPath: /var/log/modsecurity
-          name: {{ .Values.name }}-proxy-security-logs
+          name: {{ .Values.global.name }}-proxy-security-logs
       {{- if .Values.prometheus.enabled }}
       initContainers:
       - name: download-prometheus-jmx-jar
@@ -204,11 +204,11 @@ spec:
         command: [
           "wget",
           "-O",
-          "/{{ .Values.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
+          "/{{ .Values.global.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
         ]
         volumeMounts:
-        - name: {{ .Values.name }}-prometheusjmx-jar
-          mountPath: /{{ .Values.name }}-prometheusjmx-jar
+        - name: {{ .Values.global.name }}-prometheusjmx-jar
+          mountPath: /{{ .Values.global.name }}-prometheusjmx-jar
       {{- end }}
       {{- if .Values.elasticsearch.transportProbe.enabled }}
       - name: install-jq
@@ -219,9 +219,9 @@ spec:
         - |
           #!/usr/bin/env bash
           set -e
-          wget -O /{{ .Values.name }}-es-probe-tools/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-          chmod +x /{{ .Values.name }}-es-probe-tools/jq
+          wget -O /{{ .Values.global.name }}-es-probe-tools/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          chmod +x /{{ .Values.global.name }}-es-probe-tools/jq
         volumeMounts:
-        - name: {{ .Values.name }}-es-probe-tools
-          mountPath: /{{ .Values.name }}-es-probe-tools
+        - name: {{ .Values.global.name }}-es-probe-tools
+          mountPath: /{{ .Values.global.name }}-es-probe-tools
       {{- end }}

--- a/charts/firecloudorch/templates/ingress/backendConfig.yaml
+++ b/charts/firecloudorch/templates/ingress/backendConfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-backendconfig
+  name: {{ .Values.global.name }}-ingress-backendconfig
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
 spec:

--- a/charts/firecloudorch/templates/ingress/cert.yaml
+++ b/charts/firecloudorch/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/firecloudorch/templates/ingress/frontendConfig.yaml
+++ b/charts/firecloudorch/templates/ingress/frontendConfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-frontendconfig
+  name: {{ .Values.global.name }}-ingress-frontendconfig
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
 spec:

--- a/charts/firecloudorch/templates/ingress/ingress.yaml
+++ b/charts/firecloudorch/templates/ingress/ingress.yaml
@@ -2,11 +2,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}-ingress
+  name: {{ .Values.global.name }}-ingress
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.global.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.cert.preSharedCerts) }}
@@ -15,9 +15,9 @@ metadata:
 spec:
 {{- if empty .Values.ingress.cert.preSharedCerts }}
   tls:
-  - secretName: {{ .Values.name }}-cert
+  - secretName: {{ .Values.global.name }}-cert
 {{- end }}
   backend:
-    serviceName: {{ .Values.name }}-service
+    serviceName: {{ .Values.global.name }}-service
     servicePort: 443
 {{- end }}

--- a/charts/firecloudorch/templates/ingress/service.yaml
+++ b/charts/firecloudorch/templates/ingress/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
   annotations:
     # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
-    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "{{ .Values.global.name }}-ingress-backendconfig"}'
     # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
     cloud.google.com/neg: '{"ingress": true}'
     # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    deployment: {{ .Values.name }}-deployment
+    deployment: {{ .Values.global.name }}-deployment
   ports:
   - name: https
     protocol: TCP

--- a/charts/firecloudorch/templates/podDisruptionBudget.yaml
+++ b/charts/firecloudorch/templates/podDisruptionBudget.yaml
@@ -4,5 +4,5 @@
 spec:
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
 {{- end }}

--- a/charts/firecloudorch/templates/probe/configmap.yaml
+++ b/charts/firecloudorch/templates/probe/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-es-probe-cm
+  name: {{ .Values.global.name }}-es-probe-cm
   labels: {{ include "firecloudorch.labels" . | nindent 4 }}
 data:
   probe.sh: |

--- a/charts/firecloudorch/templates/role.yaml
+++ b/charts/firecloudorch/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
 rules:

--- a/charts/firecloudorch/templates/roleBinding.yaml
+++ b/charts/firecloudorch/templates/roleBinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/firecloudorch/templates/serviceAccount.yaml
+++ b/charts/firecloudorch/templates/serviceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   labels:
 {{ include "firecloudorch.labels" . | indent 4 }}

--- a/charts/firecloudorch/values.yaml
+++ b/charts/firecloudorch/values.yaml
@@ -1,8 +1,8 @@
 global:
   # global.applicationVersion -- What version of the Cromwell application to deploy
   applicationVersion: latest
-
-name: firecloudorch
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: firecloudorch
 
 ingress:
   # ingress.enabled -- Whether to create Ingress, Service and associated config resources

--- a/charts/firecloudui/README.md
+++ b/charts/firecloudui/README.md
@@ -26,6 +26,7 @@ Chart for Firecloud UI service in Terra
 | app.resources.requests.cpu | int | `1` | Number of CPU units to request for the deployment |
 | app.resources.requests.memory | string | `"3.75Gi"` | Memory to request for the deployment |
 | global.applicationVersion | string | `"latest"` | What version of the firecloudui application to deploy |
+| global.name | string | `"firecloudui"` | Name for this deployment |
 | ingress.cert.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |
 | ingress.cert.vault.cert.path | string | `nil` | Path to secret containing .crt |
 | ingress.cert.vault.cert.secretKey | string | `nil` | Key in secret containing .crt |
@@ -37,7 +38,6 @@ Chart for Firecloud UI service in Terra
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `"nul"` | (string) Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` | Load balancer backend timeout |
-| name | string | `"firecloudui"` | Name for this deployment |
 | replicas | int | `2` | Number of replicas to spin up in the deployment |
 | sherlock.appImageName | string | `"gcr.io/broad-dsp-gcr-public/firecloud-ui"` |  |
 | sherlock.appName | string | `"firecloudui"` |  |

--- a/charts/firecloudui/templates/_labels.tpl
+++ b/charts/firecloudui/templates/_labels.tpl
@@ -9,6 +9,6 @@ helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/component: {{ .Values.name }}
+app.kubernetes.io/component: {{ .Values.global.name }}
 app.kubernetes.io/part-of: terra
 {{- end -}}

--- a/charts/firecloudui/templates/deployment.yaml
+++ b/charts/firecloudui/templates/deployment.yaml
@@ -1,9 +1,9 @@
 {{- $imageTag := .Values.app.image.tag | default .Values.global.applicationVersion -}}
-{{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Values.name -}}
+{{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Values.global.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
 {{ include "firecloudui.labels" . | nindent 4 }}
 spec:
@@ -16,17 +16,17 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
 {{ include "firecloudui.labels" . | nindent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-configmap: {{ include (print $.Template.BasePath "/config/configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-configmap: {{ include (print $.Template.BasePath "/config/configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       # Containers are configured to talk to each other by name
       # via docker-compose links; make corresponding aliases
       # to loopback in /etc/hosts
@@ -39,7 +39,7 @@ spec:
         secret:
           secretName: {{ $legacyResourcePrefix }}-app-ctmpls
       containers:
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag | default .Values.global.applicationVersion }}"
         ports:
           - containerPort: 443

--- a/charts/firecloudui/templates/ingress/cert.yaml
+++ b/charts/firecloudui/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
 {{ include "firecloudui.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/firecloudui/templates/ingress/service.yaml
+++ b/charts/firecloudui/templates/ingress/service.yaml
@@ -3,5 +3,5 @@
 {{- define "firecloudui.service" -}}
 spec:
   selector:
-    deployment: {{ .Values.name }}-deployment
+    deployment: {{ .Values.global.name }}-deployment
 {{- end }}

--- a/charts/firecloudui/templates/podDisruptionBudget.yaml
+++ b/charts/firecloudui/templates/podDisruptionBudget.yaml
@@ -4,5 +4,5 @@
 spec:
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
 {{- end }}

--- a/charts/firecloudui/templates/role.yaml
+++ b/charts/firecloudui/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   labels: {{- include "firecloudui.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']

--- a/charts/firecloudui/templates/rolebinding.yaml
+++ b/charts/firecloudui/templates/rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   labels: {{- include "firecloudui.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/firecloudui/templates/serviceaccount.yaml
+++ b/charts/firecloudui/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   labels: {{- include "firecloudui.labels" . | nindent 4 }}

--- a/charts/firecloudui/values.yaml
+++ b/charts/firecloudui/values.yaml
@@ -1,12 +1,12 @@
 global:
   # global.applicationVersion -- What version of the firecloudui application to deploy
   applicationVersion: latest
+  # global.name -- Name for this deployment
+  name: firecloudui
 
 # replicas -- Number of replicas to spin up in the deployment
 replicas: 2
 
-# name -- Name for this deployment
-name: firecloudui
 
 # Settings for Firecloud UI's Ingress & Service
 ingress:

--- a/charts/hydra/README.md
+++ b/charts/hydra/README.md
@@ -1,6 +1,6 @@
 # hydra
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for the Hydra deployment used by Identity Concentrator in Terra
 

--- a/charts/icdemo/README.md
+++ b/charts/icdemo/README.md
@@ -1,6 +1,6 @@
 # icdemo
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for the Identity Concentrator demo/test
 

--- a/charts/identityconcentrator/README.md
+++ b/charts/identityconcentrator/README.md
@@ -1,6 +1,6 @@
 # identityconcentrator
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for the Identity Concentrator deployment used by Terra
 

--- a/charts/istioconfig/README.md
+++ b/charts/istioconfig/README.md
@@ -1,6 +1,6 @@
 # istioconfig
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to setup Istio configs
 

--- a/charts/jobmanager/README.md
+++ b/charts/jobmanager/README.md
@@ -25,13 +25,13 @@ Chart for Job Manager service in Terra
 | api.resources.requests.cpu | int | `4` | Number of CPU units to request for the deployment |
 | api.resources.requests.memory | string | `"3.6Gi"` | Memory to request for the deployment |
 | global.applicationVersion | string | `"latest"` | What version of the jobmanager application to deploy |
+| global.name | string | `"jobmanager"` | Name for this deployment |
 | ingress.cert.preSharedCerts | list | `[]` | Array of pre-shared GCP SSL certificate names to associate with the Ingress |
 | ingress.enabled | bool | `true` | Whether to create Ingress and associated Service, FrontendConfig and BackendConfig |
 | ingress.requestPath | string | `"/health"` | Request path to which the probe system should connect |
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` | Load balancer backend timeout |
-| name | string | `"jobmanager"` | Name for this deployment |
 | proxy.image.repository | string | `"broadinstitute/openidc-proxy"` | Image repository |
 | proxy.image.tag | string | `"modsecurity_2_9_2"` | (string) Image tag. |
 | replicas | int | `3` | Number of API replicas to spin up in the deployment |

--- a/charts/jobmanager/templates/_labels.tpl
+++ b/charts/jobmanager/templates/_labels.tpl
@@ -9,6 +9,6 @@ helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/component: {{ .Values.name }}
+app.kubernetes.io/component: {{ .Values.global.name }}
 app.kubernetes.io/part-of: terra
 {{- end -}}

--- a/charts/jobmanager/templates/configmap.yaml
+++ b/charts/jobmanager/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-cm
+  name: {{ .Values.global.name }}-cm
   labels: {{- include "jobmanager.labels" . | nindent 4 }}
 # No data yet

--- a/charts/jobmanager/templates/deployment.yaml
+++ b/charts/jobmanager/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels: {{- include "jobmanager.labels" . | nindent 4 }}
 spec:
   strategy:
@@ -13,17 +13,17 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
         {{- include "jobmanager.labels" . | nindent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-cm: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-cm: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       # Containers are configured to talk to each other by name
       # via docker-compose links; make corresponding aliases
       # to loopback in /etc/hosts
@@ -35,17 +35,17 @@ spec:
       volumes:
       - name: ui-ctmpls
         secret:
-          secretName: {{ .Values.name }}-ui-ctmpls
+          secretName: {{ .Values.global.name }}-ui-ctmpls
       - name: api-ctmpls
         secret:
-          secretName: {{ .Values.name }}-api-ctmpls
+          secretName: {{ .Values.global.name }}-api-ctmpls
       - name: proxy-ctmpls
         secret:
-          secretName: {{ .Values.name }}-proxy-ctmpls
-      - name: {{ .Values.name }}-modsecurity-logs
+          secretName: {{ .Values.global.name }}-proxy-ctmpls
+      - name: {{ .Values.global.name }}-modsecurity-logs
         emptyDir: {}
       containers:
-      - name: {{ .Values.name }}-api
+      - name: {{ .Values.global.name }}-api
         image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.global.applicationVersion }}"
         args: ["-b", ":8190", "-t", "60"]
         ports:
@@ -59,7 +59,7 @@ spec:
             memory: {{ .Values.api.resources.limits.memory }}
         envFrom:
         - secretRef:
-            name: {{ .Values.name }}-api-env
+            name: {{ .Values.global.name }}-api-env
         env:
         # Make node, pod name accessible to app as env vars
         - name: K8S_NODE_NAME
@@ -88,7 +88,7 @@ spec:
         livenessProbe:
           {{- toYaml .Values.api.probes.liveness.spec | nindent 10 }}
         {{- end }}
-      - name: {{ .Values.name }}-ui
+      - name: {{ .Values.global.name }}-ui
         image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.global.applicationVersion }}"
         ports:
         - containerPort: 8000
@@ -127,7 +127,7 @@ spec:
         livenessProbe:
           {{- toYaml .Values.ui.probes.liveness.spec | nindent 10 }}
         {{- end }}
-      - name: {{ .Values.name }}-proxy
+      - name: {{ .Values.global.name }}-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
         ports:
           - containerPort: 443
@@ -135,7 +135,7 @@ spec:
           - containerPort: 8888
         envFrom:
         - secretRef:
-            name: {{ .Values.name }}-proxy-env
+            name: {{ .Values.global.name }}-proxy-env
         volumeMounts:
         - mountPath: /etc/ssl/certs/server.crt
           subPath: server.crt
@@ -159,4 +159,4 @@ spec:
           subPath: site.conf
           name: proxy-ctmpls
         - mountPath: /var/log/modsecurity
-          name: {{ .Values.name }}-modsecurity-logs
+          name: {{ .Values.global.name }}-modsecurity-logs

--- a/charts/jobmanager/templates/ingress/service.yaml
+++ b/charts/jobmanager/templates/ingress/service.yaml
@@ -3,5 +3,5 @@
 {{- define "jobmanager.service" -}}
 spec:
   selector:
-    deployment: {{ .Values.name }}-deployment
+    deployment: {{ .Values.global.name }}-deployment
 {{- end }}

--- a/charts/jobmanager/templates/podDisruptionBudget.yaml
+++ b/charts/jobmanager/templates/podDisruptionBudget.yaml
@@ -4,5 +4,5 @@
 spec:
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
 {{- end }}

--- a/charts/jobmanager/templates/role.yaml
+++ b/charts/jobmanager/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   labels: {{- include "jobmanager.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']

--- a/charts/jobmanager/templates/rolebinding.yaml
+++ b/charts/jobmanager/templates/rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   labels: {{- include "jobmanager.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/jobmanager/templates/serviceaccount.yaml
+++ b/charts/jobmanager/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   labels: {{- include "jobmanager.labels" . | nindent 4 }}

--- a/charts/jobmanager/values.yaml
+++ b/charts/jobmanager/values.yaml
@@ -1,12 +1,12 @@
 global:
   # global.applicationVersion -- What version of the jobmanager application to deploy
   applicationVersion: latest
+  # global.name -- Name for this deployment
+  name: jobmanager
 
 # replicas -- Number of API replicas to spin up in the deployment
 replicas: 3
 
-# name -- Name for this deployment
-name: jobmanager
 
 # Settings for Job Manager's Ingress & Service
 ingress:

--- a/charts/leonardo/README.md
+++ b/charts/leonardo/README.md
@@ -19,7 +19,7 @@ A Helm chart for Leonardo, a Terra service for interactive analysis applications
 | cronjob.enabled | bool | `false` |  |
 | cronjob.googleProject | string | `nil` |  |
 | cronjob.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/resource-validator"` |  |
-| cronjob.imageTag | string | `"79854b1"` |  |
+| cronjob.imageTag | string | `"3695ba2"` |  |
 | cronjob.name | string | `"leonardo-resource-validator-cronjob"` |  |
 | deploymentDefaults.annotations | object | `{}` |  |
 | deploymentDefaults.enabled | bool | `true` | Whether a declared deployment is enabled. If false, no resources will be created |
@@ -47,7 +47,7 @@ A Helm chart for Leonardo, a Terra service for interactive analysis applications
 | ingress.timeoutSec | int | `28800` | Load balancer backend timeout (Leonardo has a large backend timeout to support long-lived websockets -- see DDO-132 / IA-1665) |
 | janitorCron.enabled | bool | `false` |  |
 | janitorCron.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/janitor"` |  |
-| janitorCron.imageTag | string | `"79854b1"` |  |
+| janitorCron.imageTag | string | `"3695ba2"` |  |
 | janitorCron.name | string | `"leonardo-janitor-cronjob"` |  |
 | liquibase-migration.defaults.enabled | bool | `false` |  |
 | liquibase-migration.defaults.migrationArgsClasspath[0] | string | `"$(find /leonardo -name 'leonardo*.jar')"` |  |
@@ -67,5 +67,5 @@ A Helm chart for Leonardo, a Terra service for interactive analysis applications
 | vault.pathPrefix | string | `nil` | Vault path prefix for secrets. Required if vault.enabled. |
 | zombieMonitorCron.enabled | bool | `false` |  |
 | zombieMonitorCron.imageRepository | string | `"us.gcr.io/broad-dsp-gcr-public/zombie-monitor"` |  |
-| zombieMonitorCron.imageTag | string | `"79854b1"` |  |
+| zombieMonitorCron.imageTag | string | `"3695ba2"` |  |
 | zombieMonitorCron.name | string | `"leonardo-zombie-monitor-cronjob"` |  |

--- a/charts/liquibase-migration/README.md
+++ b/charts/liquibase-migration/README.md
@@ -1,6 +1,6 @@
 # liquibase-migration
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart to run Liquibase migrations before Terra app startup
 

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -45,9 +45,9 @@ This chart is heavily customized to Terra's needs and is a thin wrapper around B
 | bitnami.volumePermissions.enabled | bool | `true` |  |
 | expose | bool | `false` | Whether to expose MongoDB outside the cluster. This is only for backwards-compatibility with existing Terra dev workflows; avoid enabling in new environments |
 | exposeIPs | list | `[]` | Static public IPs to assign to replicas. Required if expose is `true`; must match the number of replicas. Eg. ["1.2.3.4", "5.6.7.8", "9.10.11.12"]. |
+| global.name | string | `"mongodb"` | The name of the service deployed by this chart. Defaults to "mongodb". If this value is overridden, be careful to also update the bitnami subchart values below to match! |
 | global.storageClass | string | `"terra-xfs-zonal"` | Storage class to use when provisioning persistent disks (passed to Bitnami chart) |
 | global.trustedAddresses | object | `{}` | A map of addesses that should be permitted to connect to MongoDB (see `expose` value). Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
-| name | string | `"mongodb"` | The name of the service deployed by this chart. Defaults to "mongodb". If this value is overridden, be careful to also update the bitnami subchart values below to match! |
 | vaultSecrets | object | `{"agoraPassword":{"key":null,"path":null},"backupCredentials":{"key":null,"path":null},"replicaSetKey":{"key":null,"path":null},"rootPassword":{"key":null,"path":null}}` | Where in Vault to find secrets used by MongoDB chart. |
 | vaultSecrets.agoraPassword.key | string | `nil` | Key in Vault where the Agora password is stored |
 | vaultSecrets.agoraPassword.path | string | `nil` | Path in Vault the Agora password is stored |

--- a/charts/mongodb/templates/_helpers.tpl
+++ b/charts/mongodb/templates/_helpers.tpl
@@ -20,8 +20,8 @@ Craft a MongoDB replicaset connection url for use by backup job. Eg.
 */ -}}
 {{- define "_mongodb.backup.replicaset.url" -}}
   {{- $user := "root"                            -}}{{- /* user to connect as */ -}}
-  {{- $svc  := printf "%s-headless" .Values.name -}}{{- /* name of MongoDB headless service */ -}}
-  {{- $sts  := printf .Values.name               -}}{{- /* name of MongoDB statefulset */ -}}
+  {{- $svc  := printf "%s-headless" .Values.global.name -}}{{- /* name of MongoDB headless service */ -}}
+  {{- $sts  := printf .Values.global.name               -}}{{- /* name of MongoDB statefulset */ -}}
   {{- $port := 27017                             -}}{{- /* port MongoDB is listening */ -}}
   {{- $rs   := "rs0"                             -}}{{- /* replica set identifier */ -}}
 

--- a/charts/mongodb/templates/backup/cronjob.yaml
+++ b/charts/mongodb/templates/backup/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Values.name }}-backup-cronjob
+  name: {{ .Values.global.name }}-backup-cronjob
   labels: {{ include "mongodb.labels" . | nindent 4 }}
 spec:
   schedule: "0 10 * * *" # Run once a day at 10 am UTC / 5 am EST
@@ -15,9 +15,9 @@ spec:
         metadata:
           labels: {{ include "mongodb.labels" . | nindent 12 }}
         spec:
-          serviceAccountName: {{ .Values.name }}-sa
+          serviceAccountName: {{ .Values.global.name }}-sa
           initContainers:
-          - name: {{ .Values.name }}-backup-dump
+          - name: {{ .Values.global.name }}-backup-dump
             image: {{ include "_mongodb.image" . }}
             command: ['sh', '-c']
             args:
@@ -30,7 +30,7 @@ spec:
             - name: MONGODUMP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.name }}-secrets
+                  name: {{ .Values.global.name }}-secrets
                   key: mongodb-root-password
             - name: MONGODUMP_CONNECTION_STRING
               value: {{ include "_mongodb.backup.replicaset.url" . | quote }}
@@ -38,7 +38,7 @@ spec:
             - mountPath: /backup
               name: backup-data
           containers:
-          - name: {{ .Values.name }}-backup-upload
+          - name: {{ .Values.global.name }}-backup-upload
             image: {{ include "_mongodb.backup.cloudsdk.image" . }}
             command: ['sh', '-c']
             args:
@@ -64,7 +64,7 @@ spec:
             emptyDir: {}
           - name: gcp-sa
             secret:
-              secretName: {{ .Values.name }}-secrets
+              secretName: {{ .Values.global.name }}-secrets
               items:
               - key: mongodb-backup-credentials
                 path: sa-key.json

--- a/charts/mongodb/templates/expose.yaml
+++ b/charts/mongodb/templates/expose.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.name }}-{{ $index }}
+  name: {{ $.Values.global.name }}-{{ $index }}
   labels: {{ include "mongodb.labels" $ | nindent 4 }}
 spec:
   type: LoadBalancer

--- a/charts/mongodb/templates/role.yaml
+++ b/charts/mongodb/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   labels: {{ include "mongodb.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']

--- a/charts/mongodb/templates/rolebinding.yaml
+++ b/charts/mongodb/templates/rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   labels: {{ include "mongodb.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/mongodb/templates/secretdefinition.yaml
+++ b/charts/mongodb/templates/secretdefinition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongodb-secretdef
   labels: {{ include "mongodb.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-secrets
+  name: {{ .Values.global.name }}-secrets
   keysMap:
     mongodb-password:
       key: {{ required "A valid vaultSecrets.agoraPassword.key is required" .Values.vaultSecrets.agoraPassword.key }}

--- a/charts/mongodb/templates/serviceaccount.yaml
+++ b/charts/mongodb/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   labels: {{ include "mongodb.labels" . | nindent 4 }}

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -64,12 +64,12 @@ bitnami:
     enabled: false
   architecture: replicaset
   auth:
-    existingSecret: mongodb-secrets # Update to match .Values.name if changed!
+    existingSecret: mongodb-secrets # Update to match .Values.global.name if changed!
     username: agora
     database: agora
-  fullnameOverride: mongodb # Update to match .Values.name if changed!
+  fullnameOverride: mongodb # Update to match .Values.global.name if changed!
   labels:
-    app.kubernetes.io/instance: mongodb # Update to match .Values.name if changed!
+    app.kubernetes.io/instance: mongodb # Update to match .Values.global.name if changed!
     app.kubernetes.io/name: mongodb
     app.kubernetes.io/part-of: terra
   persistence:
@@ -79,7 +79,7 @@ bitnami:
   podLabels:
     # Note: don't try to set app.kubernetes.io/name here -- the Bitnami chart uses
     # it in the StatefulSet selector
-    app.kubernetes.io/instance: mongodb # Update to match .Values.name if changed!
+    app.kubernetes.io/instance: mongodb # Update to match .Values.global.name if changed!
     app.kubernetes.io/part-of: terra
   replicaCount: 3
   resources: # Match pre-GKE click-to-deploy MongoDB instances
@@ -91,6 +91,6 @@ bitnami:
       memory: 21Gi
   serviceAccount:
     create: false
-    name: mongodb-sa # Update to match .Values.name if changed!
+    name: mongodb-sa # Update to match .Values.global.name if changed!
   volumePermissions:
     enabled: true

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -5,9 +5,8 @@ global:
   storageClass: terra-xfs-zonal
   # global.trustedAddresses -- A map of addesses that should be permitted to connect to MongoDB (see `expose` value). Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }`
   trustedAddresses: {}
-
-# name -- The name of the service deployed by this chart. Defaults to "mongodb". If this value is overridden, be careful to also update the bitnami subchart values below to match!
-name: mongodb
+  # global.name -- The name of the service deployed by this chart. Defaults to "mongodb". If this value is overridden, be careful to also update the bitnami subchart values below to match!
+  name: mongodb
 
 # expose -- Whether to expose MongoDB outside the cluster. This is only for backwards-compatibility with existing Terra dev workflows; avoid enabling in new environments
 expose: false

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -9,11 +9,11 @@ This chart is customized for Terra preview environments
 |-----|------|---------|-------------|
 | databaseName | string | `nil` | name of a default database that the service expects (if any) i.e. a new leonardo instance expects a 'leonardo' database to already exist |
 | global.applicationVersion | string | `"latest"` | What version of mysql to deploy |
+| global.name | string | `"mysql"` | A name for the statefulset that will be substituted into resource definitions |
 | global.storageClass | string | `"standard"` | Storage class to use when provisioning persistent disks |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"mysql"` | Image repository |
 | imageConfig.tag | string | `nil` | Image tag. |
-| name | string | `"mysql"` | A name for the statefulset that will be substituted into resource definitions |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.exec.command[0] | string | `"mysqladmin"` |  |
 | probes.liveness.spec.exec.command[1] | string | `"ping"` |  |

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -5,9 +5,8 @@ global:
   storageClass: standard
   # global.applicationVersion -- What version of mysql to deploy
   applicationVersion: latest
-
-# name -- A name for the statefulset that will be substituted into resource definitions
-name: mysql
+  # global.name -- A name for the statefulset that will be substituted into resource definitions
+  name: mysql
 
 # serviceName -- name of the terra service for which this mysql is for, i.e. leonardo.
 # required, no default

--- a/charts/ncbiaccess/README.md
+++ b/charts/ncbiaccess/README.md
@@ -8,10 +8,10 @@ Chart for NCBI Access service in Terra
 |-----|------|---------|-------------|
 | annotations | object | `{}` |  |
 | global.applicationVersion | string | `"latest"` | What version of the Sam application to deploy |
+| global.name | string | `"ncbiaccess"` | prefix for k8s resource names |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"broadinstitute/ncbiaccess"` | Image repo to use |
 | imageConfig.tag | string | global.applicationVersion | Image tag to run |
-| name | string | `"ncbiaccess"` | prefix for k8s resource names |
 | replicas | int | `1` | number of pods to run |
 | resources.limits.cpu | int | `1` |  |
 | resources.limits.memory | string | `"2Gi"` |  |

--- a/charts/ncbiaccess/templates/_labels.tpl
+++ b/charts/ncbiaccess/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "ncbiaccess.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: {{ .Chart.Name }}
 app.kubernetes.io/part-of: terra
@@ -18,5 +18,5 @@ Selector labels
 */}}
 {{- define "ncbiaccess.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 {{- end }}

--- a/charts/ncbiaccess/templates/deployment.yaml
+++ b/charts/ncbiaccess/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels: {{ include "ncbiaccess.labels" . | nindent 4 }}
 spec:
   revisionHistoryLimit: 0
@@ -22,13 +22,13 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
     spec:
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       volumes:
       - name: app-ctmpls
         secret:
-          secretName: {{ .Values.name }}-app-ctmpls
+          secretName: {{ .Values.global.name }}-app-ctmpls
       containers:
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.imageConfig.repository }}:{{ $imageTag }}"
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/ncbiaccess/templates/imagePullSecret.yaml
+++ b/charts/ncbiaccess/templates/imagePullSecret.yaml
@@ -1,11 +1,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-dockerhub-creds
+  name: {{ .Values.global.name }}-dockerhub-creds
   labels:
 {{ include "ncbiaccess.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-dockerhub-creds
+  name: {{ .Values.global.name }}-dockerhub-creds
   type: kubernetes.io/dockerconfigjson
   keysMap:
     .dockerconfigjson:

--- a/charts/ncbiaccess/templates/role.yaml
+++ b/charts/ncbiaccess/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   labels: {{- include "ncbiaccess.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']

--- a/charts/ncbiaccess/templates/roleBinding.yaml
+++ b/charts/ncbiaccess/templates/roleBinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   labels:
     {{- include "ncbiaccess.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io
   

--- a/charts/ncbiaccess/templates/serviceAccount.yaml
+++ b/charts/ncbiaccess/templates/serviceAccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   labels: {{- include "ncbiaccess.labels" . | nindent 4 }}
 imagePullSecrets:
-- name: {{ .Values.name }}-dockerhub-creds
+- name: {{ .Values.global.name }}-dockerhub-creds

--- a/charts/ncbiaccess/values.yaml
+++ b/charts/ncbiaccess/values.yaml
@@ -1,9 +1,9 @@
 global:
   # global.applicationVersion -- What version of the Sam application to deploy
   applicationVersion: latest
+  # global.name -- prefix for k8s resource names
+  name: ncbiaccess
 
-# name -- prefix for k8s resource names
-name: ncbiaccess
 # replicas -- number of pods to run
 replicas: 1
 

--- a/charts/ontology/README.md
+++ b/charts/ontology/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for DUOS Ontology, the DUOS Algorithmic Matching System
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Values
 

--- a/charts/opendj/README.md
+++ b/charts/opendj/README.md
@@ -1,6 +1,6 @@
 # opendj
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for OpenDJ, used by Sam(Terra IAM service) as well as various Terra applications' OIDC proxy deploys
 
@@ -22,12 +22,12 @@ Chart for OpenDJ, used by Sam(Terra IAM service) as well as various Terra applic
 | backup.nodeSelector | object | `{}` | NodeSelector for backup CronJob pods |
 | backup.timeoutSeconds | int | `7200` | How many seconds to wait before assuming job is hung and killing it |
 | backup.tolerations | list | `[]` | Tolerations for backup CronJob pods |
+| global.name | string | `"opendj"` | A name for the deployment that will be substituted into resource definitions |
 | global.trustedAddresses | object | `{}` | A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }` |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"broadinstitute/openam"` | Image repository |
 | imageConfig.tag | string | `"opendj_3"` | (string) Image tag. |
 | legacyResourcePrefix | string | `nil` | What prefix to use to refer to secrets rendered from firecloud-develop @default .Chart.Name |
-| name | string | `"opendj"` | A name for the deployment that will be substituted into resuorce definitions |
 | nodeSelector | object | `{}` | nodeSelector map |
 | persistence.capacity | string | `"200Gi"` | Capacity of persistent data volume |
 | persistence.storageClassName | string | `nil` | If not null, the volume will be restricted to the specified storage class |

--- a/charts/opendj/templates/_labels.tpl
+++ b/charts/opendj/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "opendj.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: opendj
 app.kubernetes.io/part-of: terra
@@ -18,5 +18,5 @@ Selector labels
 */}}
 {{- define "opendj.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 {{- end }}

--- a/charts/opendj/templates/backup/cronjob.yaml
+++ b/charts/opendj/templates/backup/cronjob.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Values.name }}-backup-cronjob
+  name: {{ .Values.global.name }}-backup-cronjob
   labels: {{ include "opendj.labels" . | nindent 4 }}
 spec:
   schedule: "0 10 * * *" # Run once a day at 10 am UTC / 5 am EST
@@ -17,9 +17,9 @@ spec:
         metadata:
           labels: {{ include "opendj.labels" . | nindent 12 }}
         spec:
-          serviceAccountName: {{ .Values.name }}-service-sa
+          serviceAccountName: {{ .Values.global.name }}-service-sa
           containers:
-          - name: {{ .Values.name }}-backup-upload
+          - name: {{ .Values.global.name }}-backup-upload
             image: {{ .Values.backup.cloudsdkImage.repository }}:{{ .Values.backup.cloudsdkImage.tag }}
             command: ['sh', '-c']
             args:
@@ -57,7 +57,7 @@ spec:
             emptyDir: {}
           - name: gcp-sa
             secret:
-              secretName: {{ .Values.name }}-secrets
+              secretName: {{ .Values.global.name }}-secrets
               items:
               - key: backup-credentials
                 path: sa-key.json

--- a/charts/opendj/templates/checks.yaml
+++ b/charts/opendj/templates/checks.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-checks
+  name: {{ .Values.global.name }}-checks
   labels:
     {{- include "opendj.labels" . | nindent 4 }}
 data:

--- a/charts/opendj/templates/role.yaml
+++ b/charts/opendj/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   labels:
     {{- include "opendj.labels" . | nindent 4 }}
 rules:

--- a/charts/opendj/templates/rolebinding.yaml
+++ b/charts/opendj/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-service-role-binding
+  name: {{ .Values.global.name }}-service-role-binding
   labels:
     {{- include "opendj.labels" . | nindent 4 }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa

--- a/charts/opendj/templates/secretdefinition.yaml
+++ b/charts/opendj/templates/secretdefinition.yaml
@@ -2,10 +2,10 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-secretdef
+  name: {{ .Values.global.name }}-secretdef
   labels: {{ include "opendj.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-secrets
+  name: {{ .Values.global.name }}-secrets
   keysMap:
     backup-credentials:
       key: {{ required "A valid vaultSecrets.backupCredentials.key is required" .Values.vaultSecrets.backupCredentials.key }}

--- a/charts/opendj/templates/service-account.yaml
+++ b/charts/opendj/templates/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa
   labels:
     {{- include "opendj.labels" . | nindent 4 }}

--- a/charts/opendj/templates/service.yaml
+++ b/charts/opendj/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
     {{- include "opendj.labels" . | nindent 4 }}
 spec:

--- a/charts/opendj/templates/statefulset.yaml
+++ b/charts/opendj/templates/statefulset.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Values.name }}-statefulset
+  name: {{ .Values.global.name }}-statefulset
   labels:
     {{- include "opendj.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ .Values.name }}-service
+  serviceName: {{ .Values.global.name }}-service
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 3
   selector:
@@ -17,17 +17,17 @@ spec:
       labels:
         {{- include "opendj.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Values.name }}-service-sa
+      serviceAccountName: {{ .Values.global.name }}-service-sa
       volumes:
       - name: app-ctmpls
         secret:
           secretName: {{ $legacyResourcePrefix }}-app-ctmpls
       - name: checks
         configMap:
-          name: {{ .Values.name }}-checks
+          name: {{ .Values.global.name }}-checks
           defaultMode: 0744
       containers:
-      - name: {{ .Values.name }}
+      - name: {{ .Values.global.name }}
         image: {{ .Values.imageConfig.repository }}:{{  .Values.imageConfig.tag }}
         imagePullPolicy: {{ .Values.imageConfig.pullPolicy }}
         envFrom:
@@ -61,7 +61,7 @@ spec:
           successThreshold: 1
         volumeMounts:
           - mountPath: /opt/opendj/data/
-            name: {{ .Values.name }}-data
+            name: {{ .Values.global.name }}-data
           - mountPath: /var/secrets/opendj/server.p12
             name: app-ctmpls
             subPath: server.p12
@@ -98,7 +98,7 @@ spec:
       {{- end }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Values.name }}-data
+      name: {{ .Values.global.name }}-data
       labels:
         {{- include "opendj.selectorLabels" . | nindent 8 }}
       {{- if .Values.snapshot.enable }}

--- a/charts/opendj/values.yaml
+++ b/charts/opendj/values.yaml
@@ -1,9 +1,8 @@
 global:
   # global.trustedAddresses -- A map of addresses that will be merged with serviceAllowedAddresses. Example: `{ "nickname": ["x.x.x.x/y", "x.x.x.x/y"] }`
   trustedAddresses: {}
-
-# name -- A name for the deployment that will be substituted into resuorce definitions
-name: opendj
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: opendj
 
 imageConfig:
   # imageConfig.repository -- Image repository

--- a/charts/rawls/README.md
+++ b/charts/rawls/README.md
@@ -1,6 +1,6 @@
 # rawls
 
-![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Chart for Rawls service in Terra
 

--- a/charts/revere/README.md
+++ b/charts/revere/README.md
@@ -1,6 +1,6 @@
 # revere
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Revere - Terra's Status and Uptime Reporting Service
 
@@ -17,10 +17,10 @@ Chart for Revere - Terra's Status and Uptime Reporting Service
 | annotations | object | `{}` | Annotations for application pods |
 | config | object | `nil` | Required; contents of revere.yaml to be given to the application |
 | global.applicationVersion | string | `"latest"` | (string) What version of the application to deploy |
+| global.name | string | `"revere"` | A name for the deployment that will be substituted into resource definitions |
 | imageConfig.imagePullPolicy | string | `"Always"` | (string) When to pull images |
 | imageConfig.repository | string | `"us-central1-docker.pkg.dev/dsp-artifact-registry/revere/revere"` | (string) Image repository |
 | imageConfig.tag | string | `nil` | Image tag |
-| name | string | `"revere"` | A name for the deployment that will be substituted into resource definitions |
 | nodeSelector | object | `{}` | nodeSelector map for application pods |
 | probes.liveness.enabled | bool | `false` | (boolean) If the liveness probe should be enabled |
 | probes.liveness.spec | object | `nil` | Spec for the liveness probe |

--- a/charts/revere/templates/_podSpec.tpl
+++ b/charts/revere/templates/_podSpec.tpl
@@ -2,7 +2,7 @@
 Abstract common yaml between deployment.yaml and job.yaml
 */ -}}
 {{- define "revere.podSpec" -}}
-serviceAccountName: {{ .Values.name }}-sa
+serviceAccountName: {{ .Values.global.name }}-sa
 
 {{- with .Values.nodeSelector }}
 nodeSelector:
@@ -18,17 +18,17 @@ tolerations:
 {{- end }}
 
 volumes:
-- name: {{ .Values.name }}-cm
+- name: {{ .Values.global.name }}-cm
   configMap:
-    name: {{ .Values.name }}-cm
+    name: {{ .Values.global.name }}-cm
 {{- if .Values.secrets.gcpServiceAccount.secretsManager.enabled }}
-- name: {{ .Values.name }}-gcp-sa
+- name: {{ .Values.global.name }}-gcp-sa
   secret:
-    secretName: {{ .Values.name }}-gcp-sa
+    secretName: {{ .Values.global.name }}-gcp-sa
 {{- end }}
 
 containers:
-- name: {{ .Values.name }}-app
+- name: {{ .Values.global.name }}-app
   image: "{{ .Values.imageConfig.repository }}:{{ .Values.imageConfig.tag | default .Values.global.applicationVersion }}"
   imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
   resources:
@@ -38,7 +38,7 @@ containers:
   - name: REVERE_STATUSPAGE_APIKEY
     valueFrom:
       secretKeyRef:
-        name: {{ .Values.name }}-statuspage-api-key
+        name: {{ .Values.global.name }}-statuspage-api-key
         key: statuspageApiKey
   {{- if .Values.secrets.gcpServiceAccount.secretsManager.enabled }}
   - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -47,12 +47,12 @@ containers:
 
   volumeMounts:
   - mountPath: /etc/revere/revere.yaml
-    name: {{ .Values.name }}-cm
+    name: {{ .Values.global.name }}-cm
     readOnly: true
     subPath: revere.yaml
   {{- if .Values.secrets.gcpServiceAccount.secretsManager.enabled }}
   - mountPath: /etc/revere-sa/
-    name: {{ .Values.name }}-gcp-sa
+    name: {{ .Values.global.name }}-gcp-sa
     readOnly: true
   {{- end }}
 {{- end -}}

--- a/charts/revere/templates/configMap.yaml
+++ b/charts/revere/templates/configMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-cm
+  name: {{ .Values.global.name }}-cm
   labels:
     {{- include "revere.labels" . | nindent 4 }}
 data:

--- a/charts/revere/templates/deployment.yaml
+++ b/charts/revere/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
     {{- include "revere.labels" . | nindent 4 }}
   annotations:
@@ -18,15 +18,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
         {{- include "revere.labels" . | nindent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-cm: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-cm: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}

--- a/charts/revere/templates/job.yaml
+++ b/charts/revere/templates/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Values.name }}-job
+  name: {{ .Values.global.name }}-job
   labels:
     {{- include "revere.labels" . | nindent 4 }}
   annotations:
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
         {{- include "revere.labels" . | nindent 8 }}
       {{- if .Values.annotations }}
       annotations:

--- a/charts/revere/templates/psp.yaml
+++ b/charts/revere/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Values.name }}-psp
+  name: {{ .Values.global.name }}-psp
   labels:
     {{- include "revere.labels" . | nindent 4 }}
   annotations:

--- a/charts/revere/templates/role.yaml
+++ b/charts/revere/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-psp-role
+  name: {{ .Values.global.name }}-psp-role
   labels:
     {{- include "revere.labels" . | nindent 4 }}
 rules:
@@ -9,4 +9,4 @@ rules:
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
   resourceNames:
-  - {{ .Values.name }}-psp
+  - {{ .Values.global.name }}-psp

--- a/charts/revere/templates/roleBinding.yaml
+++ b/charts/revere/templates/roleBinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-psp-role-binding
+  name: {{ .Values.global.name }}-psp-role-binding
   labels:
     {{- include "revere.labels" . | nindent 4 }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-psp-role
+  name: {{ .Values.global.name }}-psp-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   namespace: {{ .Release.Namespace }}

--- a/charts/revere/templates/secretDefinition.yaml
+++ b/charts/revere/templates/secretDefinition.yaml
@@ -3,11 +3,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-gcp-sa-secretdef
+  name: {{ .Values.global.name }}-gcp-sa-secretdef
   labels:
     {{- include "revere.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-gcp-sa
+  name: {{ .Values.global.name }}-gcp-sa
   keysMap:
     serviceAccount.json:
       {{- with .Values.secrets.gcpServiceAccount.secretsManager }}
@@ -22,11 +22,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-statuspage-api-key-secretdef
+  name: {{ .Values.global.name }}-statuspage-api-key-secretdef
   labels:
     {{- include "revere.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-statuspage-api-key
+  name: {{ .Values.global.name }}-statuspage-api-key
   keysMap:
     statuspageApiKey:
       {{- with .Values.secrets.statuspageApiKey.secretsManager }}

--- a/charts/revere/templates/serviceAccount.yaml
+++ b/charts/revere/templates/serviceAccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   {{- if .Values.secrets.gcpServiceAccount.workloadIdentity.enabled }}
   annotations:
     iam.gke.io/gcp-service-account: {{ .Values.secrets.gcpServiceAccount.workloadIdentity.accountName }}@{{ .Values.secrets.gcpServiceAccount.workloadIdentity.projectId }}.iam.gserviceaccount.com

--- a/charts/revere/values.yaml
+++ b/charts/revere/values.yaml
@@ -5,9 +5,8 @@ config:
 global:
   # -- (string) What version of the application to deploy
   applicationVersion: latest
-
-# name -- A name for the deployment that will be substituted into resource definitions
-name: revere
+  # -- A name for the deployment that will be substituted into resource definitions
+  name: revere
 
 imageConfig:
   # -- (string) Image repository

--- a/charts/sam/README.md
+++ b/charts/sam/README.md
@@ -1,6 +1,6 @@
 # sam
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Sam, the Terra Identity and Access Management application
 
@@ -21,6 +21,7 @@ Chart for Sam, the Terra Identity and Access Management application
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.applicationVersion | string | `"latest"` | What version of the Sam application to deploy |
+| global.name | string | `"sam"` | A name for the deployment that will be substituted into resource definitions |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/broad-dsp-gcr-public/sam"` | Image repository |
 | imageConfig.tag | string | global.applicationVersion | Image tag. |
@@ -46,7 +47,6 @@ Chart for Sam, the Terra Identity and Access Management application
 | liquibase-migration.defaults.sqlproxyContainerConfig.envFrom[0].secretRef.name | string | `"sam-sqlproxy-env"` |  |
 | liquibase-migration.defaults.sqlproxyCredentialFileMount.secretName | string | `"sam-sqlproxy-ctmpls"` |  |
 | liquibase-migration.name | string | `"sam"` |  |
-| name | string | `"sam"` | A name for the deployment that will be substituted into resuorce definitions |
 | probes.liveness.enabled | bool | `false` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/version"` |  |

--- a/charts/sam/templates/_labels.tpl
+++ b/charts/sam/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "sam.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: {{ .Chart.Name }}
 app.kubernetes.io/part-of: terra
@@ -18,5 +18,5 @@ Selector labels
 */}}
 {{- define "sam.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 {{- end }}

--- a/charts/sam/templates/configmap.yaml
+++ b/charts/sam/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-configmap
+  name: {{ .Values.global.name }}-configmap
   labels:
     {{- include "sam.labels" . | nindent 4 }}
 data:

--- a/charts/sam/templates/deployment.yaml
+++ b/charts/sam/templates/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
     {{- include "sam.labels" . | nindent 4 }}
 spec:
@@ -23,7 +23,7 @@ spec:
         {{- include "sam.labels" . | nindent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-sa
       # Containers are configured to talk to each other by name
@@ -47,16 +47,16 @@ spec:
       - name: sqlproxy-ctmpls
         secret:
           secretName: {{ $legacyResourcePrefix }}-sqlproxy-ctmpls
-      - name: {{ .Values.name }}-gc-logs
+      - name: {{ .Values.global.name }}-gc-logs
         emptyDir: {}
-      - name: {{ .Values.name }}-proxy-security-logs
+      - name: {{ .Values.global.name }}-proxy-security-logs
         emptyDir: {}
       {{- if .Values.prometheus.enabled }}
-      - name: {{ .Values.name }}-prometheusjmx-jar
+      - name: {{ .Values.global.name }}-prometheusjmx-jar
         emptyDir: {}
       {{- end }}
       containers:
-      - name: {{ .Values.name }}-sqlproxy
+      - name: {{ .Values.global.name }}-sqlproxy
         image: broadinstitute/cloudsqlproxy:1.11_20180808
         lifecycle:
           postStart:
@@ -70,7 +70,7 @@ spec:
           subPath: sqlproxy-service-account.json
           name: sqlproxy-ctmpls
           readOnly: true
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.imageConfig.repository }}:{{ $imageTag }}"
         ports:
           - name: status
@@ -87,7 +87,7 @@ spec:
         - >-
           java ${JAVA_OPTS}
           {{- if .Values.prometheus.enabled }}
-          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ .Values.name }}-cm/prometheusJmx.yaml
+          -javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ .Values.global.name }}-cm/prometheusJmx.yaml
           {{- end }}
           -jar $(find /sam -name 'sam*.jar')
         - '--'
@@ -108,7 +108,7 @@ spec:
               fieldPath: metadata.name
         volumeMounts:
         - name: configs
-          mountPath: /etc/{{ .Values.name }}-cm
+          mountPath: /etc/{{ .Values.global.name }}-cm
           readOnly: true
         - mountPath: /etc/sam.conf
           subPath: sam.conf
@@ -127,9 +127,9 @@ spec:
           name: app-ctmpls
           readOnly: true
         - mountPath: /var/log/gc
-          name: {{ .Values.name }}-gc-logs
+          name: {{ .Values.global.name }}-gc-logs
         {{- if .Values.prometheus.enabled }}
-        - name: {{ .Values.name }}-prometheusjmx-jar
+        - name: {{ .Values.global.name }}-prometheusjmx-jar
           mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
         {{- end }}
@@ -141,7 +141,7 @@ spec:
         livenessProbe:
           {{- toYaml .Values.probes.liveness.spec | nindent 10 }}
         {{- end }}
-      - name: {{ .Values.name }}-proxy
+      - name: {{ .Values.global.name }}-proxy
         image: {{ .Values.proxyImage }}
         ports:
           - containerPort: 443
@@ -180,7 +180,7 @@ spec:
           name: proxy-ctmpls
           readOnly: true
         - mountPath: /var/log/modsecurity
-          name: {{ .Values.name }}-proxy-security-logs
+          name: {{ .Values.global.name }}-proxy-security-logs
       {{- if .Values.prometheus.enabled }}
       initContainers:
       - name: download-prometheus-jmx-jar
@@ -188,9 +188,9 @@ spec:
         command: [
           "wget",
           "-O",
-          "/{{ .Values.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
+          "/{{ .Values.global.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
         ]
         volumeMounts:
-        - name: {{ .Values.name }}-prometheusjmx-jar
-          mountPath: /{{ .Values.name }}-prometheusjmx-jar
+        - name: {{ .Values.global.name }}-prometheusjmx-jar
+          mountPath: /{{ .Values.global.name }}-prometheusjmx-jar
       {{- end }}

--- a/charts/sam/templates/ingress/backendconfig.yaml
+++ b/charts/sam/templates/ingress/backendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-backendconfig
+  name: {{ .Values.global.name }}-ingress-backendconfig
   labels:
     {{- include "sam.labels" . | nindent 4 }}
 spec:

--- a/charts/sam/templates/ingress/cert.yaml
+++ b/charts/sam/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
     {{- include "sam.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/sam/templates/ingress/frontendconfig.yaml
+++ b/charts/sam/templates/ingress/frontendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-frontendconfig
+  name: {{ .Values.global.name }}-ingress-frontendconfig
   labels:
     {{- include "sam.labels" . | nindent 4 }}
 {{- if .Values.ingress.sslPolicy }}

--- a/charts/sam/templates/ingress/ingress.yaml
+++ b/charts/sam/templates/ingress/ingress.yaml
@@ -2,11 +2,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}-ingress
+  name: {{ .Values.global.name }}-ingress
   labels:
     {{- include "sam.labels" . | nindent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.global.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.cert.preSharedCerts) }}
@@ -15,9 +15,9 @@ metadata:
 spec:
 {{- if empty .Values.ingress.cert.preSharedCerts }}
   tls:
-  - secretName: {{ .Values.name }}-cert
+  - secretName: {{ .Values.global.name }}-cert
 {{- end }}
   backend:
-    serviceName: {{ .Values.name }}-service
+    serviceName: {{ .Values.global.name }}-service
     servicePort: 443
 {{- end }}

--- a/charts/sam/templates/ingress/service.yaml
+++ b/charts/sam/templates/ingress/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
     {{- include "sam.labels" . | nindent 4 }}
   annotations:
     # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
-    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "{{ .Values.global.name }}-ingress-backendconfig"}'
     # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
     cloud.google.com/neg: '{"ingress": true}'
     # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb

--- a/charts/sam/templates/podMonitor.yaml
+++ b/charts/sam/templates/podMonitor.yaml
@@ -2,11 +2,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Values.name }}-jvm-monitor
+  name: {{ .Values.global.name }}-jvm-monitor
   labels:
     {{- include "sam.labels" . | nindent 4 }}
 spec:
-  jobLabel: {{ .Values.name }}-jvm
+  jobLabel: {{ .Values.global.name }}-jvm
   selector:
     matchLabels:
       app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/sam/templates/role.yaml
+++ b/charts/sam/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/sam/templates/roleBinding.yaml
+++ b/charts/sam/templates/roleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
@@ -9,8 +9,8 @@ metadata:
     {{- include "sam.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/sam/templates/serviceAccount.yaml
+++ b/charts/sam/templates/serviceAccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/sam/values.yaml
+++ b/charts/sam/values.yaml
@@ -1,9 +1,8 @@
 global:
   # global.applicationVersion -- What version of the Sam application to deploy
   applicationVersion: latest
-
-# name -- A name for the deployment that will be substituted into resuorce definitions
-name: sam
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: sam
 
 imageConfig:
   # imageConfig.repository -- Image repository

--- a/charts/sherlock-reporter/README.md
+++ b/charts/sherlock-reporter/README.md
@@ -1,6 +1,6 @@
 # sherlock-reporter
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Library chart to report deploy events to sherlock (Terra environment tracking service)
 

--- a/charts/sherlock/README.md
+++ b/charts/sherlock/README.md
@@ -1,6 +1,6 @@
 # sherlock
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Sherlock - DSP's environment tracking and management service
 
@@ -17,6 +17,7 @@ Chart for Sherlock - DSP's environment tracking and management service
 | annotations | object | `{}` |  |
 | config | object | `nil` | Required; contents of revere.yaml to be given to the application |
 | global.applicationVersion | string | `"latest"` | (string) What version of the application to deploy |
+| global.name | string | `"sherlock"` | (string) Name of the application being deployed to template into manifests |
 | imageConfig.imagePullPolicy | string | `"Always"` | (string) When to pull images |
 | imageConfig.repository | string | `"us-central1-docker.pkg.dev/dsp-artifact-registry/sherlock/server"` | (string) Image repository |
 | imageConfig.tag | string | `nil` | Image tag |
@@ -31,7 +32,6 @@ Chart for Sherlock - DSP's environment tracking and management service
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
-| name | string | `"sherlock"` | (string) Name of the application being deployed to template into manifests |
 | nodeSelector | object | `{}` | nodeSelector map |
 | probes.liveness.enabled | bool | `false` | (boolean) If the liveness probe should be enabled |
 | probes.liveness.spec | object | `nil` | Spec for the liveness probe |

--- a/charts/sherlock/templates/_labels.tpl
+++ b/charts/sherlock/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "sherlock.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: sherlock
 app.kubernetes.io/part-of: dsp
@@ -16,5 +16,5 @@ Selector labels
 */}}
 {{- define "sherlock.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 {{- end }}

--- a/charts/sherlock/templates/configMap.yaml
+++ b/charts/sherlock/templates/configMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-cm
+  name: {{ .Values.global.name }}-cm
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 data:

--- a/charts/sherlock/templates/deployment.yaml
+++ b/charts/sherlock/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 spec:
@@ -14,20 +14,20 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
         {{- include "sherlock.labels" . | nindent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-cm: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-cm: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}
     spec:
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -42,12 +42,12 @@ spec:
       {{- end }}
       
       volumes:
-      - name: {{ .Values.name }}-cm
+      - name: {{ .Values.global.name }}-cm
         configMap:
-          name: {{ .Values.name }}-cm
+          name: {{ .Values.global.name }}-cm
 
       containers:
-      - name: {{ .Values.name }}-sqlproxy
+      - name: {{ .Values.global.name }}-sqlproxy
         image: "gcr.io/cloudsql-docker/gce-proxy:{{ .Values.sqlproxy.version }}"
         lifecycle:
           postStart:
@@ -57,17 +57,17 @@ spec:
         - name: SQL_INSTANCE_PROJECT
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: project
         - name: SQL_INSTANCE_REGION
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: region
         - name: SQL_INSTANCE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: name
         command: ["/cloud_sql_proxy",
                   "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432"]
@@ -75,7 +75,7 @@ spec:
           runAsUser: 2  # non-root user
           allowPrivilegeEscalation: false
 
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.imageConfig.repository }}:{{ .Values.imageConfig.tag | default .Values.global.applicationVersion }}"
         imagePullPolicy: {{ .Values.imageConfig.imagePullPolicy }}
         ports:
@@ -89,22 +89,22 @@ spec:
         - name: SHERLOCK_DBUSER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: username
         - name: SHERLOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: password
         - name: SHERLOCK_DBNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: db
 
         volumeMounts:
         - mountPath: /etc/sherlock/sherlock.yaml
-          name: {{ .Values.name }}-cm
+          name: {{ .Values.global.name }}-cm
           readOnly: true
           subPath: sherlock.yaml
 

--- a/charts/sherlock/templates/ingress/backendConfig.yaml
+++ b/charts/sherlock/templates/ingress/backendConfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-backendconfig
+  name: {{ .Values.global.name }}-ingress-backendconfig
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 spec:
@@ -23,6 +23,6 @@ spec:
   iap:
     enabled: true
     oauthclientCredentials:
-      secretName: {{ .Values.name }}-iap-credentials
+      secretName: {{ .Values.global.name }}-iap-credentials
 {{- end }}
 {{- end }}

--- a/charts/sherlock/templates/ingress/cert.yaml
+++ b/charts/sherlock/templates/ingress/cert.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: {{ .Values.name }}-certificate
+  name: {{ .Values.global.name }}-certificate
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 spec:

--- a/charts/sherlock/templates/ingress/frontendConfig.yaml
+++ b/charts/sherlock/templates/ingress/frontendConfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-frontendconfig
+  name: {{ .Values.global.name }}-ingress-frontendconfig
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 {{- if .Values.ingress.sslPolicy }}

--- a/charts/sherlock/templates/ingress/ingress.yaml
+++ b/charts/sherlock/templates/ingress/ingress.yaml
@@ -2,11 +2,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}-ingress
+  name: {{ .Values.global.name }}-ingress
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.global.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.cert.preSharedCerts) }}
@@ -15,9 +15,9 @@ metadata:
 spec:
 {{- if empty .Values.ingress.cert.preSharedCerts }}
   tls:
-  - secretName: {{ .Values.name }}-cert
+  - secretName: {{ .Values.global.name }}-cert
 {{- end }}
   backend:
-    serviceName: {{ .Values.name }}-service
+    serviceName: {{ .Values.global.name }}-service
     servicePort: 80
 {{- end }}

--- a/charts/sherlock/templates/ingress/service.yaml
+++ b/charts/sherlock/templates/ingress/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
   annotations:
     # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
-    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "{{ .Values.global.name }}-ingress-backendconfig"}'
     # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
     cloud.google.com/neg: '{"ingress": true}'
     # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb

--- a/charts/sherlock/templates/psp.yaml
+++ b/charts/sherlock/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Values.name }}-psp
+  name: {{ .Values.global.name }}-psp
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
   annotations:

--- a/charts/sherlock/templates/role.yaml
+++ b/charts/sherlock/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-psp-role
+  name: {{ .Values.global.name }}-psp-role
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 rules:
@@ -9,4 +9,4 @@ rules:
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
   resourceNames:
-  - {{ .Values.name }}-psp
+  - {{ .Values.global.name }}-psp

--- a/charts/sherlock/templates/rolebinding.yaml
+++ b/charts/sherlock/templates/rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-psp-role-binding
+  name: {{ .Values.global.name }}-psp-role-binding
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-psp-role
+  name: {{ .Values.global.name }}-psp-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   namespace: {{ .Release.Namespace }}

--- a/charts/sherlock/templates/secretDefinition.yaml
+++ b/charts/sherlock/templates/secretDefinition.yaml
@@ -2,11 +2,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   keysMap:
     db:
       path: {{ .Values.vault.pathPrefix }}/postgres/sherlock-db-creds
@@ -21,11 +21,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-instance
+  name: {{ .Values.global.name }}-postgres-instance
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-cloudsql-postgres-instance
+  name: {{ .Values.global.name }}-cloudsql-postgres-instance
   keysMap:
     project:
       path: {{ .Values.vault.pathPrefix }}/postgres/instance
@@ -40,11 +40,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-iap-credentials
+  name: {{ .Values.global.name }}-iap-credentials
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
 spec:
-  name: {{ .Values.name }}-iap-credentials
+  name: {{ .Values.global.name }}-iap-credentials
   keysMap:
     client_id:
       path: {{ .Values.vault.pathPrefix }}/iap

--- a/charts/sherlock/templates/serviceAccount.yaml
+++ b/charts/sherlock/templates/serviceAccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   {{- if .Values.secrets.gcpServiceAccount.workloadIdentity.enabled }}
   annotations:
     iam.gke.io/gcp-service-account: {{ .Values.secrets.gcpServiceAccount.workloadIdentity.accountName }}@{{ .Values.secrets.gcpServiceAccount.workloadIdentity.projectID }}.iam.gserviceaccount.com

--- a/charts/sherlock/templates/serviceMonitor.yaml
+++ b/charts/sherlock/templates/serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ include "sherlock.labels" . | nindent 4 }}
     release: terra-prometheus
 spec:
-  jobLabel: {{ .Values.name }}
+  jobLabel: {{ .Values.global.name }}
   selector:
     matchLabels:
       app.kubernetes.io/component: sherlock

--- a/charts/sherlock/values.yaml
+++ b/charts/sherlock/values.yaml
@@ -5,6 +5,8 @@ config:
 global:
   # -- (string) What version of the application to deploy
   applicationVersion: latest
+  # -- (string) Name of the application being deployed to template into manifests
+  name: sherlock
 
 imageConfig:
   # -- (string) Image repository
@@ -76,9 +78,7 @@ vault:
   enabled: true
   # -- (string) base path in vault containing sherlock's secrets
   pathPrefix: ""
-  
-# -- (string) Name of the application being deployed to template into manifests
-name: sherlock
+
 # -- (number) Number of sherlock pods to run
 replicas: 1
 # -- (string) Length of sleep to account for sqlproxy startup

--- a/charts/terra-ap-prometheus-operator/templates/_helpers.tpl
+++ b/charts/terra-ap-prometheus-operator/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 {{/* Expand the name of the chart. This is suffixed with -alertmanager, which means subtract 13 from longest 63 available */}}
 {{- define "prometheus-operator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 50 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*
@@ -15,7 +15,7 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 26 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.global.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 26 | trimSuffix "-" -}}
 {{- else -}}

--- a/charts/terra-argocd-app/README.md
+++ b/charts/terra-argocd-app/README.md
@@ -1,6 +1,6 @@
 # terra-argocd-app
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for generating ArgoCD applications for Terra services
 

--- a/charts/terra-argocd-app/templates/app.yaml
+++ b/charts/terra-argocd-app/templates/app.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   project: {{ required "A valid projectName is required" .Values.projectName | quote }}
   destination:
-    namespace: {{ required "A valid namespace is required" .Values.namespace | quote }}
+    namespace: {{ required "A valid namespace is required" .Values.global.namespace | quote }}
     server: {{ required "A valid clusterAddress is required" .Values.clusterAddress | quote }}
   source:
     repoURL: {{ .Values.helmfileRepo | quote }}

--- a/charts/terra-argocd-app/templates/cluster.yaml
+++ b/charts/terra-argocd-app/templates/cluster.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   project: {{ required "A valid projectName is required" .Values.projectName | quote }}
   destination:
-    namespace: {{ required "A valid namespace is required" .Values.namespace | quote }}
+    namespace: {{ required "A valid namespace is required" .Values.global.namespace | quote }}
     server: {{ required "A valid clusterAddress is required" .Values.clusterAddress | quote }}
   source:
     repoURL: {{ .Values.helmfileRepo | quote }}

--- a/charts/terra-argocd-app/templates/legacy-configs-app.yaml
+++ b/charts/terra-argocd-app/templates/legacy-configs-app.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   project: {{ required "projectName is required" .Values.projectName | quote }}
   destination:
-    namespace: {{ required "namespace is required" .Values.namespace | quote }}
+    namespace: {{ required "namespace is required" .Values.global.namespace | quote }}
     server: {{ required "clusterAddress is required" .Values.clusterAddress | quote }}
   source:
     repoURL: {{ required "legacyConfigsRepo is required" .Values.legacyConfigsRepo | quote }}

--- a/charts/terra-argocd-project/README.md
+++ b/charts/terra-argocd-project/README.md
@@ -1,6 +1,6 @@
 # terra-argocd-project
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for generating Terra ArgoCD projects
 

--- a/charts/terra-cluster-networking/README.md
+++ b/charts/terra-cluster-networking/README.md
@@ -1,6 +1,6 @@
 # terra-cluster-networking
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to configure cluster-wide networking for Terra clusters
 

--- a/charts/terra-cluster-networking/templates/_helpers.tpl
+++ b/charts/terra-cluster-networking/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "terra-cluster-networking.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 56 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/terra-cluster-networking/templates/istio-gateway.yaml
+++ b/charts/terra-cluster-networking/templates/istio-gateway.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: {{ .Values.gateway.name }}
-  namespace: {{ .Values.namespaces.istio }}
+  namespace: {{ .Values.global.namespaces.istio }}
   labels:
     name: istiogateway
     helm.sh/chart: {{ template "terra-cluster-networking.chart" . }}

--- a/charts/terra-cluster-psps/README.md
+++ b/charts/terra-cluster-psps/README.md
@@ -1,6 +1,6 @@
 # terra-cluster-psps
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to deploy terra kernel pod security policies
 

--- a/charts/terra-cluster-psps/templates/_helpers.tpl
+++ b/charts/terra-cluster-psps/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "terra-cluster-psps.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 56 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 56 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/terra-cluster-psps/templates/istio.yaml
+++ b/charts/terra-cluster-psps/templates/istio.yaml
@@ -30,7 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: istio-clusterrole
-  namespace: {{ .Values.namespaces.istio }}
+  namespace: {{ .Values.global.namespaces.istio }}
   labels:
     name: clusterrole
     helm.sh/chart: {{ template "terra-cluster-psps.chart" . }}
@@ -47,7 +47,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: istio-rolebinding
-  namespace: {{ .Values.namespaces.istio }}
+  namespace: {{ .Values.global.namespaces.istio }}
   labels:
     name: clusterrolebinding
     helm.sh/chart: {{ template "terra-cluster-psps.chart" . }}
@@ -63,5 +63,5 @@ subjects:
   {{- range .Values.serviceAccounts.istio }}
   - kind: ServiceAccount
     name: {{ . }}
-    namespace: {{ $root.Values.namespaces.istio }}
+    namespace: {{ $root.Values.global.namespaces.istio }}
   {{- end }}

--- a/charts/terra-prometheus/README.md
+++ b/charts/terra-prometheus/README.md
@@ -1,6 +1,6 @@
 # terra-prometheus
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 a helm chart to deploy monitoring infrastructure
 

--- a/charts/terra-prometheus/templates/alertmanager-conf.yaml
+++ b/charts/terra-prometheus/templates/alertmanager-conf.yaml
@@ -2,8 +2,8 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   name: secretdefinition-{{ .Chart.Name }}-alertmanager-config
-  {{- if ne .Values.namespaceOverride "" }}
-  namespace: {{ .Values.namespaceOverride }}
+  {{- if ne .Values.global.namespaceOverride "" }}
+  namespace: {{ .Values.global.namespaceOverride }}
   {{- end }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 spec:

--- a/charts/terra-prometheus/templates/cloud-armor.yaml
+++ b/charts/terra-prometheus/templates/cloud-armor.yaml
@@ -2,8 +2,8 @@ apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: prometheus-cloud-armor
-  {{- if ne .Values.namespaceOverride "" }}
-  namespace: {{ .Values.namespaceOverride }}
+  {{- if ne .Values.global.namespaceOverride "" }}
+  namespace: {{ .Values.global.namespaceOverride }}
   {{- end }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 spec:

--- a/charts/terra-prometheus/templates/prometheusToSD/deployment.yaml
+++ b/charts/terra-prometheus/templates/prometheusToSD/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-to-sd-deployment
-  namespace: {{ .Values.namespaceOverride }}
+  namespace: {{ .Values.global.namespaceOverride }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.prometheusToSD.replicaCount }}

--- a/charts/terra-prometheus/templates/prometheusToSD/role.yaml
+++ b/charts/terra-prometheus/templates/prometheusToSD/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-to-sd-role
-  namespace: {{ .Values.namespaceOverride }}
+  namespace: {{ .Values.global.namespaceOverride }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']

--- a/charts/terra-prometheus/templates/prometheusToSD/roleBinding.yaml
+++ b/charts/terra-prometheus/templates/prometheusToSD/roleBinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-to-sd-sa-binding
-  namespace: {{ .Values.namespaceOverride }}
+  namespace: {{ .Values.global.namespaceOverride }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount

--- a/charts/terra-prometheus/templates/prometheusToSD/serviceAccount.yaml
+++ b/charts/terra-prometheus/templates/prometheusToSD/serviceAccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-to-sd-sa
-  namespace: {{ .Values.namespaceOverride }}
+  namespace: {{ .Values.global.namespaceOverride }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}

--- a/charts/terra-prometheus/templates/rules/appRules.yaml
+++ b/charts/terra-prometheus/templates/rules/appRules.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ .Chart.Name }}-app-rules
-  namespace: {{ .Values.namespaceOverride}}
+  namespace: {{ .Values.global.namespaceOverride}}
   labels:
     app: {{ .Values.prometheusRuleSelector}}
 spec:

--- a/charts/terra-prometheus/templates/rules/k8sSystemApiServer.yaml
+++ b/charts/terra-prometheus/templates/rules/k8sSystemApiServer.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ .Chart.Name }}-system-apiserver-rules
-  namespace: {{ .Values.namespaceOverride }}
+  namespace: {{ .Values.global.namespaceOverride }}
   labels:
     app: {{ .Values.prometheusRuleSelector }}
 spec:

--- a/charts/terra-prometheus/templates/rules/k8sSystemKubelet.yaml
+++ b/charts/terra-prometheus/templates/rules/k8sSystemKubelet.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ .Chart.Name}}-system-kubelet-rules
-  namespace: {{ .Values.namespaceOverride }}
+  namespace: {{ .Values.global.namespaceOverride }}
   labels:
     app: {{ .Values.prometheusRuleSelector }}
 spec:

--- a/charts/terra-prometheus/templates/tls.yaml
+++ b/charts/terra-prometheus/templates/tls.yaml
@@ -4,8 +4,8 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: {{ .Chart.Name }}-cert
-  {{- if ne .Values.namespaceOverride "" }}
-  namespace: {{ .Values.namespaceOverride }}
+  {{- if ne .Values.global.namespaceOverride "" }}
+  namespace: {{ .Values.global.namespaceOverride }}
   {{- end }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 spec:
@@ -21,8 +21,8 @@ apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
   name: secretdefinition-{{ .Chart.Name }}-cert
-  {{- if ne .Values.namespaceOverride "" }}
-  namespace: {{ .Values.namespaceOverride }}
+  {{- if ne .Values.global.namespaceOverride "" }}
+  namespace: {{ .Values.global.namespaceOverride }}
   {{- end }}
   labels: {{ include "prometheus.labels" . | nindent 4 }}
 spec:

--- a/charts/testrunnerdashboard/README.md
+++ b/charts/testrunnerdashboard/README.md
@@ -1,6 +1,6 @@
 # trdash
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for TestRunner Dashbaord
 
@@ -23,6 +23,7 @@ Chart for TestRunner Dashbaord
 | config | object | `nil` | Required; contents of testrunnerdashboard.yaml to be given to the application |
 | createReleaseNamespace | bool | `false` | Emulate current Helm3 chart functionality, i.e., do not create the release namespace by default |
 | global.applicationVersion | string | `"latest"` | (string) What version of the application to deploy |
+| global.name | string | `"trdash"` | A name for the deployment that will be substituted into resource definitions |
 | imageConfig.imagePullPolicy | string | `"Always"` | (string) When to pull images |
 | imageConfig.repository | string | `"us-central1-docker.pkg.dev/dsp-artifact-registry/terra-test-runner-dashboard/terra-test-runner-dashboard"` | (string) Image repository |
 | imageConfig.tag | string | `nil` | Image tag |
@@ -49,7 +50,6 @@ Chart for TestRunner Dashbaord
 | ingress.sslPolicy | string | `nil` | Name of a GCP SSL policy to associate with the Ingress |
 | ingress.staticIpName | string | `nil` | Required. Name of the static IP, allocated in GCP, to associate with the Ingress |
 | ingress.timeoutSec | int | `120` |  |
-| name | string | `"trdash"` | A name for the deployment that will be substituted into resource definitions |
 | probes.liveness.enabled | bool | `false` | (boolean) If the liveness probe should be enabled |
 | probes.liveness.spec | object | `nil` | Spec for the liveness probe |
 | probes.readiness.enabled | bool | `false` | (boolean) If the readiness probe should be enabled |

--- a/charts/testrunnerdashboard/templates/_labels.tpl
+++ b/charts/testrunnerdashboard/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "testrunnerdashboard.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: testrunnerdashboard
 app.kubernetes.io/part-of: tools

--- a/charts/testrunnerdashboard/templates/workloadidentity.yaml
+++ b/charts/testrunnerdashboard/templates/workloadidentity.yaml
@@ -18,7 +18,7 @@ metadata:
   name: {{ .Chart.Name }}-iampolicy-member
   labels: {{ include "testrunnerdashboard.labels" . | nindent 4 }}
 spec:
-  member: serviceAccount:{{ .Values.secrets.gcpServiceAccount.workloadIdentity.projectId }}.svc.id.goog[{{ .Release.Namespace }}/{{ .Values.name }}-sa]
+  member: serviceAccount:{{ .Values.secrets.gcpServiceAccount.workloadIdentity.projectId }}.svc.id.goog[{{ .Release.Namespace }}/{{ .Values.global.name }}-sa]
   role: roles/iam.workloadIdentityUser
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1

--- a/charts/testrunnerdashboard/values.yaml
+++ b/charts/testrunnerdashboard/values.yaml
@@ -5,12 +5,12 @@ config:
 global:
   # -- (string) What version of the application to deploy
   applicationVersion: latest
+  # -- A name for the deployment that will be substituted into resource definitions
+  name: trdash
 
 # createReleaseNamespace -- Emulate current Helm3 chart functionality, i.e., do not create the release namespace by default
 createReleaseNamespace: false
 
-# name -- A name for the deployment that will be substituted into resource definitions
-name: trdash
 
 # Settings for TestRunner Dashboard's Ingress & Service
 ingress:

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # thanos
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 
 Chart for deploying Thanos metrics system in dsp infrastructure
 
@@ -19,6 +19,7 @@ Chart for deploying Thanos metrics system in dsp infrastructure
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.name | string | `"thanos"` | A name for the deployment that will be substituted into resource definitions |
 | ingress.cert.preSharedCerts | list | `[]` | list of existing certificates in google to associate with the ingress |
 | ingress.certmanager.enabled | bool | `true` | whether to use certmanager to provision a lets encrypt cert for the ingress |
 | ingress.domain.hostname | string | `"thanos"` | hostname to access thanos server |
@@ -29,7 +30,6 @@ Chart for deploying Thanos metrics system in dsp infrastructure
 | ingress.sslPolicy | string | `nil` | policy to restrict the tls versions or ciphers that can be used with thanos |
 | ingress.staticIpName | string | `nil` | name of the global static ip to associate with the ingress |
 | ingress.timeoutSec | int | `120` | timeout for the ingress loadbalancer health check |
-| name | string | `"thanos"` |  |
 | thanos-local.fullnameOverride | string | `"thanos-local"` |  |
 | thanos-local.metrics.enabled | bool | `true` |  |
 | thanos-local.query.dnsDiscovery.enabled | bool | `false` | whether to have the query attempt to automatically discover thanos sidecars |

--- a/charts/thanos/templates/_labels.tpl
+++ b/charts/thanos/templates/_labels.tpl
@@ -5,9 +5,9 @@ See
 https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 */ -}}
 {{- define "thanos.labels" -}}
-helm.sh/chart: "{{ .Values.name }}-{{ .Chart.Version }}"
-app.kubernetes.io/name: {{ .Values.name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+helm.sh/chart: "{{ .Values.global.name }}-{{ .Chart.Version }}"
+app.kubernetes.io/name: {{ .Values.global.name }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: thanos
 app.kubernetes.io/part-of: dsp-tools

--- a/charts/thanos/templates/ingress/backendConfig.yaml
+++ b/charts/thanos/templates/ingress/backendConfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-backendconfig
+  name: {{ .Values.global.name }}-ingress-backendconfig
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
 spec:
@@ -23,6 +23,6 @@ spec:
   iap:
     enabled: true
     oauthclientCredentials:
-      secretName: {{ .Values.name }}-iap-credentials
+      secretName: {{ .Values.global.name }}-iap-credentials
 {{- end }}
 {{- end }}

--- a/charts/thanos/templates/ingress/cert.yaml
+++ b/charts/thanos/templates/ingress/cert.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
-  name: {{ .Values.name }}-certificate
+  name: {{ .Values.global.name }}-certificate
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
 spec:
@@ -14,7 +14,7 @@ spec:
     kind: ClusterIssuer
     name: letsencrypt-prod
   renewBefore: 720h0m0s
-  secretName: {{ .Values.name }}-cert
+  secretName: {{ .Values.global.name }}-cert
   subject:
     organizations:
     - broad-institute

--- a/charts/thanos/templates/ingress/frontendConfig.yaml
+++ b/charts/thanos/templates/ingress/frontendConfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-frontendconfig
+  name: {{ .Values.global.name }}-ingress-frontendconfig
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
 {{- if .Values.ingress.sslPolicy }}

--- a/charts/thanos/templates/ingress/ingress.yaml
+++ b/charts/thanos/templates/ingress/ingress.yaml
@@ -2,11 +2,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}-ingress
+  name: {{ .Values.global.name }}-ingress
   labels:
     {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.global.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.cert.preSharedCerts) }}
@@ -15,9 +15,9 @@ metadata:
 spec:
 {{- if empty .Values.ingress.cert.preSharedCerts }}
   tls:
-  - secretName: {{ .Values.name }}-cert
+  - secretName: {{ .Values.global.name }}-cert
 {{- end }}
   backend:
-    serviceName: {{ .Values.name }}-local-query
+    serviceName: {{ .Values.global.name }}-local-query
     servicePort: 9090
 {{- end }}

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -1,4 +1,7 @@
-name: thanos
+global:
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: thanos
+
 ingress:
   # ingress.enabled -- Whether to create ingress and associated resources for thanos query
   enabled: true

--- a/charts/thurloe/README.md
+++ b/charts/thurloe/README.md
@@ -15,6 +15,7 @@ Chart for Thurloe service in Terra
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.applicationVersion | string | `"latest"` | What version of the Thurloe application to deploy |
+| global.name | string | `"thurloe"` |  |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
 | imageConfig.repository | string | `"gcr.io/broad-dsp-gcr-public/thurloe"` | Image repository |
 | imageConfig.tag | string | global.applicationVersion | Image tag. |
@@ -37,7 +38,6 @@ Chart for Thurloe service in Terra
 | liquibase-migration.defaults.migrationImage | string | `"gcr.io/broad-dsp-gcr-public/thurloe"` |  |
 | liquibase-migration.defaults.sqlproxyContainerConfig.envFrom[0].secretRef.name | string | `"thurloe-sqlproxy-env"` |  |
 | liquibase-migration.defaults.sqlproxyCredentialFileMount.secretName | string | `"thurloe-sqlproxy-ctmpls"` |  |
-| name | string | `"thurloe"` |  |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/status"` |  |

--- a/charts/thurloe/templates/deployment.yaml
+++ b/charts/thurloe/templates/deployment.yaml
@@ -1,9 +1,9 @@
 {{- $imageTag := .Values.imageConfig.tag | default .Values.global.applicationVersion -}}
-{{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Values.name -}}
+{{- $legacyResourcePrefix := .Values.legacyResourcePrefix | default .Values.global.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
 {{ include "thurloe.labels" . | indent 4 }}
 spec:
@@ -16,17 +16,17 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
 {{ include "thurloe.labels" . | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map change: */}}
-        checksum/{{ .Values.name }}-configmap: {{ include (print $.Template.BasePath "/config/configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-configmap: {{ include (print $.Template.BasePath "/config/configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Values.name }}-sa
+      serviceAccountName: {{ .Values.global.name }}-sa
       # Containers are configured to talk to each other by name
       # via docker-compose links; make corresponding aliases
       # to loopback in /etc/hosts
@@ -36,9 +36,9 @@ spec:
         - app
         - sqlproxy
       volumes:
-      - name: {{ .Values.name }}-cm
+      - name: {{ .Values.global.name }}-cm
         configMap:
-          name: {{ .Values.name }}-cm
+          name: {{ .Values.global.name }}-cm
       - name: app-ctmpls
         secret:
           secretName: {{ $legacyResourcePrefix }}-app-ctmpls
@@ -48,14 +48,14 @@ spec:
       - name: sqlproxy-ctmpls
         secret:
           secretName: {{ $legacyResourcePrefix }}-sqlproxy-ctmpls
-      - name: {{ .Values.name }}-gc-logs
+      - name: {{ .Values.global.name }}-gc-logs
         emptyDir: {}
-      - name: {{ .Values.name }}-proxy-security-logs
+      - name: {{ .Values.global.name }}-proxy-security-logs
         emptyDir: {}
-      - name: {{ .Values.name }}-prometheusjmx-jar
+      - name: {{ .Values.global.name }}-prometheusjmx-jar
         emptyDir: {}
       containers:
-      - name: {{ .Values.name }}-sqlproxy
+      - name: {{ .Values.global.name }}-sqlproxy
         image: broadinstitute/cloudsqlproxy:1.11_20180808
         envFrom:
         - secretRef:
@@ -69,7 +69,7 @@ spec:
           subPath: sqlproxy-service-account.json
           name: sqlproxy-ctmpls
           readOnly: true
-      - name: {{ .Values.name }}-app
+      - name: {{ .Values.global.name }}-app
         image: "{{ .Values.imageConfig.repository }}:{{ $imageTag }}"
         ports:
         - name: app
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.name
         {{- if .Values.prometheus.enabled }}
         - name: PROMETHEUS_ARGS
-          value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ .Values.name }}-cm/prometheusJmx.yaml"
+          value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ .Values.global.name }}-cm/prometheusJmx.yaml"
         {{- end }}
         command: ["/bin/bash"]
         args:
@@ -108,8 +108,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/{{ .Values.name }}-cm
-          name: {{ .Values.name }}-cm
+        - mountPath: /etc/{{ .Values.global.name }}-cm
+          name: {{ .Values.global.name }}-cm
           readOnly: true
         - mountPath: /etc/thurloe.conf
           subPath: thurloe.conf
@@ -120,10 +120,10 @@ spec:
           name: app-ctmpls
           readOnly: true
         - mountPath: /var/log/gc
-          name: {{ .Values.name }}-gc-logs
+          name: {{ .Values.global.name }}-gc-logs
         - mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
-          name: {{ .Values.name }}-prometheusjmx-jar
+          name: {{ .Values.global.name }}-prometheusjmx-jar
           readOnly: true
         {{- if .Values.probes.readiness.enabled }}
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         startupProbe:
           {{- toYaml .Values.probes.startup.spec | nindent 10 }}
         {{- end }}
-      - name: {{ .Values.name }}-proxy
+      - name: {{ .Values.global.name }}-proxy
         image: {{ .Values.proxyImage }}
         ports:
           - containerPort: 443
@@ -172,7 +172,7 @@ spec:
           name: proxy-ctmpls
           readOnly: true
         - mountPath: /var/log/modsecurity
-          name: {{ .Values.name }}-proxy-security-logs
+          name: {{ .Values.global.name }}-proxy-security-logs
       {{- if .Values.prometheus.enabled }}
       initContainers:
       - name: download-prometheus-jmx-jar
@@ -180,9 +180,9 @@ spec:
         command: [
           "wget",
           "-O",
-          "/{{ .Values.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
+          "/{{ .Values.global.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
         ]
         volumeMounts:
-        - name: {{ .Values.name }}-prometheusjmx-jar
-          mountPath: /{{ .Values.name }}-prometheusjmx-jar
+        - name: {{ .Values.global.name }}-prometheusjmx-jar
+          mountPath: /{{ .Values.global.name }}-prometheusjmx-jar
       {{- end }}

--- a/charts/thurloe/templates/ingress/backendconfig.yaml
+++ b/charts/thurloe/templates/ingress/backendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-backendconfig
+  name: {{ .Values.global.name }}-ingress-backendconfig
   labels:
 {{ include "thurloe.labels" . | indent 4 }}
 spec:

--- a/charts/thurloe/templates/ingress/cert.yaml
+++ b/charts/thurloe/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
 {{ include "thurloe.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/thurloe/templates/ingress/frontendconfig.yaml
+++ b/charts/thurloe/templates/ingress/frontendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-frontendconfig
+  name: {{ .Values.global.name }}-ingress-frontendconfig
   labels:
 {{ include "thurloe.labels" . | indent 4 }}
 spec:

--- a/charts/thurloe/templates/ingress/ingress.yaml
+++ b/charts/thurloe/templates/ingress/ingress.yaml
@@ -2,11 +2,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}-ingress
+  name: {{ .Values.global.name }}-ingress
   labels:
 {{ include "thurloe.labels" . | indent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.global.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.preSharedCerts) }}
@@ -15,9 +15,9 @@ metadata:
 spec:
 {{- if empty .Values.ingress.preSharedCerts }}
   tls:
-  - secretName: {{ .Values.name }}-cert
+  - secretName: {{ .Values.global.name }}-cert
 {{- end }}
   backend:
-    serviceName: {{ .Values.name }}-service
+    serviceName: {{ .Values.global.name }}-service
     servicePort: 443
 {{- end }}

--- a/charts/thurloe/templates/ingress/service.yaml
+++ b/charts/thurloe/templates/ingress/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
 {{ include "thurloe.labels" . | indent 4 }}
   annotations:
     # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
-    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "{{ .Values.global.name }}-ingress-backendconfig"}'
     # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
     cloud.google.com/neg: '{"ingress": true}'
     # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    deployment: {{ .Values.name }}-deployment
+    deployment: {{ .Values.global.name }}-deployment
   ports:
   - name: https
     protocol: TCP

--- a/charts/thurloe/templates/role.yaml
+++ b/charts/thurloe/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/thurloe/templates/roleBinding.yaml
+++ b/charts/thurloe/templates/roleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-sa-binding
+  name: {{ .Values.global.name }}-sa-binding
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
@@ -9,8 +9,8 @@ metadata:
 {{ include "thurloe.labels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-role
+  name: {{ .Values.global.name }}-role
   apiGroup: rbac.authorization.k8s.io

--- a/charts/thurloe/templates/serviceAccount.yaml
+++ b/charts/thurloe/templates/serviceAccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sa
+  name: {{ .Values.global.name }}-sa
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/thurloe/values.yaml
+++ b/charts/thurloe/values.yaml
@@ -1,8 +1,7 @@
 global:
   # global.applicationVersion -- What version of the Thurloe application to deploy
   applicationVersion: latest
-
-name: thurloe
+  name: thurloe
 
 ingress:
   # ingress.enabled -- Whether to create Ingress, Service and associated config resources

--- a/charts/workspacemanager/README.md
+++ b/charts/workspacemanager/README.md
@@ -22,6 +22,7 @@ Chart for Terra Workspace Manager
 | cloudTraceEnabled | bool | `true` | Whether to enable gcp cloud trace |
 | env | object | `{}` |  |
 | global.applicationVersion | string | `"latest"` | What version of the application to deploy |
+| global.name | string | `"workspacemanager"` | A name for the deployment that will be substituted into resource definitions |
 | global.terraEnv | string | Is set by Helmfile on deploy | Terget Terra environment name. Required. |
 | image | string | Is set by Skaffold on local deploys | Used for local Skaffold deploys |
 | imageConfig.imagePullPolicy | string | `"Always"` |  |
@@ -77,8 +78,6 @@ Chart for Terra Workspace Manager
 | liquibase-migration.migrationJobs[1].migrationArgsConfigChangelog | string | `"stairway/db/changelog.xml"` |  |
 | liquibase-migration.migrationJobs[1].migrationDatabaseCredentials.fromKubernetesSecret.name | string | `"workspacemanager-stairway-db-creds"` |  |
 | liquibase-migration.migrationJobs[1].name | string | `"workspacemanager-stairway"` |  |
-| liquibase-migration.name | string | `"workspacemanager"` |  |
-| name | string | `"workspacemanager"` | A name for the deployment that will be substituted into resuorce definitions |
 | probes.liveness.enabled | bool | `true` |  |
 | probes.liveness.spec.failureThreshold | int | `30` |  |
 | probes.liveness.spec.httpGet.path | string | `"/version"` |  |

--- a/charts/workspacemanager/templates/_labels.tpl
+++ b/charts/workspacemanager/templates/_labels.tpl
@@ -7,7 +7,7 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 {{- define "workspacemanager.labels" -}}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Values.global.name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/component: workspacemanager
 app.kubernetes.io/part-of: terra

--- a/charts/workspacemanager/templates/configmaps/prometheus-configmap.yaml
+++ b/charts/workspacemanager/templates/configmaps/prometheus-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-prometheus-configmap
+  name: {{ .Values.global.name }}-prometheus-configmap
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 data:

--- a/charts/workspacemanager/templates/configmaps/proxy-apache-httpd-configmap.yaml
+++ b/charts/workspacemanager/templates/configmaps/proxy-apache-httpd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-proxy-configmap
+  name: {{ .Values.global.name }}-proxy-configmap
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 data:

--- a/charts/workspacemanager/templates/configmaps/tcell_configmap.yaml
+++ b/charts/workspacemanager/templates/configmaps/tcell_configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-tcell-configmap
+  name: {{ .Values.global.name }}-tcell-configmap
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 data:

--- a/charts/workspacemanager/templates/deployment.yaml
+++ b/charts/workspacemanager/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-deployment
+  name: {{ .Values.global.name }}-deployment
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
   {{- if and .Values.proxy.enabled .Values.proxy.reloadOnCertUpdate }}
@@ -19,55 +19,55 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
   template:
     metadata:
       labels:
-        deployment: {{ .Values.name }}-deployment
+        deployment: {{ .Values.global.name }}-deployment
 {{ include "workspacemanager.labels" . | indent 8 }}
       annotations:
         {{- /* Automatically restart deployments on config map changes: */}}
-        checksum/{{ .Values.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") . | sha256sum }}
-        checksum/{{ .Values.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/tcell_configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-proxy-configmap: {{ include (print $.Template.BasePath "/configmaps/proxy-apache-httpd-configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-tcell-configmap: {{ include (print $.Template.BasePath "/configmaps/tcell_configmap.yaml") . | sha256sum }}
         {{- if .Values.prometheus.enabled }}
-        checksum/{{ .Values.name }}-prometheus-configmap: {{ include (print $.Template.BasePath "/configmaps/prometheus-configmap.yaml") . | sha256sum }}
+        checksum/{{ .Values.global.name }}-prometheus-configmap: {{ include (print $.Template.BasePath "/configmaps/prometheus-configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}
     spec:
-      serviceAccountName: {{ .Values.name }}-service-sa
+      serviceAccountName: {{ .Values.global.name }}-service-sa
       volumes:
       - name: cloudsql-sa-creds
         secret:
-          secretName: {{ .Values.name }}-sqlproxy-sa
+          secretName: {{ .Values.global.name }}-sqlproxy-sa
       - name: app-sa-creds
         secret:
-          secretName: {{ .Values.name }}-app-sa
+          secretName: {{ .Values.global.name }}-app-sa
       {{- if .Values.proxy.enabled }}
       - name: apache-httpd-proxy-config
         configMap:
-          name: {{ .Values.name }}-proxy-configmap
+          name: {{ .Values.global.name }}-proxy-configmap
           items:
           - key: apache-httpd-proxy-config
-            path: {{ .Values.name }}-proxy.conf
+            path: {{ .Values.global.name }}-proxy.conf
       - name: cert
         secret:
-          secretName: {{ .Values.name }}-cert
+          secretName: {{ .Values.global.name }}-cert
       {{- if .Values.proxy.tcell.enabled }}
       - name: tcell-config
         configMap:
-          name: {{ .Values.name }}-tcell-configmap
+          name: {{ .Values.global.name }}-tcell-configmap
           items:
           - key: tcell-config
             path: tcell-config.conf
       {{- end }}
       {{- end }}
       {{- if .Values.prometheus.enabled }}
-      - name: {{ .Values.name }}-prometheusjmx-config
+      - name: {{ .Values.global.name }}-prometheusjmx-config
         configMap:
-          name: {{ .Values.name }}-prometheus-configmap
-      - name: {{ .Values.name }}-prometheusjmx-jar
+          name: {{ .Values.global.name }}-prometheus-configmap
+      - name: {{ .Values.global.name }}-prometheusjmx-jar
         emptyDir: {}
       {{- end }}
       containers:
@@ -81,17 +81,17 @@ spec:
         - name: SQL_INSTANCE_PROJECT
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: project
         - name: SQL_INSTANCE_REGION
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: region
         - name: SQL_INSTANCE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-cloudsql-postgres-instance
+              name: {{ .Values.global.name }}-cloudsql-postgres-instance
               key: name
         command: ["/cloud_sql_proxy",
                   "-instances=$(SQL_INSTANCE_PROJECT):$(SQL_INSTANCE_REGION):$(SQL_INSTANCE_NAME)=tcp:5432",
@@ -103,7 +103,7 @@ spec:
         - name: cloudsql-sa-creds
           mountPath: /secrets/cloudsql
           readOnly: true
-      - name: {{ .Values.name }}
+      - name: {{ .Values.global.name }}
         image: "{{- if .Values.image -}}
             {{ .Values.image }}
           {{- else -}}
@@ -132,37 +132,37 @@ spec:
         env:
         {{- if .Values.prometheus.enabled }}
         - name: JAVA_TOOL_OPTIONS
-          value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ .Values.name }}-prometheusjmx-config/prometheusJmx.yaml"
+          value: "-javaagent:/etc/prometheusjmx/prometheusjmx.jar=9090:/etc/{{ .Values.global.name }}-prometheusjmx-config/prometheusJmx.yaml"
         {{- end }}
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: username
         - name: DATABASE_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: password
         - name: DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-postgres-db-creds
+              name: {{ .Values.global.name }}-postgres-db-creds
               key: db
         - name: STAIRWAY_DATABASE_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-stairway-db-creds
+              name: {{ .Values.global.name }}-stairway-db-creds
               key: username
         - name: STAIRWAY_DATABASE_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-stairway-db-creds
+              name: {{ .Values.global.name }}-stairway-db-creds
               key: password
         - name: STAIRWAY_DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-stairway-db-creds
+              name: {{ .Values.global.name }}-stairway-db-creds
               key: db
         {{- if .Values.initDB }}
         - name: INIT_DB
@@ -201,7 +201,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: TERRA_COMMON_KUBERNETES_POD_NAME_FILTER
-          value: {{ .Values.name }}-deployment
+          value: {{ .Values.global.name }}-deployment
         - name: TERRA_COMMON_KUBERNETES_IN_KUBERNETES
           value: 'true'
         {{- end }}
@@ -210,9 +210,9 @@ spec:
           mountPath: /secrets/app
           readOnly: true
         {{- if .Values.prometheus.enabled }}
-        - name: {{ .Values.name }}-prometheusjmx-config
-          mountPath: /etc/{{ .Values.name }}-prometheusjmx-config
-        - name: {{ .Values.name }}-prometheusjmx-jar
+        - name: {{ .Values.global.name }}-prometheusjmx-config
+          mountPath: /etc/{{ .Values.global.name }}-prometheusjmx-config
+        - name: {{ .Values.global.name }}-prometheusjmx-jar
           mountPath: /etc/prometheusjmx/prometheusjmx.jar
           subPath: prometheusjmx.jar
         {{- end }}
@@ -235,37 +235,37 @@ spec:
         - name: AOU_PREPROD_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: aou-preprod
         - name: AOU_PERF_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: aou-perf
         - name: AOU_PROD_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: aou-prod
         - name: AOU_DEV_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: aou-dev
         - name: AOU_STABLE_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: aou-stable
         - name: AOU_STAGING_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: aou-staging
         - name: TERRA_ID_WHITELIST
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-oauth-whitelist
+              name: {{ .Values.global.name }}-proxy-oauth-whitelist
               key: terra
         - name: REMOTE_USER_CLAIM
           value: sub
@@ -283,19 +283,19 @@ spec:
         - name: PROXY_LDAP_BIND_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-ldap-bind-password
+              name: {{ .Values.global.name }}-proxy-ldap-bind-password
               key: password
         {{- end }}
         {{- if .Values.proxy.tcell.enabled }}
         - name: TCELL_AGENT_APP_ID
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-tcell-secrets
+              name: {{ .Values.global.name }}-proxy-tcell-secrets
               key: app-id
         - name: TCELL_AGENT_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.name }}-proxy-tcell-secrets
+              name: {{ .Values.global.name }}-proxy-tcell-secrets
               key: api-key
         - name: ENABLE_TCELL
           value: 'yes'
@@ -306,7 +306,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/apache2/sites-available/site.conf
           name: apache-httpd-proxy-config
-          subPath: {{ .Values.name }}-proxy.conf
+          subPath: {{ .Values.global.name }}-proxy.conf
         - mountPath: /etc/ssl/certs/server.crt
           subPath: tls.crt
           name: cert
@@ -334,9 +334,9 @@ spec:
         command: [
           "wget",
           "-O",
-          "/{{ .Values.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
+          "/{{ .Values.global.name }}-prometheusjmx-jar/prometheusjmx.jar", "{{ .Values.prometheus.jmxJarRepo }}/{{ .Values.prometheus.jmxJarVersion }}/jmx_prometheus_javaagent-{{ .Values.prometheus.jmxJarVersion }}.jar"
         ]
         volumeMounts:
-        - name: {{ .Values.name }}-prometheusjmx-jar
-          mountPath: /{{ .Values.name }}-prometheusjmx-jar
+        - name: {{ .Values.global.name }}-prometheusjmx-jar
+          mountPath: /{{ .Values.global.name }}-prometheusjmx-jar
       {{- end }}

--- a/charts/workspacemanager/templates/ingress/backendconfig.yaml
+++ b/charts/workspacemanager/templates/ingress/backendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-backendconfig
+  name: {{ .Values.global.name }}-ingress-backendconfig
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:

--- a/charts/workspacemanager/templates/ingress/cert.yaml
+++ b/charts/workspacemanager/templates/ingress/cert.yaml
@@ -2,11 +2,11 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  secretName: {{ .Values.name }}-cert
+  secretName: {{ .Values.global.name }}-cert
   renewBefore: {{ .Values.ingress.cert.certManager.renewBefore }}
   dnsNames:
   - {{ template "workspacemanager.fqdn" . }}
@@ -17,11 +17,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: secretdefinition-{{ .Values.name }}-cert
+  name: secretdefinition-{{ .Values.global.name }}-cert
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-cert
+  name: {{ .Values.global.name }}-cert
   keysMap:
     tls.crt:
       path: {{ required "A valid ingress.cert.vault.cert.path value is required when ingress.cert.vault is enabled" .Values.ingress.cert.vault.cert.path }}

--- a/charts/workspacemanager/templates/ingress/frontendconfig.yaml
+++ b/charts/workspacemanager/templates/ingress/frontendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ .Values.name }}-ingress-frontendconfig
+  name: {{ .Values.global.name }}-ingress-frontendconfig
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 {{- if .Values.ingress.sslPolicy }}

--- a/charts/workspacemanager/templates/ingress/ingress.yaml
+++ b/charts/workspacemanager/templates/ingress/ingress.yaml
@@ -2,11 +2,11 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}-ingress
+  name: {{ .Values.global.name }}-ingress
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
   annotations:
-    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.name }}-ingress-frontendconfig"
+    networking.gke.io/v1beta1.FrontendConfig: "{{ .Values.global.name }}-ingress-frontendconfig"
     kubernetes.io/ingress.global-static-ip-name: {{ required "ingress.staticIpName value is required" .Values.ingress.staticIpName | quote }}
     kubernetes.io/ingress.allow-http: "false"
 {{- if not (empty .Values.ingress.cert.preSharedCerts) }}
@@ -15,9 +15,9 @@ metadata:
 spec:
 {{- if empty .Values.ingress.cert.preSharedCerts }}
   tls:
-  - secretName: {{ .Values.name }}-cert
+  - secretName: {{ .Values.global.name }}-cert
 {{- end }}
   backend:
-    serviceName: {{ .Values.name }}-service
+    serviceName: {{ .Values.global.name }}-service
     servicePort: 443
 {{- end }}

--- a/charts/workspacemanager/templates/ingress/service.yaml
+++ b/charts/workspacemanager/templates/ingress/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ .Values.global.name }}-service
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
   annotations:
     # Associate a backend config with the ingress: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress
-    cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ingress-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "{{ .Values.global.name }}-ingress-backendconfig"}'
     # Enable container-native load balancing https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
     cloud.google.com/neg: '{"ingress": true}'
     # Enable TLS between LB and apache proxy https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    deployment: {{ .Values.name }}-deployment
+    deployment: {{ .Values.global.name }}-deployment
   ports:
   - name: https
     protocol: TCP

--- a/charts/workspacemanager/templates/podDisruptionBudget.yaml
+++ b/charts/workspacemanager/templates/podDisruptionBudget.yaml
@@ -4,5 +4,5 @@
 spec:
   selector:
     matchLabels:
-      deployment: {{ .Values.name }}-deployment
+      deployment: {{ .Values.global.name }}-deployment
 {{- end }}

--- a/charts/workspacemanager/templates/podMonitor.yaml
+++ b/charts/workspacemanager/templates/podMonitor.yaml
@@ -2,11 +2,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Values.name }}-jvm-monitor
+  name: {{ .Values.global.name }}-jvm-monitor
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  jobLabel: {{ .Values.name }}-jvm
+  jobLabel: {{ .Values.global.name }}-jvm
   selector:
     matchLabels:
       app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/workspacemanager/templates/role.yaml
+++ b/charts/workspacemanager/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/workspacemanager/templates/rolebinding.yaml
+++ b/charts/workspacemanager/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.name }}-service-role-binding
+  name: {{ .Values.global.name }}-service-role-binding
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
@@ -9,9 +9,9 @@ metadata:
 {{ include "workspacemanager.labels" . | indent 4 }}
 roleRef:
   kind: Role
-  name: {{ .Values.name }}-service-role
+  name: {{ .Values.global.name }}-service-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa

--- a/charts/workspacemanager/templates/secrets.yaml
+++ b/charts/workspacemanager/templates/secrets.yaml
@@ -2,14 +2,14 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-postgres-db-creds
+  name: {{ .Values.global.name }}-postgres-db-creds
   keysMap:
     db:
       path: {{ .Values.vault.pathPrefix }}/workspace/postgres/db-creds
@@ -24,14 +24,14 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-stairway-db-creds
+  name: {{ .Values.global.name }}-stairway-db-creds
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-stairway-db-creds
+  name: {{ .Values.global.name }}-stairway-db-creds
   keysMap:
     db:
       path: {{ .Values.vault.pathPrefix }}/workspace/postgres/stairway-db-creds
@@ -46,14 +46,14 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-postgres-instance
+  name: {{ .Values.global.name }}-postgres-instance
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-cloudsql-postgres-instance
+  name: {{ .Values.global.name }}-cloudsql-postgres-instance
   keysMap:
     project:
       path: {{ .Values.vault.pathPrefix }}/workspace/postgres/instance
@@ -68,14 +68,14 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-sqlproxy-sa
+  name: {{ .Values.global.name }}-sqlproxy-sa
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-sqlproxy-sa
+  name: {{ .Values.global.name }}-sqlproxy-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/workspace/sqlproxy-sa
@@ -86,11 +86,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-oauth-whitelist
+  name: {{ .Values.global.name }}-proxy-oauth-whitelist
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-oauth-whitelist
+  name: {{ .Values.global.name }}-proxy-oauth-whitelist
   keysMap:
     aou-preprod:
       path: secret/dsde/firecloud/common/preprod_researchallofus_oauth_client_ids
@@ -118,11 +118,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-ldap-bind-password
+  name: {{ .Values.global.name }}-proxy-ldap-bind-password
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-ldap-bind-password
+  name: {{ .Values.global.name }}-proxy-ldap-bind-password
   keysMap:
     password:
       path: {{ .Values.proxy.ldap.passwordVaultPath }}
@@ -133,11 +133,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-proxy-tcell-secrets
+  name: {{ .Values.global.name }}-proxy-tcell-secrets
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-proxy-tcell-secrets
+  name: {{ .Values.global.name }}-proxy-tcell-secrets
   keysMap:
     app-id:
       path: {{ .Values.proxy.tcell.vaultPrefix }}/tcell_app_id
@@ -151,11 +151,11 @@ spec:
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-app-sa
+  name: {{ .Values.global.name }}-app-sa
   labels:
 {{ include "workspacemanager.labels" . | indent 4 }}
 spec:
-  name: {{ .Values.name }}-app-sa
+  name: {{ .Values.global.name }}-app-sa
   keysMap:
     service-account.json:
       path: {{ .Values.vault.pathPrefix }}/workspace/app-sa

--- a/charts/workspacemanager/templates/service-account.yaml
+++ b/charts/workspacemanager/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-service-sa
+  name: {{ .Values.global.name }}-service-sa
   annotations:
     # Used by liquibase-migration during wave -1
     argocd.argoproj.io/sync-wave: "-1"

--- a/charts/workspacemanager/values.yaml
+++ b/charts/workspacemanager/values.yaml
@@ -5,9 +5,8 @@ global:
   # global.terraEnv -- (string) Terget Terra environment name. Required.
   # @default -- Is set by Helmfile on deploy
   terraEnv: null
-
-# name -- A name for the deployment that will be substituted into resuorce definitions
-name: workspacemanager
+  # global.name -- A name for the deployment that will be substituted into resource definitions
+  name: workspacemanager
 
 annotations: {}
 # image -- (string) Used for local Skaffold deploys
@@ -250,9 +249,6 @@ liquibase-migration:
     migrationDatabaseCredentials:
       fromKubernetesSecret:
         name: "workspacemanager-stairway-db-creds"
-
-  # Workaround pending DDO-1579
-  name: "workspacemanager"
 
   defaults:
     enabled: false


### PR DESCRIPTION
<!-- 
Please add links to any related PRs to help DevOps give approval--thanks!
-->
- Added a note in the top-level readme about this being a universal standard instead of just a common pattern
- Moved every top-level `name:` in a Values file to be under `global:` (I did this manually to avoid regex mangling)
- Added a comment to every `global.name:` field
- Removed `liquibase-migration`'s duplicated name property in Buffer and WSM (would be unreferenced after this change)
- Regenerated all Chart-level readmes
- Find/replace `.Values.name` with `.Values.global.name` everywhere

For review:
1. Check out the README.md, it is top of the Files changed
2. You're welcome to spot check all the other changes but its like 244 files... the helmfile PR comments will handle telling us if this nukes or changes something weird