### PR TITLE
DDO-1772 Adding support for atlantis to deploy resources to azure

### DIFF
--- a/charts/dsp-atlantis/README.md
+++ b/charts/dsp-atlantis/README.md
@@ -1,6 +1,6 @@
 # dsp-atlantis
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for DSP Atlantis deployment
 
@@ -20,8 +20,7 @@ Chart for DSP Atlantis deployment
 |-----|------|---------|-------------|
 | atlantis.fullnameOverride | string | `"atlantis"` |  |
 | atlantis.serviceAccount.name | string | `"atlantis"` |  |
-| azure.certificateFile | string | `"azure-cert.pfx"` |  |
-| azure.enabled | bool | `false` |  |
+| azure.enabled | bool | `false` | whether to mount the secrets containing atlantis' azure active directory credentials |
 | cert.dnsName | string | `"atlantis.dsp-devops.broadinstitute.org"` |  |
 | cert.duration | string | `"2160h0m0s"` |  |
 | cert.issuerGroup | string | `"cert-manager.io"` |  |
@@ -41,7 +40,7 @@ Chart for DSP Atlantis deployment
 | cleanup.timeoutSeconds | int | `3600` | How many seconds to wait before assuming job is hung and killing it |
 | name | string | `"atlantis"` |  |
 | serviceAccount | string | `"atlantis"` |  |
-| vault.azure.pathPrefix | string | `"/path/to/azure/secrets"` |  |
+| vault.azure.pathPrefix | string | `"/path/to/azure/secrets"` | path to location containing credentials for atlantis to authenticate with azure |
 | vault.cleanup.key | string | `nil` | Key in Vault where base64-encoded GCP service account key for pod cleanup is stored |
 | vault.cleanup.path | string | `nil` | Path in Vault where base64-encoded GCP service account key for pod cleanup is stored |
 | vault.github.keyName | string | `nil` |  |

--- a/charts/dsp-atlantis/templates/azureCredentials.yaml
+++ b/charts/dsp-atlantis/templates/azureCredentials.yaml
@@ -2,33 +2,19 @@
 apiVersion: secrets-manager.tuenti.io/v1alpha1
 kind: SecretDefinition
 metadata:
-  name: {{ .Values.name }}-azure-creds-secretdefinition
-  labels:
-    {{- include "dsp-atlantis.labels" . | nindent 4 }}
-spec:
-  name: azure-cert
-  keysMap:
-    {{ .Values.azure.certificateFile }}:
-      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/certificate
-      encoding: base64
-      key: {{ .Values.azure.certificateFile }}.b64
----
-apiVersion: secrets-manager.tuenti.io/v1alpha1
-kind: SecretDefinition
-metadata:
   name: {{ .Values.name }}-azure-env-secretdefinition
   labels:
     {{- include "dsp-atlantis.labels" . | nindent 4 }}
 spec:
   name: azure-env
   keysMap:
-    ARM_CLIENT_CERTIFICATE_PASSWORD:
-      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/env
-      key: ARM_CLIENT_CERTIFICATE_PASSWORD
+    ARM_CLIENT_SECRET:
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/ad-credentials
+      key: client_secret
     ARM_CLIENT_ID:
-      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/env
-      key: ARM_CLIENT_ID
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/ad-credentials
+      key: client_id
     ARM_TENANT_ID:
-      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/env
-      key: ARM_TENANT_ID
+      path: {{ required "A valid .Values.vault.azure.pathPrefix is required" .Values.vault.azure.pathPrefix }}/atlantis/ad-credentials
+      key: tenant_id
 {{- end -}}

--- a/charts/dsp-atlantis/values.yaml
+++ b/charts/dsp-atlantis/values.yaml
@@ -15,10 +15,11 @@ atlantis:
     name: atlantis
 
 azure:
+  # azure.enabled -- whether to mount the secrets containing atlantis' azure active directory credentials
   enabled: false
-  certificateFile: "azure-cert.pfx"
 vault:
   azure:
+    # vault.azure.pathPrefix -- path to location containing credentials for atlantis to authenticate with azure
     pathPrefix: /path/to/azure/secrets
   github:
     pathPrefix: #/path/to/github/secrets


### PR DESCRIPTION
This PR modifies the azure credentials that get mounted to atlantis pods so that they now use the "real" azure identity (service principal) that atlantis will authenticate as to enable deploying resources to azure via terraform
Associated PRs:
- https://github.com/broadinstitute/terra-helm-definitions/pull/75
- https://github.com/broadinstitute/terraform-dsp-tools-k8s/pull/23
